### PR TITLE
Dynamodb and CouchDB enhancements

### DIFF
--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
@@ -272,6 +272,7 @@ class DefaultCouchDBDocumentManagerTest {
     @Test
     void shouldInsertNull() {
         var entity = getEntity();
+        entity.remove(CouchDBConstant.ID);
         entity.add(Element.of("name", null));
         var documentEntity = entityManager.insert(entity);
         Optional<Element> name = documentEntity.find("name");
@@ -283,7 +284,7 @@ class DefaultCouchDBDocumentManagerTest {
     }
 
     @Test
-    void shouldUpdateNull(){
+    void shouldUpdateNull() {
         var entity = entityManager.insert(getEntity());
         entity.add(Element.of("name", null));
         var documentEntity = entityManager.update(entity);
@@ -299,12 +300,12 @@ class DefaultCouchDBDocumentManagerTest {
     void shouldInsertByteArray() {
         CommunicationEntity entity = CommunicationEntity.of("Failure");
         entity.add(CouchDBConstant.ID, "id");
-        entity.add("data", new byte[]{'a','b','c','d'});
+        entity.add("data", new byte[]{'a', 'b', 'c', 'd'});
         var communication = entityManager.insert(entity);
 
         SoftAssertions.assertSoftly(soft -> {
-           soft.assertThat(communication).isNotNull();
-              soft.assertThat(communication.find("data").get().get()).isInstanceOf(byte[].class);
+            soft.assertThat(communication).isNotNull();
+            soft.assertThat(communication.find("data").get().get()).isInstanceOf(byte[].class);
         });
     }
 

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManager.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManager.java
@@ -174,7 +174,7 @@ public class DefaultDynamoDBDatabaseManager implements DynamoDBDatabaseManager {
 
     private String partitionKeyName(String table, String defaultName) {
         return this.settings
-                .get(DynamoDBConfigurations.ENTITY_PARTITION_KEY.name().formatted(table), String.class)
+                .get(DynamoDBConfigurations.ENTITY_PARTITION_KEY.get().formatted(table), String.class)
                 .orElse(defaultName);
     }
 
@@ -294,8 +294,12 @@ public class DefaultDynamoDBDatabaseManager implements DynamoDBDatabaseManager {
 
         if (!dynamoDBQuery.expressionAttributeNames().isEmpty()) {
             selectRequest = selectRequest
-                    .expressionAttributeNames(dynamoDBQuery.expressionAttributeNames())
-                    .expressionAttributeValues(dynamoDBQuery.expressionAttributeValues());
+                    .expressionAttributeNames(dynamoDBQuery.expressionAttributeNames());
+
+            if(!dynamoDBQuery.expressionAttributeValues().isEmpty()) {
+                selectRequest = selectRequest
+                        .expressionAttributeValues(dynamoDBQuery.expressionAttributeValues());
+            }
         }
 
         return StreamSupport

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerTest.java
@@ -244,7 +244,6 @@ class DefaultDynamoDBDatabaseManagerTest {
                 .getItem(GetItemRequest.builder()
                         .tableName(_entityType)
                         .key(Map.of(
-                                entityNameResolver.apply(_entityType), AttributeValue.builder().s(_entityType).build(),
                                 DynamoDBConverter.ID, AttributeValue.builder().s(id).build()
                         ))
                         .build())

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/integration/DynamoDBTemplateIntegrationTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/integration/DynamoDBTemplateIntegrationTest.java
@@ -52,6 +52,7 @@ class DynamoDBTemplateIntegrationTest {
 
     static {
         DynamoDBTestUtils.CONFIG.setupSystemProperties(Settings.builder()
+                .put(DynamoDBConfigurations.ENTITY_PARTITION_KEY.get().formatted(Magazine.class.getSimpleName()), "id")
                 .put(DynamoDBConfigurations.CREATE_TABLES, "true"));
     }
 


### PR DESCRIPTION
This pull request includes several improvements and fixes to the CouchDB and DynamoDB modules, focusing on test reliability, configuration handling, and query execution. The most significant changes involve correcting key handling in tests, improving the robustness of DynamoDB query construction, and updating configuration usage for partition keys.

**DynamoDB Improvements:**

* Improved the construction of DynamoDB scan requests by ensuring that `expressionAttributeValues` are only set when they are present, preventing potential issues with empty attribute values.
* Updated the retrieval of the partition key name to use the correct configuration accessor, improving consistency and maintainability in `DefaultDynamoDBDatabaseManager`.
* Added explicit configuration of the partition key for the `Magazine` entity in integration tests, ensuring correct test setup and reducing the likelihood of test failures due to misconfiguration.
* Fixed a test utility in `DefaultDynamoDBDatabaseManagerTest` by removing an unnecessary key entry, ensuring that only relevant keys are used when fetching items in tests.

**CouchDB Test Reliability:**

* Updated the `shouldInsertNull` test in `DefaultCouchDBDocumentManagerTest` to remove the `ID` field before insertion, ensuring the test accurately reflects intended entity state and avoids conflicts with existing IDs.