### PR TITLE
chore: update database drivers version

### DIFF
--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.37.5</dynamodb.version>
+        <dynamodb.version>2.42.28</dynamodb.version>
     </properties>
 
     <dependencies>

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -27,7 +27,7 @@
     <description>The Eclipse JNoSQL layer implementation for Infinispan</description>
 
     <properties>
-        <infinispan.version>16.0.5</infinispan.version>
+        <infinispan.version>16.1.3</infinispan.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-oracle-nosql/pom.xml
+++ b/jnosql-oracle-nosql/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.oracle.nosql.sdk</groupId>
             <artifactId>nosqldriver</artifactId>
-            <version>5.4.18</version>
+            <version>5.4.20</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
-            <version>3.2.48</version>
+            <version>3.2.51</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>7.2.0</version>
+            <version>7.4.1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This pull request updates the dependency versions for several database modules to ensure compatibility with the latest features and bug fixes. The most important changes are version bumps for key database libraries across the project.

**Dependency version updates:**

* DynamoDB: Upgraded the `dynamodb.version` property from 2.37.5 to 2.42.28 in `jnosql-dynamodb/pom.xml`.
* Infinispan: Upgraded the `infinispan.version` property from 16.0.5 to 16.1.3 in `jnosql-infinispan/pom.xml`.
* Oracle NoSQL: Updated the `nosqldriver` dependency from version 5.4.18 to 5.4.20 in `jnosql-oracle-nosql/pom.xml`.
* OrientDB: Updated the `orientdb-graphdb` dependency from version 3.2.48 to 3.2.51 in `jnosql-orientdb/pom.xml`.
* Redis: Upgraded the `jedis` dependency from version 7.2.0 to 7.4.1 in `jnosql-redis/pom.xml`.