### PR TITLE
Include test on uuid

### DIFF
--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.6.2</monbodb.driver>
+        <monbodb.driver>5.6.4</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/CustomRepositoryIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/CustomRepositoryIntegrationTest.java
@@ -72,7 +72,7 @@ class CustomRepositoryIntegrationTest {
 
     @Inject
     @Database(DatabaseType.DOCUMENT)
-    MagazineCustomRepository magazineCustomRepository;
+    private MagazineCustomRepository magazineCustomRepository;
 
 
     @BeforeEach

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Machine.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Machine.java
@@ -7,10 +7,6 @@
  *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
  *
  *   You may elect to redistribute this code under either of these licenses.
- *
- *   Contributors:
- *
- *   Maximillian Arruda
  */
 package org.eclipse.jnosql.databases.mongodb.integration;
 

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Machine.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Machine.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.databases.mongodb.integration;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+import java.util.UUID;
+
+@Entity
+public record Machine (@Id UUID id, @Column String model, @Column int release) {
+}

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MachineRepository.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MachineRepository.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.mongodb.integration;
+
+
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface MachineRepository extends BasicRepository<Machine, UUID> {
+}

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
@@ -54,7 +54,7 @@ import static org.eclipse.jnosql.databases.mongodb.communication.DocumentDatabas
 @AddPackages(Converters.class)
 @AddExtensions({ReflectionEntityMetadataExtension.class,
         DocumentExtension.class})
-//@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class RepositoryIntegrationTest {
 
     static {

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
@@ -61,16 +61,18 @@ class RepositoryIntegrationTest {
 
     @Inject
     @Database(DatabaseType.DOCUMENT)
-    MagazineRepository repository;
+    private MagazineRepository repository;
 
 
     @Inject
     @Database(DatabaseType.DOCUMENT)
-    BookStore bookStore;
+    private BookStore bookStore;
 
     @Inject
     @Database(DatabaseType.DOCUMENT)
-    AsciiCharacters characters;
+    private AsciiCharacters characters;
+
+
 
     @Test
     void shouldSave() {

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.jnosql.databases.mongodb.integration;
 
 import jakarta.inject.Inject;
+import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.databases.mongodb.communication.MongoDBDocumentConfigurations;
 import org.eclipse.jnosql.databases.mongodb.mapping.MongoDBTemplate;
 import org.eclipse.jnosql.mapping.Database;
@@ -30,10 +31,13 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.util.List;
+import java.util.UUID;
 
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,7 +54,7 @@ import static org.eclipse.jnosql.databases.mongodb.communication.DocumentDatabas
 @AddPackages(Converters.class)
 @AddExtensions({ReflectionEntityMetadataExtension.class,
         DocumentExtension.class})
-@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+//@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class RepositoryIntegrationTest {
 
     static {
@@ -72,7 +76,8 @@ class RepositoryIntegrationTest {
     @Database(DatabaseType.DOCUMENT)
     private AsciiCharacters characters;
 
-
+    @Inject
+    private MachineRepository machineRepository;
 
     @Test
     void shouldSave() {
@@ -177,5 +182,36 @@ class RepositoryIntegrationTest {
                 .isNotNull()
                 .as("Should return the characters 'A', 'B', 'C', 'D', 'F', and 'O'")
                 .contains('A', 'B', 'C', 'D', 'F', 'O'));
+    }
+
+
+    @Nested
+    @DisplayName("When saving an entity with UUID as id")
+    class WhenSavingUUID {
+
+        @Test
+        @DisplayName("Then should save")
+        void shouldSave() {
+            UUID id = randomUUID();
+            Machine machine = machineRepository.save(new Machine(id, "Machine 1", 2019));
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(machine).isNotNull();
+                softly.assertThat(machine.id()).isNotNull();
+            });
+        }
+
+        @Test
+        @DisplayName("Then should find by id")
+        void shouldFindById() {
+            UUID id = randomUUID();
+            Machine machine = machineRepository.save(new Machine(id, "Machine 1", 2019));
+            Machine found = machineRepository.findById(id).orElseThrow();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(found).isNotNull();
+                softly.assertThat(found.id()).isNotNull();
+            });
+        }
+
     }
 }


### PR DESCRIPTION
This pull request introduces support for entities with UUID identifiers in the MongoDB integration tests and improves code encapsulation in repository fields. The key changes include adding a new entity and repository for `Machine` with a UUID id, extending integration tests to cover saving and retrieving entities with UUIDs, and updating field visibility for better encapsulation.

**Support for entities with UUID identifiers:**

* Added a new `Machine` entity (`Machine.java`) with a UUID id and corresponding `MachineRepository` interface for repository operations. [[1]](diffhunk://#diff-2c43b5697662eabbd92061997ad85da8db2febaf02cd227ee376125817ccd468R1-R21) [[2]](diffhunk://#diff-7f2aed069e5ed107dc289a78530d400d7548f7d4b516705d5a0e8b6a164ebd2eR1-R21)
* Enhanced `RepositoryIntegrationTest` to include tests for saving and retrieving entities with UUID ids, ensuring correct handling of UUIDs in repositories. [[1]](diffhunk://#diff-9a3a6a708e1249b08172abbe56905a447afd4292bb3a563677ff900e9e32d3e7L64-R80) [[2]](diffhunk://#diff-9a3a6a708e1249b08172abbe56905a447afd4292bb3a563677ff900e9e32d3e7R186-R216)

**Test code improvements:**

* Changed repository and test entity fields in `RepositoryIntegrationTest` and `CustomRepositoryIntegrationTest` from package-private to private for better encapsulation. [[1]](diffhunk://#diff-9a3a6a708e1249b08172abbe56905a447afd4292bb3a563677ff900e9e32d3e7L64-R80) [[2]](diffhunk://#diff-eb3ee2628c2e52b9d791e6c242fecfef57da0bbaf7c958129131bb227d441128L75-R75)
* Added missing imports in `RepositoryIntegrationTest` to support new tests and assertions. [[1]](diffhunk://#diff-9a3a6a708e1249b08172abbe56905a447afd4292bb3a563677ff900e9e32d3e7R19) [[2]](diffhunk://#diff-9a3a6a708e1249b08172abbe56905a447afd4292bb3a563677ff900e9e32d3e7R34-R40)

**Dependency update:**

* Updated the MongoDB driver version in `pom.xml` from 5.6.2 to 5.6.4 for improved compatibility and bug fixes.