### PR TITLE
Backport: Add optimized count query support for multiple databases

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,24 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Changed
+
+- Remove unused import in DefaultCouchbaseDocumentManager
+- Add count method to DefaultCouchbaseDocumentManager
+- Add count functionality to N1QLBuilder
+- Enhance count test with delay
+- Enhance count tests in CouchbaseDocumentManager
+- Add person collection and index to Couchbase
+- Add count method for SelectQuery
+- Add count method to QueryAQLConverter
+- Add count method to CassandraTemplate
+- Enhance count methods in CassandraColumnManager
+- Enhance count query tests for CassandraColumnManager
+- Add count method based on query to CassandraColumnManager
+- Add default execute and count methods
+- Add count method based on a query to MongoDBDocumentManager
+- Add count query test for MongoDBDocumentManager
+
 == [1.1.11] - 2025-11-16
 
 === Changed

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,26 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Add default execute and count methods
 - Add count method based on a query to MongoDBDocumentManager
 - Add count query test for MongoDBDocumentManager
+- Add count query support with SelectQuery for Neo4J
+- Add count query builder for SelectQuery in Neo4J
+- Add count method to DefaultNeo4JDatabaseManager
+- Add count query tests for Neo4JQueryBuilder
+- Update Neo4J query builder to use count queries
+- Add count method to DefaultTinkerpopGraphDatabaseManager
+- Add count tests for entity manager in Tinkerpop
+- Add count method for SelectQuery in Solr Document Manager
+- Add count tests for SelectQuery to Solr Document Manager
+- Add count query support in QueryOSQLConverter for OrientDB
+- Add count query support in QueryOSQLFactory for OrientDB
+- Add count method with conditions to DefaultOrientDBDocumentManager
+- Improve URL handling in OrientDB factory
+- Update integration test configuration for OrientDB
+- Update README with database host details config for OrientDB
+- Add count method for SelectQuery support in OracleNoSQL
+- Enhance condition handling for count queries in OracleNoSQL
+- Add SelectCountBuilder for OracleNoSQL count queries support
+- Update condition handling in query builders
+- Improve assertions and add count query tests
 
 == [1.1.11] - 2025-11-16
 

--- a/README.adoc
+++ b/README.adoc
@@ -1345,7 +1345,7 @@ Please note that you can establish properties using the https://microprofile.io/
 |Configuration property |Description
 
 |`jnosql.orientdb.host`
-|The database host
+|The database host. It can be pointing to remote database (e.g: `remote:<HOST or IP>:<PORT>`) or an embedded database (e.g: `embedded:<DIRETORY>`). Please, follow the link:https://github.com/orientechnologies/orientdb/blob/develop/core/src/main/java/com/orientechnologies/orient/core/db/OrientDB.java[OrientDB Javadoc, target=window] for more details.
 
 |`jnosql.orientdb.user`
 |The user's userID.
@@ -1364,7 +1364,7 @@ This is an example using OrientDB's Document API with MicroProfile Config.
 ----
 jnosql.document.provider=org.eclipse.jnosql.databases.orientdb.communication.OrientDBDocumentConfiguration
 jnosql.document.database=heroes
-jnosql.orientdb.host=localhost:27017
+jnosql.orientdb.host=remote:localhost:2424
 jnosql.orientdb.user=root
 jnosql.orientdb.password=rootpwd
 jnosql.orientdb.storageType=plocal

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/DefaultNeo4JDatabaseManager.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/DefaultNeo4JDatabaseManager.java
@@ -149,6 +149,25 @@ class DefaultNeo4JDatabaseManager implements Neo4JDatabaseManager {
         }
     }
 
