### PR TITLE
Optimize DatabaseManager.update(UpdateQuery) to use native database operations

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,15 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 === Added
 
+- Add update method to MongoDB Document Manager accepting UpdateQuery argument for document updates
+- Add updateDocument method to MongoDB Document Manager for optimized update operations
+- Add update method to Cassandra Column Manager accepting UpdateQuery argument for entity updates
+- Add update method to Couchbase Document Manager accepting UpdateQuery argument using N1QL UPDATE queries
+- Add N1QL update query builder (N1QLUpdateQueryBuilder) for Couchbase
+- Add update query builder for Neo4J database operations
+- Add update method to Neo4J Database Manager accepting UpdateQuery argument
+- Add update method to QueryAQLConverter accepting UpdateQuery argument for ArangoDB
+- Add update method to ArangoDB Document Manager accepting UpdateQuery argument
 - Add count method to MongoDB Document Manager for optimized count queries
 - Add count method to Cassandra Column Manager with consistency level support
 - Add count method to Cassandra Template with entity mapping
@@ -22,6 +31,13 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 === Changed
 
+- Optimize update method for MongoDB Document Manager
+- Enhance updateDocument method for MongoDB with better error handling
+- Improve MongoDB document update tests
+- Validate required fields in N1QLUpdateQueryBuilder for Couchbase
+- Validate update query parameters in Couchbase driver
+- Update N1QL queries for Magazine class
+- Add update query tests for ArangoDB, Neo4J, Couchbase, Cassandra, and MongoDB
 - Update jakarta data engine
 
 == [1.1.12] - 2026-01-05

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
@@ -25,6 +25,7 @@ import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 import org.eclipse.jnosql.mapping.semistructured.MappingQuery;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +57,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class ArangoDBDocumentManagerTest {
@@ -307,6 +311,40 @@ public class ArangoDBDocumentManagerTest {
             soft.assertThat(name).isPresent();
             soft.assertThat(name).get().extracting(Element::name).isEqualTo("name");
             soft.assertThat(name).get().extracting(Element::get).isNull();
+        });
+    }
+
+    @Test
+    void shouldUpdateByQuery(){
+        var attributesNames = new LinkedHashSet<String>();
+
+        for (int index = 0; index < 10; index++) {
+            var entity = getEntity();
+            entity.add("index", index);
+            entityManager.insert(entity);
+            entity.elements().forEach(e -> attributesNames.add(e.name()));
+        }
+        var index = 4;
+
+        final var updateQuery = mock(UpdateQuery.class);
+        when(updateQuery.name()).thenReturn(COLLECTION_NAME);
+        when(updateQuery.condition()).thenReturn(Optional.of(CriteriaCondition.gt(Element.of("index", index))));
+        when(updateQuery.set()).then(inv -> List.of(Element.of("country", "Brazil")));
+        when(updateQuery.toSelectQuery()).then(inv -> select().from(COLLECTION_NAME).where("index").gt(index).build());
+
+        var entities = entityManager.update(updateQuery);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(entities).hasSize(5);
+            softly.assertThat(entities)
+                    .allMatch(e -> e.find("country").orElseThrow().get().equals("Brazil"))
+                    .allSatisfy( e-> {
+                        for (String attributeName : attributesNames) {
+                            softly.assertThat(e.find(attributeName))
+                                    .as("Attribute " + attributeName + " should be present")
+                                    .isPresent();
+                        }
+                    });
+
         });
     }
 

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultCassandraColumnManager.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultCassandraColumnManager.java
@@ -26,9 +26,11 @@ import com.datastax.oss.driver.api.core.type.codec.registry.CodecRegistry;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.api.querybuilder.delete.Delete;
 import com.datastax.oss.driver.api.querybuilder.insert.Insert;
+import com.datastax.oss.driver.api.querybuilder.update.Update;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 
 import java.time.Duration;
 import java.util.Map;
@@ -82,6 +84,13 @@ class DefaultCassandraColumnManager implements CassandraColumnManager {
         return insert(entities);
     }
 