+    public long count(SelectQuery query) {
+        Objects.requireNonNull(query, "query is required");
+        Map<String, Object> parameters = new HashMap<>();
+        String cypher = Neo4JQueryBuilder.INSTANCE.buildCountQuery(query, parameters);
+
+        LOGGER.fine("Executing Cypher Query for counting entities: " + cypher);
+        try (Transaction tx = session.beginTransaction()) {
+            long count = tx.run(cypher, Values.parameters(flattenMap(parameters)))
+                    .single()
+                    .get("count")
+                    .asLong();
+            tx.commit();
+            return count;
+        } catch (Exception e) {
+            LOGGER.severe("Error executing count query: " + e.getMessage());
+            throw new CommunicationException("Error executing count query", e);
+        }
+    }
+
     @Override
     public long count(String entity) {
         Objects.requireNonNull(entity, "entity is required");

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
@@ -85,7 +85,7 @@ enum Neo4JQueryBuilder {
 
     String buildCountQuery(SelectQuery query, Map<String, Object> parameters) {
         StringBuilder cypher = buildCypher(query.name(), query.condition(), parameters);
-        cypher.append(" RETURN COUNT(e)");
+        cypher.append(" RETURN COUNT(e) as count");
         return cypher.toString();
     }
 

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
@@ -27,6 +27,7 @@ import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 enum Neo4JQueryBuilder {
@@ -36,13 +37,7 @@ enum Neo4JQueryBuilder {
     private static final String INTERNAL_ID = "_id";
 
     String buildQuery(DeleteQuery query, Map<String, Object> parameters) {
-        StringBuilder cypher = new StringBuilder("MATCH (e:");
-        cypher.append(query.name()).append(")");
-
-        query.condition().ifPresent(c -> {
-            cypher.append(" WHERE ");
-            createWhereClause(cypher, c, parameters);
-        });
+        StringBuilder cypher = buildCypher(query.name(), query.condition(), parameters);
 
         List<String> columns = query.columns();
         if (!columns.isEmpty()) {
@@ -59,13 +54,7 @@ enum Neo4JQueryBuilder {
     }
 
     String buildQuery(SelectQuery query, Map<String, Object> parameters) {
-        StringBuilder cypher = new StringBuilder("MATCH (e:");
-        cypher.append(query.name()).append(")");
-
-        query.condition().ifPresent(c -> {
-            cypher.append(" WHERE ");
-            createWhereClause(cypher, c, parameters);
-        });
+        StringBuilder cypher = buildCypher(query.name(), query.condition(), parameters);
 
         if (!query.sorts().isEmpty()) {
             cypher.append(" ORDER BY ");
@@ -92,6 +81,24 @@ enum Neo4JQueryBuilder {
         }
 
         return cypher.toString();
+    }
+
+    String buildCountQuery(SelectQuery query, Map<String, Object> parameters) {
+        StringBuilder cypher = buildCypher(query.name(), query.condition(), parameters);
+        cypher.append(" RETURN COUNT(e) AS count");
+        return cypher.toString();
+    }
+
+    private StringBuilder buildCypher(String entityName,
+                                      Optional<CriteriaCondition> condition,
+                                      Map<String, Object> parameters) {
+        StringBuilder cypher = new StringBuilder("MATCH (e:");
+        cypher.append(entityName).append(")");
+        condition.ifPresent(c -> {
+            cypher.append(" WHERE ");
+            createWhereClause(cypher, c, parameters);
+        });
+        return cypher;
     }
 
     private void createWhereClause(StringBuilder cypher, CriteriaCondition condition, Map<String, Object> parameters) {
@@ -139,7 +146,7 @@ enum Neo4JQueryBuilder {
     }
 
     private Object value(Object value, Condition condition) {
-        if(Condition.LIKE.equals(condition)) {
+        if (Condition.LIKE.equals(condition)) {
             return LikeToCypherRegex.INSTANCE.toCypherRegex(value.toString());
         }
         return value;
@@ -162,7 +169,7 @@ enum Neo4JQueryBuilder {
             case GREATER_EQUALS_THAN -> ">=";
             case LESSER_THAN -> "<";
             case LESSER_EQUALS_THAN -> "<=";
-            case LIKE  -> "=~";
+            case LIKE -> "=~";
             case IN -> "IN";
             case AND -> "AND";
             case OR -> "OR";

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
@@ -85,7 +85,7 @@ enum Neo4JQueryBuilder {
 
     String buildCountQuery(SelectQuery query, Map<String, Object> parameters) {
         StringBuilder cypher = buildCypher(query.name(), query.condition(), parameters);
-        cypher.append(" RETURN COUNT(e) AS count");
+        cypher.append(" RETURN COUNT(e)");
         return cypher.toString();
     }
 

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.mapping.semistructured.MappingQuery;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,6 +82,24 @@ class Neo4JDatabaseManagerTest {
         entityManager.insert(entity);
         long count = entityManager.count(COLLECTION_NAME);
         assertTrue(count > 0);
+    }
+
+    @Test
+    void shouldCountWithSelectQuery() {
+        for (int index = 0; index < 10; index++) {
+            var entity = getEntity();
+            entity.add("index", index);
+            entityManager.insert(entity);
+        }
+        var index = 4;
+        var query = select().from(COLLECTION_NAME).where("index").gt(index).build();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(entityManager.count(query)).isEqualTo(5);
+
+            softly.assertThatThrownBy(() -> entityManager.count((SelectQuery) null))
+                    .as("Should not accept null SelectQuery")
+                    .isInstanceOf(NullPointerException.class);
+        });
     }
 
     @Test

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
@@ -93,6 +93,40 @@ class Neo4JQueryBuilderTest {
     }
 
     @Test
+    void shouldBuildCountQueryWithCondition() {
+        SelectQuery query = mock(SelectQuery.class);
+        when(query.name()).thenReturn("Person");
+
+        CriteriaCondition condition = mock(CriteriaCondition.class);
+        Element element = mock(Element.class);
+        when(condition.element()).thenReturn(element);
+        when(element.name()).thenReturn("age");
+        when(element.get()).thenReturn(30);
+        when(condition.condition()).thenReturn(org.eclipse.jnosql.communication.Condition.EQUALS);
+        when(query.condition()).thenReturn(java.util.Optional.of(condition));
+        when(query.columns()).thenReturn(List.of());
+
+        Map<String, Object> parameters = new HashMap<>();
+        String cypher = Neo4JQueryBuilder.INSTANCE.buildQuery(query, parameters);
+
+        assertThat(cypher).isEqualTo("MATCH (e:Person) WHERE e.age = $age RETURN COUNT(e)");
+        assertThat(parameters).containsEntry("age", 30);
+    }
+
+    @Test
+    void shouldBuildCountQueryWithoutCondition() {
+        SelectQuery query = mock(SelectQuery.class);
+        when(query.name()).thenReturn("Person");
+        when(query.condition()).thenReturn(java.util.Optional.empty());
+        when(query.columns()).thenReturn(List.of());
+
+        Map<String, Object> parameters = new HashMap<>();
+        String cypher = Neo4JQueryBuilder.INSTANCE.buildQuery(query, parameters);
+
+        assertThat(cypher).isEqualTo("MATCH (e:Person) RETURN COUNT(e)");
+    }
+
+    @Test
     void shouldTranslateIdToElementId() {
         SelectQuery query = mock(SelectQuery.class);
         when(query.name()).thenReturn("Person");

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
@@ -107,7 +107,7 @@ class Neo4JQueryBuilderTest {
         when(query.columns()).thenReturn(List.of());
 
         Map<String, Object> parameters = new HashMap<>();
-        String cypher = Neo4JQueryBuilder.INSTANCE.buildQuery(query, parameters);
+        String cypher = Neo4JQueryBuilder.INSTANCE.buildCountQuery(query, parameters);
 
         assertThat(cypher).isEqualTo("MATCH (e:Person) WHERE e.age = $age RETURN COUNT(e)");
         assertThat(parameters).containsEntry("age", 30);
@@ -121,7 +121,7 @@ class Neo4JQueryBuilderTest {
         when(query.columns()).thenReturn(List.of());
 
         Map<String, Object> parameters = new HashMap<>();
-        String cypher = Neo4JQueryBuilder.INSTANCE.buildQuery(query, parameters);
+        String cypher = Neo4JQueryBuilder.INSTANCE.buildCountQuery(query, parameters);
 
         assertThat(cypher).isEqualTo("MATCH (e:Person) RETURN COUNT(e)");
     }

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
@@ -109,7 +109,7 @@ class Neo4JQueryBuilderTest {
         Map<String, Object> parameters = new HashMap<>();
         String cypher = Neo4JQueryBuilder.INSTANCE.buildCountQuery(query, parameters);
 
-        assertThat(cypher).isEqualTo("MATCH (e:Person) WHERE e.age = $age RETURN COUNT(e)");
+        assertThat(cypher).isEqualTo("MATCH (e:Person) WHERE e.age = $age RETURN COUNT(e) as count");
         assertThat(parameters).containsEntry("age", 30);
     }
 
@@ -123,7 +123,7 @@ class Neo4JQueryBuilderTest {
         Map<String, Object> parameters = new HashMap<>();
         String cypher = Neo4JQueryBuilder.INSTANCE.buildCountQuery(query, parameters);
 
-        assertThat(cypher).isEqualTo("MATCH (e:Person) RETURN COUNT(e)");
+        assertThat(cypher).isEqualTo("MATCH (e:Person) RETURN COUNT(e) as count");
     }
 
     @Test

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeleteBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeleteBuilder.java
@@ -43,7 +43,7 @@ final class DeleteBuilder extends AbstractQueryBuilder {
         entityCondition(query, documentQuery.name());
         this.documentQuery.condition().ifPresent(c -> {
             query.append(" AND ");
-            condition(c, query, params, ids);
+            condition(c, query, params, ids,false);
         });
         return new OracleQuery(query.toString(), params, ids);
     }

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
@@ -46,7 +46,7 @@ final class SelectBuilder extends AbstractQueryBuilder {
         entityCondition(query, documentQuery.name());
         this.documentQuery.condition().ifPresent(c -> {
             query.append(" AND ");
-            condition(c, query, params, ids);
+            condition(c, query, params, ids, false);
         });
 
 

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectCountBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectCountBuilder.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import oracle.nosql.driver.values.FieldValue;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class SelectCountBuilder extends AbstractQueryBuilder {
+
+    public static final String COUNT = "count";
+    private final SelectQuery documentQuery;
+
+    private final String table;
+
+    SelectCountBuilder(SelectQuery documentQuery, String table) {
+        super(table);
+        this.documentQuery = documentQuery;
+        this.table = table;
+    }
+
+    @Override
+    public OracleQuery get() {
+        List<String> ids = new ArrayList<>();
+        List<FieldValue> params = new ArrayList<>();
+        StringBuilder query = new StringBuilder();
+        query.append("select ");
+        query.append("count(*) as ").append(COUNT).append(' ');
+        query.append("from ").append(table);
+        entityCondition(query, documentQuery.name());
+        this.documentQuery.condition().ifPresent(c -> {
+            query.append(" AND ");
+            condition(c, query, params, ids, true);
+        });
+        return new OracleQuery(query.toString(), params, ids);
+    }
+}

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
@@ -14,7 +14,6 @@
  */
 package org.eclipse.jnosql.databases.oracle.communication;
 
-import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
@@ -209,12 +208,12 @@ class OracleNoSQLDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).toList();
 
-        SoftAssertions.assertSoftly(soft -> {
+        assertSoftly(soft -> {
             soft.assertThat(entitiesFound).hasSize(1);
 
             List<String> namesFound = entitiesFound.stream()
                     .flatMap(d -> d.find("name").stream())
-                    .map(d-> d.get(String.class))
+                    .map(d -> d.get(String.class))
                     .toList();
             soft.assertThat(namesFound).contains("Lucas");
         });
@@ -252,11 +251,11 @@ class OracleNoSQLDocumentManagerTest {
             soft.assertThat(entitiesFound).hasSize(entities.size());
             List<String> namesFound = entitiesFound.stream()
                     .flatMap(d -> d.find("name").stream())
-                    .map(d-> d.get(String.class))
+                    .map(d -> d.get(String.class))
                     .toList();
             List<String> names = entities.stream()
                     .flatMap(d -> d.find("name").stream())
-                    .map(d-> d.get(String.class))
+                    .map(d -> d.get(String.class))
                     .toList();
             soft.assertThat(namesFound).containsAll(names);
         });
@@ -463,7 +462,7 @@ class OracleNoSQLDocumentManagerTest {
 
         assertEquals(1, entities.size());
         var documentEntity = entities.get(0);
-        assertSoftly(soft ->{
+        assertSoftly(soft -> {
             soft.assertThat(id).isEqualTo(documentEntity.find("_id").orElseThrow().get(Long.class));
             soft.assertThat(now).isEqualTo(documentEntity.find("now").orElseThrow().get(LocalDate.class));
         });
@@ -498,7 +497,27 @@ class OracleNoSQLDocumentManagerTest {
         assertTrue(entityManager.count(COLLECTION_NAME) > 0);
     }
 
+    @Test
+    void shouldCountWithSelectQuery() {
+        Iterable<CommunicationEntity> entitiesSaved = entityManager.insert(getEntitiesWithValues());
+        List<CommunicationEntity> entities = StreamSupport.stream(entitiesSaved.spliterator(), false).toList();
 
+        assertSoftly(softly -> {
+            softly.assertThat(entityManager.count(
+                    select().from(COLLECTION_NAME)
+                            .where("age").gt(22)
+                            .and("type").eq("V")
+                            .build()
+            )).isEqualTo(2);
+
+            softly.assertThat(entityManager.count(
+                    select().from(COLLECTION_NAME)
+                            .where("name").eq("Otavio")
+                            .build()
+            )).isEqualTo(1);
+        });
+
+    }
 
     @Test
     void shouldSaveMap() {
@@ -532,7 +551,7 @@ class OracleNoSQLDocumentManagerTest {
     }
 
     @Test
-    void shouldUpdateNull(){
+    void shouldUpdateNull() {
         var entity = entityManager.insert(getEntity());
         entity.add(Element.of("name", null));
         var documentEntity = entityManager.update(entity);
@@ -545,7 +564,7 @@ class OracleNoSQLDocumentManagerTest {
     }
 
     @Test
-    void shouldQuery(){
+    void shouldQuery() {
         entityManager.insert(getEntity());
 
         var query = "select * from database where database.content.name = 'Poliana'";
@@ -556,7 +575,7 @@ class OracleNoSQLDocumentManagerTest {
     }
 
     @Test
-    void shouldQueryParams(){
+    void shouldQueryParams() {
         entityManager.insert(getEntity());
 
         var query = "select * from database where database.content.name = ?";
@@ -598,7 +617,7 @@ class OracleNoSQLDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
 
-        SoftAssertions.assertSoftly(soft -> {
+        assertSoftly(soft -> {
             soft.assertThat(entitiesFound).hasSize(2);
             var names = entitiesFound.stream()
                     .flatMap(d -> d.find("name").stream())
@@ -618,7 +637,7 @@ class OracleNoSQLDocumentManagerTest {
                 "lia")), COLLECTION_NAME, Collections.emptyList());
 
         var result = entityManager.select(query).toList();
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
@@ -633,7 +652,7 @@ class OracleNoSQLDocumentManagerTest {
                 "Pol")), COLLECTION_NAME, Collections.emptyList());
 
         var result = entityManager.select(query).toList();
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
@@ -648,7 +667,7 @@ class OracleNoSQLDocumentManagerTest {
                 "ana")), COLLECTION_NAME, Collections.emptyList());
 
         var result = entityManager.select(query).toList();
-        SoftAssertions.assertSoftly(softly -> {
+        assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/DefaultOrientDBDocumentManager.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/DefaultOrientDBDocumentManager.java
@@ -213,7 +213,7 @@ class DefaultOrientDBDocumentManager implements OrientDBDocumentManager {
                 }
             }
         }
-        return 0l;
+        return 0L;
     }
 
     @Override

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverter.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverter.java
@@ -12,6 +12,7 @@
  *
  *   Otavio Santana
  *   Lucas Furlaneto
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.databases.orientdb.communication;
 
@@ -62,7 +63,7 @@ final class QueryOSQLConverter {
 
         if (documentQuery.condition().isPresent()) {
             query.append(WHERE);
-            definesCondition(documentQuery.condition().get(), query, params, 0, ids);
+            definesCondition(documentQuery.condition().get(), query, params, 0, ids, false);
         }
 
         if (!documentQuery.sorts().isEmpty()) {
@@ -73,40 +74,53 @@ final class QueryOSQLConverter {
         return new Query(query.toString(), params, ids);
     }
 
+    static Query selectCount(SelectQuery documentQuery) {
+        StringBuilder query = new StringBuilder();
+        List<Object> params = new java.util.ArrayList<>();
+        List<ORecordId> ids = new ArrayList<>();
+        query.append("SELECT COUNT(*) FROM ");
+        query.append(documentQuery.name());
+        if (documentQuery.condition().isPresent()) {
+            query.append(WHERE);
+            definesCondition(documentQuery.condition().get(), query, params, 0, ids, true);
+        }
+        return new Query(query.toString(), params, ids);
+    }
+
     private static void definesCondition(CriteriaCondition condition, StringBuilder query, List<Object> params,
-                                         int counter, List<ORecordId> ids) {
+                                         int counter, List<ORecordId> ids, boolean countQuery) {
 
         Element document = condition.element();
         switch (condition.condition()) {
             case IN:
-                appendCondition(query, params, document, IN, ids);
+                appendCondition(query, params, document, IN, ids, countQuery);
                 return;
             case EQUALS:
-                appendCondition(query, params, document, EQUALS, ids);
+                appendCondition(query, params, document, EQUALS, ids, countQuery);
                 return;
             case GREATER_EQUALS_THAN:
-                appendCondition(query, params, document, GREATER_EQUALS_THAN, ids);
+                appendCondition(query, params, document, GREATER_EQUALS_THAN, ids, countQuery);
                 return;
             case GREATER_THAN:
-                appendCondition(query, params, document, GREATER_THAN, ids);
+                appendCondition(query, params, document, GREATER_THAN, ids, countQuery);
                 return;
             case LESSER_THAN:
-                appendCondition(query, params, document, LESSER_THAN, ids);
+                appendCondition(query, params, document, LESSER_THAN, ids, countQuery);
                 return;
             case LESSER_EQUALS_THAN:
-                appendCondition(query, params, document, LESSER_EQUALS_THAN, ids);
+                appendCondition(query, params, document, LESSER_EQUALS_THAN, ids, countQuery);
                 return;
             case LIKE:
-                appendCondition(query, params, document, LIKE, ids);
+                appendCondition(query, params, document, LIKE, ids, countQuery);
                 return;
             case STARTS_WITH:
-                appendCondition(query, params, Element.of(document.name(), StringMatch.STARTS_WITH.format(document.get(String.class))), LIKE, ids);
+                appendCondition(query, params, Element.of(document.name(), StringMatch.STARTS_WITH.format(document.get(String.class))), LIKE, ids, countQuery);
                 return;
             case CONTAINS:
-                appendCondition(query, params, Element.of(document.name(), StringMatch.CONTAINS.format(document.get(String.class))), LIKE, ids);
+                appendCondition(query, params, Element.of(document.name(), StringMatch.CONTAINS.format(document.get(String.class))), LIKE, ids, countQuery);
                 return;
             case ENDS_WITH:
-                appendCondition(query, params, Element.of(document.name(), StringMatch.ENDS_WITH.format(document.get(String.class))), LIKE, ids);
+                appendCondition(query, params, Element.of(document.name(), StringMatch.ENDS_WITH.format(document.get(String.class))), LIKE, ids, countQuery);
                 return;
             case AND:
                 for (CriteriaCondition dc : document.get(new TypeReference<List<CriteriaCondition>>() {
@@ -115,7 +129,7 @@ final class QueryOSQLConverter {
                     if (isFirstCondition(query, counter)) {
                         query.append(AND);
                     }
-                    definesCondition(dc, query, params, ++counter, ids);
+                    definesCondition(dc, query, params, ++counter, ids, countQuery);
                 }
                 return;
             case OR:
@@ -124,13 +138,13 @@ final class QueryOSQLConverter {
                     if (isFirstCondition(query, counter)) {
                         query.append(OR);
                     }
-                    definesCondition(dc, query, params, ++counter, ids);
+                    definesCondition(dc, query, params, ++counter, ids, countQuery);
                 }
                 return;
             case NOT:
                 CriteriaCondition documentCondition = document.get(CriteriaCondition.class);
                 query.append("NOT (");
-                definesCondition(documentCondition, query, params, ++counter, ids);
+                definesCondition(documentCondition, query, params, ++counter, ids, countQuery);
                 query.append(")");
                 return;
             default:
@@ -143,15 +157,24 @@ final class QueryOSQLConverter {
     }
 
     private static void appendCondition(StringBuilder query, List<Object> params,
-                                        Element document, String condition, List<ORecordId> ids) {
+                                        Element document, String condition, List<ORecordId> ids, boolean countQuery) {
 
-        if (RID_FIELD.equals(document.name())
-                ||
-                ID_FIELD.equals(document.name())) {
-            ids.add(new ORecordId(document.get(String.class)));
-            return;
+        if(!countQuery) {
+            if (RID_FIELD.equals(document.name())
+                    ||
+                    ID_FIELD.equals(document.name())) {
+                String id = document.get(String.class);
+                ids.add(new ORecordId(id));
+                return;
+            }
         }
-        query.append(document.name())
+        String attributeName = document.name();
+        if(countQuery) {
+            if (ID_FIELD.equals(document.name())) {
+                attributeName = RID_FIELD;
+            }
+        }
+        query.append(attributeName)
                 .append(condition).append(PARAM_APPENDER);
         if (IN.equals(condition)) {
             params.add(ValueUtil.convertToList(document.value()));

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLFactory.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLFactory.java
@@ -12,6 +12,7 @@
  *
  *   Otavio Santana
  *   Lucas Furlaneto
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.databases.orientdb.communication;
 
@@ -38,6 +39,11 @@ final class QueryOSQLFactory {
 
     static QueryResult to(SelectQuery documentQuery) {
         QueryOSQLConverter.Query query = QueryOSQLConverter.select(documentQuery);
+        return new QueryResult(query.query(), query.params(), query.ids());
+    }
+
+    static QueryResult countTo(SelectQuery documentQuery) {
+        QueryOSQLConverter.Query query = QueryOSQLConverter.selectCount(documentQuery);
         return new QueryResult(query.query(), query.params(), query.ids());
     }
 

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurationTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurationTest.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 
 package org.eclipse.jnosql.databases.orientdb.communication;
@@ -22,17 +23,50 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class OrientDBDocumentConfigurationTest {
 
     @Test
-    public void shouldCreateDocumentManagerFactory() {
+    public void shouldCreateDocumentManagerFactoryForRemoteDB() {
         OrientDBDocumentConfiguration configuration = new OrientDBDocumentConfiguration();
-        configuration.setHost("172.17.0.2");
+        configuration.setHost("remote:172.17.0.2");
         configuration.setUser("root");
         configuration.setPassword("rootpwd");
         var managerFactory = configuration.apply(Settings.builder().build());
         assertNotNull(managerFactory);
+    }
+
+    @Test
+    public void shouldCreateDocumentManagerFactoryForEmbeddedDB() {
+        OrientDBDocumentConfiguration configuration = new OrientDBDocumentConfiguration();
+        configuration.setHost("embedded:/tmp/db/");
+        configuration.setUser("root");
+        configuration.setPassword("rootpwd");
+        var managerFactory = configuration.apply(Settings.builder().build());
+        assertNotNull(managerFactory);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenURLIsNotSupported() {
+
+        assertThrows(IllegalArgumentException.class, ()-> {
+            OrientDBDocumentConfiguration configuration = new OrientDBDocumentConfiguration();
+            configuration.setHost("172.17.0.2");
+            configuration.setUser("root");
+            configuration.setPassword("rootpwd");
+            configuration.apply(Settings.builder().build());
+            fail("Should throw exception");
+        });
+
+        assertThrows(IllegalArgumentException.class, ()-> {
+            OrientDBDocumentConfiguration configuration = new OrientDBDocumentConfiguration();
+            configuration.setHost("/tmp/db/");
+            configuration.setUser("root");
+            configuration.setPassword("rootpwd");
+            configuration.apply(Settings.builder().build());
+            fail("Should throw exception");
+        });
     }
 
 

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverterTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverterTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QueryOSQLConverterTest {
 
@@ -29,11 +29,22 @@ public class QueryOSQLConverterTest {
         var query = select().from("collection")
                 .where("name").eq("value").build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        String sql = convert.query();
-        List<Object> values = convert.params();
-        assertEquals("value", values.get(0));
-        assertEquals("SELECT FROM collection WHERE name = ?", sql);
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT FROM collection WHERE name = ?", List.of("value"));
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT COUNT(*) FROM collection WHERE name = ?", List.of("value"));
+
+        });
     }
 
     @Test
@@ -43,12 +54,22 @@ public class QueryOSQLConverterTest {
                 .and("age").lte(10)
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        String sql = convert.query();
-        List<Object> values = convert.params();
-        assertEquals("value", values.get(0));
-        assertEquals(10, values.get(1));
-        assertEquals("SELECT FROM collection WHERE name = ? AND age <= ?", sql);
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT FROM collection WHERE name = ? AND age <= ?", List.of("value", 10));
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT COUNT(*) FROM collection WHERE name = ? AND age <= ?", List.of("value", 10));
+
+        });
     }
 
     @Test
@@ -58,12 +79,22 @@ public class QueryOSQLConverterTest {
                 .or("age").lte(10)
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        String sql = convert.query();
-        List<Object> values = convert.params();
-        assertEquals("value", values.get(0));
-        assertEquals(10, values.get(1));
-        assertEquals("SELECT FROM collection WHERE name = ? OR age <= ?", sql);
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT FROM collection WHERE name = ? OR age <= ?", List.of("value", 10));
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT COUNT(*) FROM collection WHERE name = ? OR age <= ?", List.of("value", 10));
+
+        });
     }
 
     @Test
@@ -71,11 +102,23 @@ public class QueryOSQLConverterTest {
         var query = select().from("collection")
                 .where("name").not().eq("value").build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        String sql = convert.query();
-        List<Object> values = convert.params();
-        assertEquals("value", values.get(0));
-        assertEquals("SELECT FROM collection WHERE NOT (name = ?)", sql);
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT FROM collection WHERE NOT (name = ?)", List.of("value"));
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT COUNT(*) FROM collection WHERE NOT (name = ?)", List.of("value"));
+
+        });
+
     }
 
     @Test
@@ -85,14 +128,24 @@ public class QueryOSQLConverterTest {
                 .and("name").eq("Otavio")
                 .or("name").not().eq("Lucas").build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        String sql = convert.query();
-        List<Object> values = convert.params();
-        assertEquals(3, values.size());
-        assertEquals("Assis", values.get(0));
-        assertEquals("Otavio", values.get(1));
-        assertEquals("Lucas", values.get(2));
-        assertEquals("SELECT FROM collection WHERE NOT (city = ?) AND name = ? OR NOT (name = ?)", sql);
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT FROM collection WHERE NOT (city = ?) AND name = ? OR NOT (name = ?)",
+                            List.of("Assis", "Otavio", "Lucas"));
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query, QueryOSQLConverter.Query::params)
+                    .containsExactly("SELECT COUNT(*) FROM collection WHERE NOT (city = ?) AND name = ? OR NOT (name = ?)",
+                            List.of("Assis", "Otavio", "Lucas"));
+
+        });
     }
 
     @Test
@@ -101,8 +154,22 @@ public class QueryOSQLConverterTest {
                 .skip(10)
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        assertEquals("SELECT FROM collection SKIP 10", convert.query());
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT FROM collection SKIP 10");
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT COUNT(*) FROM collection");
+
+        });
     }
 
     @Test
@@ -111,8 +178,22 @@ public class QueryOSQLConverterTest {
                 .limit(100)
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        assertEquals("SELECT FROM collection LIMIT 100", convert.query());
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT FROM collection LIMIT 100");
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT COUNT(*) FROM collection");
+
+        });
     }
 
     @Test
@@ -122,8 +203,22 @@ public class QueryOSQLConverterTest {
                 .limit(100)
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        assertEquals("SELECT FROM collection SKIP 10 LIMIT 100", convert.query());
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT FROM collection SKIP 10 LIMIT 100");
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT COUNT(*) FROM collection");
+
+        });
     }
 
     @Test
@@ -132,8 +227,22 @@ public class QueryOSQLConverterTest {
                 .orderBy("name").asc()
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        assertEquals("SELECT FROM collection ORDER BY name ASC", convert.query());
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT FROM collection ORDER BY name ASC");
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT COUNT(*) FROM collection");
+
+        });
     }
 
     @Test
@@ -142,8 +251,23 @@ public class QueryOSQLConverterTest {
                 .orderBy("name").desc()
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        assertEquals("SELECT FROM collection ORDER BY name DESC", convert.query());
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT FROM collection ORDER BY name DESC");
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT COUNT(*) FROM collection");
+
+        });
+
     }
 
     @Test
@@ -153,7 +277,22 @@ public class QueryOSQLConverterTest {
                 .orderBy("age").desc()
                 .build();
 
-        QueryOSQLConverter.Query convert = QueryOSQLConverter.select(query);
-        assertEquals("SELECT FROM collection ORDER BY name ASC, age DESC", convert.query());
+        QueryOSQLConverter.Query selectQuery = QueryOSQLConverter.select(query);
+        QueryOSQLConverter.Query selectCountQuery = QueryOSQLConverter.selectCount(query);
+
+        assertSoftly(softly -> {
+
+            softly.assertThat(selectQuery)
+                    .as("Converted OrientDB SQL query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT FROM collection ORDER BY name ASC, age DESC");
+
+            softly.assertThat(selectCountQuery)
+                    .as("Converted OrientDB SQL count query is different than expected")
+                    .extracting(QueryOSQLConverter.Query::query)
+                    .isEqualTo("SELECT COUNT(*) FROM collection");
+
+        });
+
     }
 }

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/OrientDBTemplateIntegrationTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/OrientDBTemplateIntegrationTest.java
@@ -11,16 +11,16 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.databases.orientdb.integration;
 
 
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.databases.orientdb.communication.DocumentDatabase;
-import org.eclipse.jnosql.databases.orientdb.communication.OrientDBDocumentConfigurations;
 import org.eclipse.jnosql.databases.orientdb.mapping.OrientDBTemplate;
 import org.eclipse.jnosql.mapping.Database;
-import org.eclipse.jnosql.mapping.core.config.MappingConfigurations;
+import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.document.DocumentTemplate;
 import org.eclipse.jnosql.mapping.document.spi.DocumentExtension;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
@@ -34,17 +34,16 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.util.Optional;
 
-import static com.orientechnologies.orient.core.db.ODatabaseType.PLOCAL;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 
 @EnableAutoWeld
-@AddPackages(value = {Database.class, EntityConverter.class, DocumentTemplate.class})
+@AddPackages(value = {Database.class, EntityConverter.class, DocumentTemplate.class, OrientDBTemplate.class})
 @AddPackages(Magazine.class)
-@AddPackages(OrientDBTemplate.class)
 @AddPackages(Reflections.class)
+@AddPackages(Converters.class)
 @AddExtensions({ReflectionEntityMetadataExtension.class,
         DocumentExtension.class})
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -55,11 +54,6 @@ class OrientDBTemplateIntegrationTest {
 
     static {
         DocumentDatabase.INSTANCE.get("library");
-        System.setProperty(MappingConfigurations.DOCUMENT_DATABASE.get(), "jnosql");
-        System.setProperty(OrientDBDocumentConfigurations.HOST.get(), "/tmp/db/");
-        System.setProperty(OrientDBDocumentConfigurations.USER.get(), "root");
-        System.setProperty(OrientDBDocumentConfigurations.PASSWORD.get(), "rootpwd");
-        System.setProperty(OrientDBDocumentConfigurations.STORAGE_TYPE.get(), PLOCAL.toString());
     }
     @Test
     public void shouldInsert() {

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/TemplateIntegrationTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/TemplateIntegrationTest.java
@@ -11,15 +11,16 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.databases.orientdb.integration;
 
 
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.databases.orientdb.communication.DocumentDatabase;
-import org.eclipse.jnosql.databases.orientdb.communication.OrientDBDocumentConfigurations;
+import org.eclipse.jnosql.databases.orientdb.mapping.OrientDBTemplate;
 import org.eclipse.jnosql.mapping.Database;
-import org.eclipse.jnosql.mapping.core.config.MappingConfigurations;
+import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.document.DocumentTemplate;
 import org.eclipse.jnosql.mapping.document.spi.DocumentExtension;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
@@ -33,18 +34,18 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.util.Optional;
 
-import static com.orientechnologies.orient.core.db.ODatabaseType.PLOCAL;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 
 @EnableAutoWeld
-@AddPackages(value = {Database.class, EntityConverter.class, DocumentTemplate.class})
+@AddPackages(value = {Database.class, EntityConverter.class, DocumentTemplate.class, OrientDBTemplate.class})
 @AddPackages(Magazine.class)
+@AddPackages(Reflections.class)
+@AddPackages(Converters.class)
 @AddExtensions({ReflectionEntityMetadataExtension.class,
         DocumentExtension.class})
-@AddPackages(Reflections.class)
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class TemplateIntegrationTest {
 
@@ -53,11 +54,6 @@ class TemplateIntegrationTest {
 
     static {
         DocumentDatabase.INSTANCE.get("library");
-        System.setProperty(MappingConfigurations.DOCUMENT_DATABASE.get(), "jnosql");
-        System.setProperty(OrientDBDocumentConfigurations.HOST.get(), "/tmp/db/");
-        System.setProperty(OrientDBDocumentConfigurations.USER.get(), "root");
-        System.setProperty(OrientDBDocumentConfigurations.PASSWORD.get(), "rootpwd");
-        System.setProperty(OrientDBDocumentConfigurations.STORAGE_TYPE.get(), PLOCAL.toString());
     }
 
     @Test

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/DefaultOrientDBTemplateTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/DefaultOrientDBTemplateTest.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.databases.orientdb.mapping;
 
@@ -23,6 +24,8 @@ import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.databases.orientdb.communication.OrientDBDocumentManager;
 import org.eclipse.jnosql.databases.orientdb.communication.OrientDBLiveCallback;
 import org.eclipse.jnosql.databases.orientdb.communication.OrientDBLiveCreateCallback;
+import org.eclipse.jnosql.databases.orientdb.integration.Magazine;
+import org.eclipse.jnosql.mapping.Database;
 import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.document.DocumentTemplate;
 import org.eclipse.jnosql.mapping.document.spi.DocumentExtension;
@@ -48,12 +51,12 @@ import static org.mockito.Mockito.when;
 
 
 @EnableAutoWeld
-@AddPackages(value = {Converters.class,
-        EntityConverter.class, DocumentTemplate.class, SQL.class})
-@AddPackages(MockProducer.class)
+@AddPackages(value = {Database.class, EntityConverter.class, DocumentTemplate.class, OrientDBTemplate.class})
+@AddPackages(Magazine.class)
 @AddPackages(Reflections.class)
+@AddPackages(Converters.class)
 @AddExtensions({ReflectionEntityMetadataExtension.class,
-        DocumentExtension.class, OrientDBExtension.class})
+        DocumentExtension.class})
 public class DefaultOrientDBTemplateTest {
 
     @Inject

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
@@ -19,6 +19,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import java.util.stream.StreamSupport;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
@@ -69,7 +71,8 @@ public class DefaultSolrDocumentManagerTest {
 
     @Test
     void shouldThrowExceptionWhenInsertWithTTL() {
-        assertThrows(UnsupportedOperationException.class, () -> entityManager.insert(getEntity(), Duration.ofSeconds(10)));
+        assertThrows(UnsupportedOperationException.class,
+                () -> entityManager.insert(getEntity(), Duration.ofSeconds(10)));
     }
 
     @Test
@@ -115,7 +118,6 @@ public class DefaultSolrDocumentManagerTest {
         assertEquals(entity.find("city").get(), result.find("city").get());
 
     }
-
 
     @Test
     void shouldFindDocument2() {
@@ -368,8 +370,8 @@ public class DefaultSolrDocumentManagerTest {
         params.put("type", "V");
         params.put("entity", "person");
 
-        List<CommunicationEntity> entitiesFound = entityManager.solr("age:@age AND type:@type AND _entity:@entity"
-                , params);
+        List<CommunicationEntity> entitiesFound = entityManager.solr("age:@age AND type:@type AND _entity:@entity",
+                params);
         assertEquals(1, entitiesFound.size());
     }
 
@@ -383,11 +385,9 @@ public class DefaultSolrDocumentManagerTest {
         Map<String, Object> params = new HashMap<>();
         params.put("age", 22);
 
-        List<CommunicationEntity> entitiesFound = entityManager.solr("age:@age AND age:@age"
-                , params);
+        List<CommunicationEntity> entitiesFound = entityManager.solr("age:@age AND age:@age", params);
         assertEquals(1, entitiesFound.size());
     }
-
 
     @Test
     void shouldFindAll() {
@@ -396,7 +396,6 @@ public class DefaultSolrDocumentManagerTest {
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
     }
-
 
     @Test
     void shouldReturnErrorWhenSaveSubDocument() {
@@ -442,8 +441,36 @@ public class DefaultSolrDocumentManagerTest {
 
     @Test
     void shouldCount() {
-        var entity = entityManager.insert(getEntity());
-        assertTrue(entityManager.count(COLLECTION_NAME) > 0);
+        entityManager.insert(getEntity());
+        assertSoftly(softly -> {
+            softly.assertThat(entityManager.count(COLLECTION_NAME))
+                    .as("should count collection")
+                    .isGreaterThan(0);
+            softly.assertThat(entityManager.count("unknown_collection"))
+                    .as("should count unknown collection")
+                    .isEqualTo(0);
+            softly.assertThatCode(() -> entityManager.count((String) null))
+                    .as("should throw exception when count with null collection name")
+                    .isInstanceOf(NullPointerException.class);
+        });
+    }
+
+    @Test
+    void shouldCountWithSelectQuery() {
+        entityManager.insert(getEntity());
+        var query = SelectQuery.select()
+                .from(COLLECTION_NAME)
+                .where("name").eq("Poliana")
+                .build();
+
+        assertSoftly(softly -> {
+            softly.assertThat(entityManager.count(query))
+                    .as("should count with select query")
+                    .isEqualTo(1);
+            softly.assertThatCode(() -> entityManager.count((SelectQuery) null))
+                    .as("should throw exception when count with null select query")
+                    .isInstanceOf(NullPointerException.class);
+        });
     }
 
     @Test
@@ -460,7 +487,7 @@ public class DefaultSolrDocumentManagerTest {
     }
 
     @Test
-    void shouldUpdateNull(){
+    void shouldUpdateNull() {
         var entity = entityManager.insert(getEntity());
         entity.add(Element.of("name", null));
         var documentEntity = entityManager.update(entity);
@@ -489,7 +516,6 @@ public class DefaultSolrDocumentManagerTest {
         entity.add(Element.of("contacts", documents));
         return entity;
     }
-
 
     private CommunicationEntity getEntity() {
         CommunicationEntity entity = CommunicationEntity.of(COLLECTION_NAME);

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManager.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManager.java
@@ -124,37 +124,32 @@ public class DefaultTinkerpopGraphDatabaseManager implements TinkerpopGraphDatab
     public void delete(DeleteQuery query) {
         Objects.requireNonNull(query, "delete is required");
         GraphTraversal<Vertex, Vertex> traversal = graph.traversal().V().hasLabel(query.name());
-        query.condition().ifPresent(c ->{
+        query.condition().ifPresent(c -> {
             GraphTraversal<Vertex, Vertex> predicate = TraversalExecutor.getPredicate(c);
             traversal.filter(predicate);
         });
 
-       traversal.drop().iterate();
+        traversal.drop().iterate();
         GraphTransactionUtil.transaction(graph);
     }
 
     @Override
     public Stream<CommunicationEntity> select(SelectQuery query) {
-        Objects.requireNonNull(query, "query is required");
-        GraphTraversal<Vertex, Vertex> traversal = graph.traversal().V().hasLabel(query.name());
-        query.condition().ifPresent(c ->{
-            GraphTraversal<Vertex, Vertex> predicate = TraversalExecutor.getPredicate(c);
-            traversal.filter(predicate);
-        });
+        GraphTraversal<Vertex, Vertex> traversal = buildGraphTraversalOf(query);
 
-        if(query.limit()> 0) {
+        if (query.limit() > 0) {
             traversal.limit(query.limit());
-        } else if(query.skip() > 0) {
+        } else if (query.skip() > 0) {
             traversal.skip(query.skip());
         }
-       query.sorts().forEach(
-               s -> {
-                   if (s.isAscending()) {
-                       traversal.order().by(s.property(), asc);
-                   } else {
-                       traversal.order().by(s.property(), desc);
-                   }
-               });
+        query.sorts().forEach(
+                s -> {
+                    if (s.isAscending()) {
+                        traversal.order().by(s.property(), asc);
+                    } else {
+                        traversal.order().by(s.property(), desc);
+                    }
+                });
         return traversal.toStream().map(CommunicationEntityConverter.INSTANCE);
     }
 
@@ -163,6 +158,22 @@ public class DefaultTinkerpopGraphDatabaseManager implements TinkerpopGraphDatab
         Objects.requireNonNull(entity, "entity is required");
         GraphTraversal<Vertex, Long> count = graph.traversal().V().hasLabel(entity).count();
         return count.next();
+    }
+
+    @Override
+    public long count(SelectQuery query) {
+        GraphTraversal<Vertex, Vertex> traversal = buildGraphTraversalOf(query);
+        return traversal.count().next();
+    }
+
+    private GraphTraversal<Vertex, Vertex> buildGraphTraversalOf(SelectQuery query) {
+        Objects.requireNonNull(query, "query is required");
+        GraphTraversal<Vertex, Vertex> traversal = graph.traversal().V().hasLabel(query.name());
+        query.condition().ifPresent(c -> {
+            GraphTraversal<Vertex, Vertex> predicate = TraversalExecutor.getPredicate(c);
+            traversal.filter(predicate);
+        });
+        return traversal;
     }
 
     @Override

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
@@ -432,6 +432,52 @@ class DefaultTinkerpopGraphDatabaseManagerTest {
     }
 
     @Test
+    void shouldCountByCollectionName() {
+
+        List<CommunicationEntity> entitiesWithValues = getEntitiesWithValues();
+
+        entityManager.insert(entitiesWithValues);
+
+        SelectQuery query = select().from(COLLECTION_NAME)
+                .where("age").gt(22)
+                .and("type").eq("V")
+                .orderBy("age").asc()
+                .build();
+
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(entityManager.count(COLLECTION_NAME))
+                    .isEqualTo(entitiesWithValues.size());
+            softly.assertThatThrownBy(()-> entityManager.count((String)null))
+                    .as("should throw exception when collection name is null")
+                    .isInstanceOf(NullPointerException.class);
+        });
+    }
+
+    @Test
+    void shouldCountBySelectQuery() {
+
+        List<CommunicationEntity> entitiesWithValues = getEntitiesWithValues();
+
+        entityManager.insert(entitiesWithValues);
+
+        var query = select().from(COLLECTION_NAME)
+                .where("age").gt(22)
+                .and("type").eq("V")
+                .orderBy("age").asc()
+                .build();
+
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(entityManager.count(query))
+                    .isEqualTo(2);
+            softly.assertThatThrownBy(()-> entityManager.count((SelectQuery) null))
+                    .as("should throw exception when select query is null")
+                    .isInstanceOf(NullPointerException.class);
+        });
+    }
+
+    @Test
     void shouldCreateEdge() {
         var person1 = entityManager.insert(getEntity());
         var person2 = entityManager.insert(getEntity());

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplateTest.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.databases.tinkerpop.mapping.entities.Creature;
 import org.eclipse.jnosql.databases.tinkerpop.mapping.entities.Human;
 import org.eclipse.jnosql.databases.tinkerpop.mapping.entities.Magazine;
@@ -498,6 +499,13 @@ public abstract class AbstractTinkerpopTemplateTest {
         getGraphTemplate().insert(Human.builder().withAge().withName("Otavio").build());
         getGraphTemplate().insert(Human.builder().withAge().withName("Poliana").build());
         assertEquals(2L, getGraphTemplate().count(Human.class));
+    }
+
+    @Test
+    void shouldCountFromSelectQuery() {
+        getGraphTemplate().insert(Human.builder().withAge().withName("Otavio").build());
+        getGraphTemplate().insert(Human.builder().withAge().withName("Poliana").build());
+        assertEquals(2L, getGraphTemplate().count(SelectQuery.builder().select().from("Human").build()));
     }
 
 


### PR DESCRIPTION
### Overview
This PR backports count query support optimizations from the main branch to 1.1.x, adding efficient count operations across multiple JNoSQL database drivers.

### Changes
This backport introduces optimized count query functionality for the following databases:
- **Neo4J**: Added count method with SelectQuery support and query builder enhancements
- **Tinkerpop**: Implemented count methods for graph database manager
- **Solr**: Added count method for SelectQuery in document manager
- **OrientDB**: Enhanced count query support with QueryOSQLConverter and factory improvements
- **OracleNoSQL**: Added SelectCountBuilder and enhanced condition handling for count queries
- **Couchbase**: Implemented count methods and N1QL builder support
- **Cassandra**: Enhanced count methods in column manager
- **MongoDB**: Added count query support with SelectQuery

### Technical Details
- Improved query builders across multiple databases to support count operations
- Enhanced condition handling for more accurate count queries
- Added comprehensive test coverage for count functionality
- Updated integration test configurations where needed
- Documentation updates for OrientDB configuration

### Affected Modules
- jnosql-neo4j
- jnosql-tinkerpop
- jnosql-solr
- jnosql-orientdb
- jnosql-oracle-nosql
- jnosql-couchbase
- jnosql-cassandra
- jnosql-mongodb

### Testing
All changes include corresponding test cases to ensure count query functionality works correctly across different databases.

### Compatibility
This is a backward-compatible enhancement that adds new count functionality without breaking existing APIs.