+    @Override
+    public Iterable<CommunicationEntity> update(UpdateQuery query) {
+        requireNonNull(query, "query is required");
+        final Update update = QueryUtils.update(query, keyspace, session);
+        session.execute(update.build());
+        return select(query.toSelectQuery()).toList();
+    }
 
     @Override
     public Iterable<CommunicationEntity> insert(Iterable<CommunicationEntity> entities) {

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseDocumentManager.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseDocumentManager.java
@@ -134,6 +134,7 @@ class DefaultCouchbaseDocumentManager implements CouchbaseDocumentManager {
 
     @Override
     public Iterable<CommunicationEntity> update(UpdateQuery query) {
+        Objects.requireNonNull(query, "query is required");
         return waitBucketBeReadyAndGet(() -> {
             N1QLQuery n1QLQuery = N1QLBuilder.of(query, database, bucket.defaultScope().name()).get();
             QueryResult result = cluster.query(n1QLQuery.query(), QueryOptions

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLSelectQueryBuilder.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLSelectQueryBuilder.java
@@ -1,0 +1,194 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.databases.couchbase.communication;
+
+import com.couchbase.client.java.json.JsonObject;
+import jakarta.data.Direction;
+import org.eclipse.jnosql.communication.TypeReference;
+import org.eclipse.jnosql.communication.driver.StringMatch;
+import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
+import org.eclipse.jnosql.communication.semistructured.Element;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+record N1QLSelectQueryBuilder(SelectQuery query, String database, String scope,
+                              boolean shouldCount) implements N1QLBuilder {
+    @Override
+    public N1QLQuery get() {
+
+        StringBuilder n1ql = new StringBuilder();
+        JsonObject params = JsonObject.create();
+        List<String> ids = new ArrayList<>();
+
+        n1ql.append("select ");
+        n1ql.append(select()).append(' ');
+        n1ql.append("from ")
+                .append(database).append(".")
+                .append(scope).append(".")
+                .append(query.name());
+
+        query.condition().ifPresent(c -> {
+            n1ql.append(" WHERE ");
+            condition(c, n1ql, params, ids, shouldCount);
+        });
+
+        if (shouldCount) {
+            return N1QLQuery.of(n1ql, params, ids);
+        }
+
+        if (!query.sorts().isEmpty()) {
+            n1ql.append(" ORDER BY ");
+            String order = query.sorts().stream()
+                    .map(s -> s.property() + " " + (s.isAscending() ? Direction.ASC : Direction.DESC))
+                    .collect(Collectors.joining(", "));
+            n1ql.append(order);
+        }
+
+        if (query.limit() > 0) {
+            n1ql.append(" LIMIT ").append(query.limit());
+        }
+
+        if (query.skip() > 0) {
+            n1ql.append(" OFFSET ").append(query.skip());
+        }
+
+        return N1QLQuery.of(n1ql, params, ids);
+    }
+
+    private String select() {
+        if (shouldCount) {
+            return "COUNT(*)";
+        }
+        String documents = String.join(", ", query.columns());
+        if (documents.isBlank()) {
+            return "*";
+        }
+        return documents;
+    }
+
+    private void condition(CriteriaCondition condition, StringBuilder n1ql, JsonObject params, List<String> ids, boolean shouldCount) {
+        Element document = condition.element();
+        switch (condition.condition()) {
+            case EQUALS:
+                if (document.name().equals(EntityConverter.ID_FIELD) && !shouldCount) {
+                    ids.add(document.get(String.class));
+                } else {
+                    predicate(n1ql, " = ", document, params);
+                }
+                return;
+            case IN:
+                if (document.name().equals(EntityConverter.ID_FIELD) && !shouldCount) {
+                    ids.addAll(document.get(new TypeReference<List<String>>() {
+                    }));
+                } else {
+                    predicate(n1ql, " IN ", document, params);
+                }
+                return;
+            case LESSER_THAN:
+                predicate(n1ql, " < ", document, params);
+                return;
+            case GREATER_THAN:
+                predicate(n1ql, " > ", document, params);
+                return;
+            case LESSER_EQUALS_THAN:
+                predicate(n1ql, " <= ", document, params);
+                return;
+            case GREATER_EQUALS_THAN:
+                predicate(n1ql, " >= ", document, params);
+                return;
+            case LIKE:
+                predicate(n1ql, " LIKE ", document, params);
+                return;
+            case CONTAINS:
+                predicate(n1ql, " LIKE ", Element.of(document.name(), StringMatch.CONTAINS.format(document.get(String.class))), params);
+                return;
+            case STARTS_WITH:
+                predicate(n1ql, " LIKE ", Element.of(document.name(), StringMatch.STARTS_WITH.format(document.get(String.class))), params);
+                return;
+            case ENDS_WITH:
+                predicate(n1ql, " LIKE ", Element.of(document.name(), StringMatch.ENDS_WITH.format(document.get(String.class))), params);
+                return;
+            case NOT:
+                n1ql.append(" NOT ");
+                condition(document.get(CriteriaCondition.class), n1ql, params, ids, shouldCount);
+                return;
+            case OR:
+                appendCondition(n1ql, params, document.get(new TypeReference<>() {
+                }), " OR ", ids, shouldCount);
+                return;
+            case AND:
+                appendCondition(n1ql, params, document.get(new TypeReference<>() {
+                }), " AND ", ids, shouldCount);
+                return;
+            case BETWEEN:
+                predicateBetween(n1ql, params, document);
+                return;
+            default:
+                throw new UnsupportedOperationException("There is not support condition for " + condition.condition());
+        }
+    }
+
+    private void predicateBetween(StringBuilder n1ql, JsonObject params, Element document) {
+        n1ql.append(" BETWEEN ");
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        String name = identifierOf(document.name());
+
+        List<Object> values = new ArrayList<>();
+        ((Iterable<?>) document.get()).forEach(values::add);
+
+        String param = "$".concat(document.name()).concat("_").concat(Integer.toString(random.nextInt(0, 100)));
+        String param2 = "$".concat(document.name()).concat("_").concat(Integer.toString(random.nextInt(0, 100)));
+        n1ql.append(name).append(" ").append(param).append(" AND ").append(param2);
+        params.put(param, values.get(0));
+        params.put(param2, values.get(1));
+    }
+
+    private void appendCondition(StringBuilder n1ql, JsonObject params,
+                                 List<CriteriaCondition> conditions,
+                                 String condition, List<String> ids, boolean shouldCount) {
+        int index = 0;
+        for (CriteriaCondition documentCondition : conditions) {
+            StringBuilder query = new StringBuilder();
+            condition(documentCondition, query, params, ids, shouldCount);
+            if (index == 0) {
+                n1ql.append(" ").append(query);
+            } else if (!query.isEmpty()) {
+                n1ql.append(condition).append(query);
+            }
+            index++;
+        }
+    }
+
+    private void predicate(StringBuilder n1ql,
+                           String condition,
+                           Element document,
+                           JsonObject params) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        String name = identifierOf(document.name());
+        Object value = document.get();
+        String param = "$".concat(document.name()).concat("_").concat(Integer.toString(random.nextInt(0, 100)));
+        n1ql.append(name).append(condition).append(param);
+        params.put(param, value);
+    }
+
+    private String identifierOf(String name) {
+        return ' ' + name + ' ';
+    }
+
+}

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLUpdateQueryBuilder.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLUpdateQueryBuilder.java
@@ -24,14 +24,23 @@ import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 record N1QLUpdateQueryBuilder(UpdateQuery query, String database, String scope) implements N1QLBuilder {
-    @Override
-    public N1QLQuery get() {
+
+    N1QLUpdateQueryBuilder{
+        Objects.requireNonNull(query.name(), "documentCollection is required");
+        Objects.requireNonNull(query.set(), "set operations are required");
         if (query.set().isEmpty())
             throw new IllegalArgumentException("UpdateQuery must have at least one set operation");
+        Objects.requireNonNull(database, "database is required");
+        Objects.requireNonNull(scope, "scope is required");
+    }
+
+    @Override
+    public N1QLQuery get() {
         var alias = "d";
         var n1ql = new StringBuilder();
         var params = JsonObject.create();

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLUpdateQueryBuilder.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLUpdateQueryBuilder.java
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.databases.couchbase.communication;
+
+import com.couchbase.client.java.json.JsonObject;
+import org.eclipse.jnosql.communication.TypeReference;
+import org.eclipse.jnosql.communication.driver.StringMatch;
+import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
+import org.eclipse.jnosql.communication.semistructured.Element;
+import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+record N1QLUpdateQueryBuilder(UpdateQuery query, String database, String scope) implements N1QLBuilder {
+    @Override
+    public N1QLQuery get() {
+        if (query.set().isEmpty())
+            throw new IllegalArgumentException("UpdateQuery must have at least one set operation");
+        var alias = "d";
+        var n1ql = new StringBuilder();
+        var params = JsonObject.create();
+        n1ql.append("UPDATE ")
+                .append(database).append(".")
+                .append(scope).append(".")
+                .append(query.name())
+                .append(" AS ").append(alias);
+
+        n1ql.append(" SET ");
+        String updates = query.set().stream()
+                .map(element -> {
+                    ThreadLocalRandom random = ThreadLocalRandom.current();
+                    String name =  identifierOf(alias, element.name());
+                    Object value = element.get();
+                    String param = "$".concat(element.name()).concat("_").concat(Integer.toString(random.nextInt(0, 100)));
+                    params.put(param, value);
+                    return name + " = " + param;
+                })
+                .collect(Collectors.joining(", "));
+        n1ql.append(updates).append(' ');
+
+        n1ql.append(" WHERE ");
+
+        condition(query.condition().orElseThrow(() -> new IllegalArgumentException("UpdateQuery must have a condition")),
+                alias, n1ql, params);
+
+        n1ql.append(" RETURNING ").append(alias).append(".*");
+
+        return N1QLQuery.of(n1ql, params, Collections.emptyList());
+    }
+
+    private void condition(CriteriaCondition condition, String alias, StringBuilder n1ql, JsonObject params) {
+        Element document = condition.element();
+        switch (condition.condition()) {
+            case EQUALS:
+                predicate(alias, n1ql, " = ", document, params);
+                return;
+            case IN:
+                predicate(alias, n1ql, " IN ", document, params);
+                return;
+            case LESSER_THAN:
+                predicate(alias, n1ql, " < ", document, params);
+                return;
+            case GREATER_THAN:
+                predicate(alias, n1ql, " > ", document, params);
+                return;
+            case LESSER_EQUALS_THAN:
+                predicate(alias, n1ql, " <= ", document, params);
+                return;
+            case GREATER_EQUALS_THAN:
+                predicate(alias, n1ql, " >= ", document, params);
+                return;
+            case LIKE:
+                predicate(alias, n1ql, " LIKE ", document, params);
+                return;
+            case CONTAINS:
+                predicate(alias, n1ql, " LIKE ", Element.of(document.name(), StringMatch.CONTAINS.format(document.get(String.class))), params);
+                return;
+            case STARTS_WITH:
+                predicate(alias, n1ql, " LIKE ", Element.of(document.name(), StringMatch.STARTS_WITH.format(document.get(String.class))), params);
+                return;
+            case ENDS_WITH:
+                predicate(alias, n1ql, " LIKE ", Element.of(document.name(), StringMatch.ENDS_WITH.format(document.get(String.class))), params);
+                return;
+            case NOT:
+                n1ql.append(" NOT ");
+                condition(document.get(CriteriaCondition.class), alias, n1ql, params);
+                return;
+            case OR:
+                appendCondition(alias, n1ql, params, document.get(new TypeReference<>() {
+                }), " OR ");
+                return;
+            case AND:
+                appendCondition(alias, n1ql, params, document.get(new TypeReference<>() {
+                }), " AND ");
+                return;
+            case BETWEEN:
+                predicateBetween(alias, n1ql, params, document);
+                return;
+            default:
+                throw new UnsupportedOperationException("There is not support condition for " + condition.condition());
+        }
+    }
+
+    private void predicateBetween(String alias, StringBuilder n1ql, JsonObject params, Element document) {
+        n1ql.append(" BETWEEN ");
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        String name = identifierOf(alias, document.name());
+
+        List<Object> values = new ArrayList<>();
+        ((Iterable<?>) document.get()).forEach(values::add);
+
+        String param = "$".concat(document.name()).concat("_").concat(Integer.toString(random.nextInt(0, 100)));
+        String param2 = "$".concat(document.name()).concat("_").concat(Integer.toString(random.nextInt(0, 100)));
+        n1ql.append(name).append(" ").append(param).append(" AND ").append(param2);
+        params.put(param, values.get(0));
+        params.put(param2, values.get(1));
+    }
+
+    private void appendCondition(String alias, StringBuilder n1ql, JsonObject params,
+                                 List<CriteriaCondition> conditions,
+                                 String condition) {
+        int index = 0;
+        for (CriteriaCondition documentCondition : conditions) {
+            StringBuilder query = new StringBuilder();
+            condition(documentCondition, alias, query, params);
+            if (index == 0) {
+                n1ql.append(" ").append(query);
+            } else if (!query.isEmpty()) {
+                n1ql.append(condition).append(query);
+            }
+            index++;
+        }
+    }
+
+    private void predicate(String alias,
+                           StringBuilder n1ql,
+                           String condition,
+                           Element document,
+                           JsonObject params) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        String name = identifierOf(alias,document.name());
+        Object value = document.get();
+        String param = "$".concat(document.name()).concat("_").concat(Integer.toString(random.nextInt(0, 100)));
+        n1ql.append(name).append(condition).append(param);
+        params.put(param, value);
+    }
+
+    private String identifierOf(String alias, String field) {
+        return "%s.%s".formatted(alias, field);
+    }
+
+}

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
@@ -22,10 +22,12 @@ import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.keyvalue.BucketManager;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
+import org.eclipse.jnosql.communication.semistructured.DefaultSelectQuery;
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 import org.eclipse.jnosql.mapping.semistructured.MappingQuery;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.StreamSupport;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,6 +87,7 @@ public class CouchbaseDocumentManagerTest {
         try {
             keyValueEntityManagerForPerson.delete("id");
             keyValueEntityManagerForPerson.delete("id2");
+            keyValueEntityManagerForPerson.delete("id3");
         } catch (DocumentNotFoundException exp) {
             //IGNORE
         }
@@ -96,23 +100,22 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldInsert() {
+    void shouldInsert() {
         CommunicationEntity entity = getEntity();
         CommunicationEntity documentEntity = entityManager.insert(entity);
         assertEquals(entity, documentEntity);
     }
 
     @Test
-   void shouldInsertWithKey() {
+    void shouldInsertWithKey() {
         CommunicationEntity entity = getEntity();
         entity.add("_key", "anyvalue");
         CommunicationEntity documentEntity = entityManager.insert(entity);
         assertEquals(entity, documentEntity);
     }
 
-
     @Test
-   void shouldUpdate() {
+    void shouldUpdate() {
         CommunicationEntity entity = getEntity();
         CommunicationEntity documentEntity = entityManager.insert(entity);
         Element newField = Elements.of("newField", "10");
@@ -122,7 +125,57 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldRemoveEntityByName() throws InterruptedException {
+    void shouldUpdateQuery() {
+        List<CommunicationEntity> persistedEntities =
+                StreamSupport.stream(entityManager.insert(getEntities()).spliterator(), false)
+                        .toList();
+
+        await().until(() ->
+                entityManager
+                        .count(COLLECTION_PERSON_NAME) >=3
+        );
+
+        CommunicationEntity entity = persistedEntities.stream().findFirst().orElseThrow();
+
+        Element id = entity.find("_id").get();
+
+        Iterable<CommunicationEntity> updatedEntities = entityManager.update(
+                new UpdateQuery() {
+                    @Override
+                    public String name() {
+                        return COLLECTION_PERSON_NAME;
+                    }
+
+                    @Override
+                    public List<Element> set() {
+                        return List.of(Elements.of("newField", "10"));
+                    }
+
+                    @Override
+                    public Optional<CriteriaCondition> condition() {
+                        return Optional.of(CriteriaCondition.eq(id));
+                    }
+
+                    @Override
+                    public SelectQuery toSelectQuery() {
+                        return new DefaultSelectQuery(0, 0, COLLECTION_PERSON_NAME, List.of(), List.of(), condition().orElseThrow(), false);
+                    }
+                }
+        );
+        StreamSupport.stream(updatedEntities.spliterator(), false)
+                .forEach(e -> {
+                    Optional<Element> updateField = e.find("newField");
+                    assertSoftly(soft -> {
+                        soft.assertThat(updateField).isPresent();
+                        soft.assertThat(updateField).get().extracting(Element::name).isEqualTo("newField");
+                        soft.assertThat(updateField).get().extracting(Element::get).isEqualTo("10");
+                    });
+                });
+    }
+
+
+    @Test
+    void shouldRemoveEntityByName() throws InterruptedException {
         CommunicationEntity documentEntity = entityManager.insert(getEntity());
         Thread.sleep(1_000L);
         Element name = documentEntity.find("name").get();
@@ -135,7 +188,7 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldSaveSubDocument() {
+    void shouldSaveSubDocument() {
         CommunicationEntity entity = getEntity();
         entity.add(Element.of("phones", Element.of("mobile", "1231231")));
         CommunicationEntity entitySaved = entityManager.insert(entity);
@@ -149,7 +202,7 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldSaveSubDocument2() throws InterruptedException {
+    void shouldSaveSubDocument2() throws InterruptedException {
         CommunicationEntity entity = getEntity();
         entity.add(Element.of("phones", asList(Element.of("mobile", "1231231"), Element.of("mobile2", "1231231"))));
         CommunicationEntity entitySaved = entityManager.insert(entity);
@@ -165,7 +218,7 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldSaveSetDocument() throws InterruptedException {
+    void shouldSaveSetDocument() throws InterruptedException {
         Set<String> set = new HashSet<>();
         set.add("Acarajé");
         set.add("Munguzá");
@@ -184,14 +237,14 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldConvertFromListDocumentList() {
+    void shouldConvertFromListDocumentList() {
         CommunicationEntity entity = createSubdocumentList();
         entityManager.insert(entity);
 
     }
 
     @Test
-   void shouldRetrieveListDocumentList() {
+    void shouldRetrieveListDocumentList() {
         CommunicationEntity entity = entityManager.insert(createSubdocumentList());
         Element key = entity.find("_id").get();
         var query = select().from(COLLECTION_APP_NAME).where(key.name()).eq(key.get()).build();
@@ -221,12 +274,12 @@ public class CouchbaseDocumentManagerTest {
             softly.assertThat(entityManager.count(query))
                     .isEqualTo(1L);
 
-            softly.assertThatThrownBy(()->
-                    entityManager.count((String) null))
+            softly.assertThatThrownBy(() ->
+                            entityManager.count((String) null))
                     .isInstanceOf(NullPointerException.class);
 
-            softly.assertThatThrownBy(()->
-                    entityManager.count((SelectQuery) null))
+            softly.assertThatThrownBy(() ->
+                            entityManager.count((SelectQuery) null))
                     .isInstanceOf(NullPointerException.class);
 
         });
@@ -253,7 +306,7 @@ public class CouchbaseDocumentManagerTest {
 
 
     @Test
-   void shouldRunN1Ql() {
+    void shouldRunN1Ql() {
         CommunicationEntity entity = getEntity();
         entityManager.insert(entity);
         await().until(() ->
@@ -263,7 +316,7 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldRunN1QlParameters() {
+    void shouldRunN1QlParameters() {
         CommunicationEntity entity = getEntity();
         entityManager.insert(entity);
 
@@ -276,7 +329,7 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-   void shouldCreateLimitOrderQuery(){
+    void shouldCreateLimitOrderQuery() {
         CommunicationEntity entity = getEntity();
         entity.add("_id", "id2");
         entityManager.insert(entity);
@@ -293,7 +346,7 @@ public class CouchbaseDocumentManagerTest {
 
     @Test
     void shouldInsertNull() {
-        CommunicationEntity entity =getEntity();
+        CommunicationEntity entity = getEntity();
         entity.add(Element.of("name", null));
         CommunicationEntity documentEntity = entityManager.insert(entity);
         Optional<Element> name = documentEntity.find("name");
@@ -305,7 +358,7 @@ public class CouchbaseDocumentManagerTest {
     }
 
     @Test
-    void shouldUpdateNull(){
+    void shouldUpdateNull() {
         var entity = entityManager.insert(getEntity());
         entity.add(Element.of("name", null));
         var documentEntity = entityManager.update(entity);
@@ -387,5 +440,37 @@ public class CouchbaseDocumentManagerTest {
         documents.forEach(entity::add);
         return entity;
     }
+
+    private List<CommunicationEntity> getEntities() {
+
+        List<CommunicationEntity> entities = new ArrayList<>();
+
+        CommunicationEntity entity1 = CommunicationEntity.of(COLLECTION_PERSON_NAME);
+        Elements.of(Map.of(
+                "name", "Poliana",
+                "city", "Salvador",
+                "_id", "id"
+        )).forEach(entity1::add);
+        entities.add(entity1);
+
+        CommunicationEntity entity2 = CommunicationEntity.of(COLLECTION_PERSON_NAME);
+        Elements.of(Map.of(
+                "name", "Otavio",
+                "city", "Salvador",
+                "_id", "id2"
+        )).forEach(entity2::add);
+        entities.add(entity2);
+
+        CommunicationEntity entity3 = CommunicationEntity.of(COLLECTION_PERSON_NAME);
+        Elements.of(Map.of(
+                "name", "Maximillian",
+                "city", "Sao Paulo",
+                "_id", "id3"
+        )).forEach(entity3::add);
+        entities.add(entity3);
+
+        return entities;
+    }
+
 
 }

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseTemplateIntegrationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseTemplateIntegrationTest.java
@@ -116,7 +116,7 @@ class CouchbaseTemplateIntegrationTest {
                 .isNotNull()
                 .isEqualTo(magazine);
 
-        var data = template.n1qlQuery("select * from " + CouchbaseUtil.BUCKET_NAME + "._default.Book where title = $title",
+        var data = template.n1qlQuery("select * from " + CouchbaseUtil.BUCKET_NAME + "._default." + Magazine.class.getSimpleName() + " where title = $title",
                 JsonObject.from(Map.of("title", magazine.title()))).toList();
 
         assertSoftly(softly -> {
@@ -133,7 +133,7 @@ class CouchbaseTemplateIntegrationTest {
                 .isNotNull()
                 .isEqualTo(magazine);
 
-        var data = template.n1qlQuery("select * from " + CouchbaseUtil.BUCKET_NAME + "._default.Book").toList();
+        var data = template.n1qlQuery("select * from " + CouchbaseUtil.BUCKET_NAME + "._default." + Magazine.class.getSimpleName()).toList();
         assertSoftly(softly -> {
             softly.assertThat(data).as("query result is a non-null instance").isNotNull();
             softly.assertThat(data.size()).as("query result size is correct").isEqualTo(1);

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManager.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManager.java
@@ -34,6 +34,7 @@ import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -141,6 +142,18 @@ public class MongoDBDocumentManager implements DatabaseManager {
                 .toList();
     }
 
+    @Override
+    public Iterable<CommunicationEntity> update(UpdateQuery query) {
+        Objects.requireNonNull(query, "update query is required");
+        String columnName = query.name();
+        Objects.requireNonNull(query, "entity name is required");
+        var filter = query.condition()
+                .map(DocumentQueryConversor::convert)
+                .orElseGet(BsonDocument::new);
+        MongoCollection<Document> collection = mongoDatabase.getCollection(columnName);
+        collection.updateMany(filter, updateDocument(query::set));
+        return select(query.toSelectQuery()).toList();
+    }
 
     @Override
     public void delete(DeleteQuery query) {

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBUtils.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBUtils.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
 import static java.util.stream.StreamSupport.stream;
@@ -47,8 +48,12 @@ final class MongoDBUtils {
     }
 
     static Bson updateDocument(CommunicationEntity entity) {
+        return updateDocument(entity::elements);
+    }
+
+    static Bson updateDocument(Supplier<List<Element>> elementsSupplier) {
         List<Bson> fields = new ArrayList<>();
-        entity.elements().forEach(d -> fields.add(Updates.set(d.name(), convert(d.value()))));
+        elementsSupplier.get().forEach(d -> fields.add(Updates.set(d.name(), convert(d.value()))));
         return Updates.combine(fields);
     }
 

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBUtils.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBUtils.java
@@ -14,7 +14,9 @@
  */
 package org.eclipse.jnosql.databases.mongodb.communication;
 
+import com.mongodb.client.model.Updates;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 import org.bson.types.Binary;
 import org.eclipse.jnosql.communication.Value;
 import org.eclipse.jnosql.communication.ValueUtil;
@@ -42,6 +44,12 @@ final class MongoDBUtils {
         Document document = new Document();
         entity.elements().forEach(d -> document.append(d.name(), convert(d.value())));
         return document;
+    }
+
+    static Bson updateDocument(CommunicationEntity entity) {
+        List<Bson> fields = new ArrayList<>();
+        entity.elements().forEach(d -> fields.add(Updates.set(d.name(), convert(d.value()))));
+        return Updates.combine(fields);
     }
 
     private static Object convert(Value value) {

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/DefaultNeo4JDatabaseManager.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/DefaultNeo4JDatabaseManager.java
@@ -22,6 +22,7 @@ import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Values;
@@ -120,6 +121,20 @@ class DefaultNeo4JDatabaseManager implements Neo4JDatabaseManager {
         Objects.requireNonNull(entities, "entities is required");
         entities.forEach(this::update);
         return entities;
+    }
+
+    @Override
+    public Iterable<CommunicationEntity> update(UpdateQuery query) {
+        Objects.requireNonNull(query, "query is required");
+        Map<String, Object> parameters = new HashMap<>();
+        String cypher = Neo4JQueryBuilder.INSTANCE.buildQuery(query, parameters);
+
+        LOGGER.fine("Executing Cypher Query for select entities: " + cypher);
+        try (Transaction tx = session.beginTransaction()) {
+            return tx.run(cypher, Values.parameters(flattenMap(parameters)))
+                    .list(record -> extractEntity(query.name(), record, true))
+                    .stream().toList();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Description

This PR addresses issue https://github.com/eclipse-jnosql/jnosql/issues/638 by implementing native update operations for database drivers to avoid unnecessary full entity rewrites and improve performance.

### Current Status (Draft)
✅ **Complete** - All feasible database drivers have been optimized (5 out of 7)

### Changes Made

#### ✅ **MongoDB Driver** (Complete)
- Implemented native `update(UpdateQuery)` using MongoDB's `$set` operator
- Added `updateDocument` helper method in `MongoDBDocumentManager`
- Enhanced `MongoDBUtils` to support partial document updates
- Comprehensive test coverage

#### ✅ **Cassandra Driver** (Complete)
- Implemented native `update(UpdateQuery)` using CQL `UPDATE ... SET` statements
- Enhanced `QueryUtils` to build native Cassandra update queries
- Updated `DefaultCassandraColumnManager` with optimized update logic
- Added comprehensive test cases

#### ✅ **Couchbase Driver** (Complete)
- Implemented native `update(UpdateQuery)` using N1QL `UPDATE ... SET` statements
- Created `N1QLUpdateQueryBuilder` for building N1QL update queries
- Refactored `N1QLBuilder` with `N1QLSelectQueryBuilder` for cleaner separation
- Added validation for required fields in update queries
- Enhanced test coverage including integration tests

#### ✅ **Neo4j Driver** (Complete)
- Implemented native `update(UpdateQuery)` using Cypher `SET` statements
- Enhanced `Neo4JQueryBuilder` to support building update queries
- Updated `DefaultNeo4JDatabaseManager` with optimized update logic
- Added comprehensive test cases for update operations

#### ✅ **ArangoDB Driver** (Complete)
- Implemented native `update(UpdateQuery)` using AQL `UPDATE` statements
- Enhanced `QueryAQLConverter` to build native AQL update queries
- Updated `DefaultArangoDBDocumentManager` with optimized update logic
- Added comprehensive test cases for update operations

### Problem
The current default `update()` method performs unnecessary operations:
1. ⚠️ Fetch existing entity from database
2. ⚠️ Deserialize to Java
3. ⚠️ Update field(s) in memory  
4. ⚠️ Save entire object back

This introduces unnecessary round-trips, bandwidth usage, and serialization overhead, especially problematic for large documents or high-frequency updates.

### Solution
Override `update(UpdateQuery)` per database driver to leverage native update operations:

- **MongoDB**: ✅ Uses `$set` operator for atomic partial updates
- **Cassandra**: ✅ Uses native CQL `UPDATE ... SET` statements
- **Couchbase**: ✅ Uses native N1QL `UPDATE ... SET` statements
- **Neo4j**: ✅ Uses native Cypher `SET` statements
- **ArangoDB**: ✅ Uses native AQL `UPDATE` statements
  - All implementations:
    - Eliminate read-before-write operations
    - Reduce network payload (only modified fields sent)
    - Improve performance and reduce latency
    - Support atomic updates at database level

### Technical Details
**Modified Files:**
- **MongoDB:**
  - `MongoDBDocumentManager.java` - Optimized `update()` implementation
  - `MongoDBUtils.java` - Update query conversion utilities
  - `MongoDBDocumentManagerTest.java` - Test coverage
- **Cassandra:**
  - `DefaultCassandraColumnManager.java` - Optimized `update()` implementation
  - `QueryUtils.java` - CQL update query builder
  - `CassandraColumnManagerTest.java` - Test coverage
- **Couchbase:**
  - `DefaultCouchbaseDocumentManager.java` - Optimized `update()` implementation
  - `N1QLBuilder.java` - Refactored query builder structure
  - `N1QLUpdateQueryBuilder.java` - New N1QL update query builder
  - `N1QLSelectQueryBuilder.java` - New N1QL select query builder
  - `CouchbaseDocumentManagerTest.java` - Test coverage
  - `CouchbaseTemplateIntegrationTest.java` - Integration test updates
- **Neo4j:**
  - `DefaultNeo4JDatabaseManager.java` - Optimized `update()` implementation
  - `Neo4JQueryBuilder.java` - Enhanced with update query support
  - `Neo4JDatabaseManagerTest.java` - Test coverage
  - `Neo4JQueryBuilderTest.java` - Query builder tests
- **ArangoDB:**
  - `DefaultArangoDBDocumentManager.java` - Optimized `update()` implementation
  - `QueryAQLConverter.java` - Enhanced with AQL update query support
  - `ArangoDBDocumentManagerTest.java` - Test coverage
  - `QueryAQLConverterTest.java` - Converter tests

### Technical Limitations

#### ⚠️ **DynamoDB - Cannot Be Implemented**

DynamoDB cannot support optimized `update(UpdateQuery)` implementation at the communication layer due to fundamental AWS SDK and PartiQL constraints:

**AWS SDK Limitations:**
- The `UpdateItem` operation requires explicit knowledge of the table's **partition key** and **sort key** (if defined)
- These key attributes are table schema metadata that is not available at the communication layer level
- Without these keys, it's impossible to construct valid update requests using the AWS SDK

**PartiQL Limitations:**
- DynamoDB's PartiQL implementation **does not support batch/multiple update statements**
- Each PartiQL `UPDATE` statement can only modify a single item
- PartiQL updates still require the partition key (and sort key if applicable) in the `WHERE` clause
- This makes it unsuitable for generic `UpdateQuery` operations that may target multiple documents

**Why This Cannot Be Solved By Now:**
- The communication layer is designed to be schema-agnostic and should not require knowledge of table-specific key structures
- Requiring partition/sort key information would break the abstraction and introduce tight coupling to DynamoDB-specific schema design
- The generic `UpdateQuery` interface expects to handle bulk updates, which PartiQL fundamentally does not support for DynamoDB

**Recommendation:**
- DynamoDB will continue using the default implementation (read-modify-write)

#### ⚠️ **CouchDB - Cannot Be Implemented**

CouchDB cannot support optimized `update(UpdateQuery)` implementation due to its document-oriented architecture and HTTP API design:

**CouchDB Architecture Limitations:**
- CouchDB **does not provide a native multi-document update command**
- The HTTP API is document-centric and requires updating documents individually
- Each update operation requires:
  1. The document's `_id` (document identifier)
  2. The current `_rev` (revision identifier) to prevent conflicts
  3. A complete document payload (CouchDB uses full document replacement)

**Why Bulk Updates Are Not Supported:**
- CouchDB's `_bulk_docs` API can create or update multiple documents, but requires the full document content for each item
- There is no native query-based update mechanism (e.g., "UPDATE WHERE condition SET field=value")
- The Mango query system is designed for reads only, not updates
- This architecture is intentional - CouchDB prioritizes ACID guarantees and conflict resolution via MVCC (Multi-Version Concurrency Control)

**Why This Cannot Be Solved:**
- The generic `UpdateQuery` interface expects to update multiple documents matching query criteria with partial field updates
- CouchDB's design requires fetching each document with its `_rev` before updating, which is exactly what the default implementation does
- There is no performance benefit to be gained as the read-before-write pattern is mandatory in CouchDB's architecture

**Recommendation:**
- CouchDB will continue using the default implementation (read-modify-write), which aligns with CouchDB's intended usage pattern
- This approach ensures proper conflict detection through revision checking
- For bulk operations, consider using CouchDB's native `_bulk_docs` API directly when appropriate

### Summary

**Completed Implementations: 5/7**
- ✅ MongoDB
- ✅ Cassandra  
- ✅ Couchbase
- ✅ Neo4j
- ✅ ArangoDB
- ❌ DynamoDB (cannot be implemented due to AWS SDK/PartiQL constraints)
- ❌ CouchDB (cannot be implemented due to lack of multi-update support)

All database drivers that support native partial update operations have been successfully optimized. The remaining two drivers (DynamoDB and CouchDB) have architectural limitations that prevent optimization at the communication layer level.

### Related Issue
Fixes https://github.com/eclipse-jnosql/jnosql/issues/638

---
_This PR addresses all feasible database driver optimizations. DynamoDB and CouchDB cannot be optimized due to architectural constraints detailed above._