### PR TITLE
fix: handle mixed _id and negated nosql-tck queries

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -23,29 +23,37 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.eclipse.jnosql.databases.oracle.communication.TableCreationConfiguration.ID_FIELD;
 import static org.eclipse.jnosql.databases.oracle.communication.TableCreationConfiguration.JSON_FIELD;
 
 abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
 
     static final int ORIGIN = 0;
     private final String table;
+    private final String entityName;
 
-    AbstractQueryBuilder(String table) {
+    AbstractQueryBuilder(String table, String entityName) {
         this.table = table;
+        this.entityName = entityName;
     }
 
     protected void condition(CriteriaCondition condition, StringBuilder query, List<FieldValue> params, List<String> ids, boolean forCount) {
+        condition(condition, query, params, ids, forCount, true);
+    }
+
+    protected void condition(CriteriaCondition condition, StringBuilder query, List<FieldValue> params,
+                             List<String> ids, boolean forCount, boolean allowIdFastPath) {
         var document = condition.element();
         switch (condition.condition()) {
             case EQUALS:
-                if (!forCount && document.name().equals(DefaultOracleNoSQLDocumentManager.ID)) {
+                if (!forCount && allowIdFastPath && document.name().equals(DefaultOracleNoSQLDocumentManager.ID)) {
                     ids.add(document.get(String.class));
                 } else {
                     predicate(query, " = ", document, params);
                 }
                 return;
             case IN:
-                if (!forCount && document.name().equals(DefaultOracleNoSQLDocumentManager.ID)) {
+                if (!forCount && allowIdFastPath && document.name().equals(DefaultOracleNoSQLDocumentManager.ID)) {
                     ids.addAll(document.get(new TypeReference<List<String>>() {
                     }));
                 } else {
@@ -78,21 +86,41 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
                 return;
             case NOT:
                 query.append(" NOT ");
-                condition(document.get(CriteriaCondition.class), query, params, ids, forCount);
+                condition(document.get(CriteriaCondition.class), query, params, ids, forCount, allowIdFastPath);
                 return;
             case OR:
+                query.append("(");
                 appendCondition(query, params, document.get(new TypeReference<>() {
-                }), " OR ", ids, forCount);
+                }), " OR ", ids, forCount, allowIdFastPath);
+                query.append(")");
                 return;
             case AND:
+                query.append("(");
                 appendCondition(query, params, document.get(new TypeReference<>() {
-                }), " AND ", ids, forCount);
+                }), " AND ", ids, forCount, allowIdFastPath);
+                query.append(")");
                 return;
             case BETWEEN:
                 predicateBetween(query, params, document);
                 return;
             default:
                 throw new UnsupportedOperationException("There is not support condition for " + condition.condition());
+        }
+    }
+
+    protected boolean hasOnlyIdConditions(CriteriaCondition condition) {
+        var document = condition.element();
+        switch (condition.condition()) {
+            case EQUALS:
+            case IN:
+                return document.name().equals(DefaultOracleNoSQLDocumentManager.ID);
+            case OR:
+            case AND:
+                var conditions = document.get(new TypeReference<List<CriteriaCondition>>() {
+                });
+                return !conditions.isEmpty() && conditions.stream().allMatch(this::hasOnlyIdConditions);
+            default:
+                return false;
         }
     }
 
@@ -112,10 +140,16 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     protected void appendCondition(StringBuilder query, List<FieldValue> params,
                                  List<CriteriaCondition> conditions,
                                  String condition, List<String> ids, boolean forCount) {
+        appendCondition(query, params, conditions, condition, ids, forCount, true);
+    }
+
+    protected void appendCondition(StringBuilder query, List<FieldValue> params,
+                                 List<CriteriaCondition> conditions,
+                                 String condition, List<String> ids, boolean forCount, boolean allowIdFastPath) {
         int index = ORIGIN;
         for (CriteriaCondition documentCondition : conditions) {
             StringBuilder appendQuery = new StringBuilder();
-            condition(documentCondition, appendQuery, params, ids, forCount);
+            condition(documentCondition, appendQuery, params, ids, forCount, allowIdFastPath);
             if(index == ORIGIN && !appendQuery.isEmpty()){
                 query.append(appendQuery);
             } else if(!appendQuery.isEmpty()) {
@@ -133,7 +167,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
                            Element document,
                            List<FieldValue> params) {
         String name = identifierOf(document.name());
-        Object value = document.get();
+        Object value = sqlValueOf(document);
         FieldValue fieldValue = FieldValueConverter.of(value);
         if(fieldValue.isArray()){
             query.append(name).append(condition).append(" ?[] ");
@@ -175,7 +209,31 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     }
 
     protected String identifierOf(String name) {
+        if (DefaultOracleNoSQLDocumentManager.ID.equals(name)) {
+            return ' ' + table + "." + ID_FIELD + ' ';
+        }
         return ' ' + table + "." + JSON_FIELD + "." + name + ' ';
+    }
+
+    private Object sqlValueOf(Element document) {
+        if (!DefaultOracleNoSQLDocumentManager.ID.equals(document.name())) {
+            return document.get();
+        }
+
+        Object value = document.get();
+        if (value instanceof Iterable<?> iterable) {
+            List<String> ids = new ArrayList<>();
+            iterable.forEach(id -> ids.add(generateId(String.valueOf(id))));
+            return ids;
+        }
+        return generateId(String.valueOf(value));
+    }
+
+    private String generateId(String id) {
+        if (id.contains(":")) {
+            return id;
+        }
+        return entityName + ":" + id;
     }
 
     protected void entityCondition(StringBuilder query, String tableName) {

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeleteBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeleteBuilder.java
@@ -28,7 +28,7 @@ final class DeleteBuilder extends AbstractQueryBuilder {
     private final String table;
 
     DeleteBuilder(DeleteQuery documentQuery, String table) {
-        super(table);
+        super(table, documentQuery.name());
         this.documentQuery = documentQuery;
         this.table = table;
     }

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
@@ -29,7 +29,7 @@ final class SelectBuilder extends AbstractQueryBuilder {
     private final String table;
 
     SelectBuilder(SelectQuery documentQuery, String table) {
-        super(table);
+        super(table, documentQuery.name());
         this.documentQuery = documentQuery;
         this.table = table;
     }
@@ -46,7 +46,7 @@ final class SelectBuilder extends AbstractQueryBuilder {
         entityCondition(query, documentQuery.name());
         this.documentQuery.condition().ifPresent(c -> {
             query.append(" AND ");
-            condition(c, query, params, ids, false);
+            condition(c, query, params, ids, false, hasOnlyIdConditions(c));
         });
 
 

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectCountBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectCountBuilder.java
@@ -28,7 +28,7 @@ final class SelectCountBuilder extends AbstractQueryBuilder {
     private final String table;
 
     SelectCountBuilder(SelectQuery documentQuery, String table) {
-        super(table);
+        super(table, documentQuery.name());
         this.documentQuery = documentQuery;
         this.table = table;
     }

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
@@ -140,8 +140,21 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
-        assertThat(entities).contains(entity);
+        assertThat(entities).containsExactly(entity);
+    }
+
+    @Test
+    void shouldNotFindDocumentWhenMixedIdPredicateDoesNotMatch() {
+        var entity = entityManager.insert(getEntity());
+        Optional<Element> id = entity.find("_id");
+
+        var query = select().from(COLLECTION_NAME)
+                .where("_id").eq(id.orElseThrow().get())
+                .and("city").eq("Recife")
+                .build();
+
+        List<CommunicationEntity> entities = entityManager.select(query).toList();
+        assertThat(entities).isEmpty();
     }
 
     @Test

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
+
+class SelectBuilderTest {
+
+    @Test
+    void shouldUseIdFastPathForEqualsQuery() {
+        var query = select().from("person")
+                .where("_id").eq("id-1")
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.ids()).containsExactly("id-1");
+        assertThat(oracleQuery.params()).isEmpty();
+        assertThat(oracleQuery.query()).doesNotContain("content._id");
+    }
+
+    @Test
+    void shouldUseIdFastPathForInQuery() {
+        var query = select().from("person")
+                .where("_id").in(List.of("id-1", "id-2"))
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.ids()).containsExactly("id-1", "id-2");
+        assertThat(oracleQuery.params()).isEmpty();
+        assertThat(oracleQuery.query()).doesNotContain("content._id");
+    }
+
+    @Test
+    void shouldKeepMixedIdPredicateInSql() {
+        var query = select().from("person")
+                .where("_id").eq("id-1")
+                .and("scope").eq("admin")
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.ids()).isEmpty();
+        assertThat(oracleQuery.params()).hasSize(2);
+        assertThat(oracleQuery.params().get(0).asString().getValue()).isEqualTo("person:id-1");
+        assertThat(oracleQuery.params().get(1).asString().getValue()).isEqualTo("admin");
+        assertThat(oracleQuery.query())
+                .contains("people.id")
+                .contains("people.content.scope");
+    }
+
+    @Test
+    void shouldWrapCompositeOrConditionsToPreserveEntityFilter() {
+        var query = select().from("person")
+                .where("age").not().gt(42)
+                .or("name").not().eq("Ada")
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.query())
+                .contains("people.entity= 'person' AND (")
+                .contains(" OR ")
+                .endsWith(")");
+    }
+}


### PR DESCRIPTION
## Issues Encountered

 The first real TCK failure was:

- BasicTemplateInheritanceTest.shouldFind(Drink)[1]: non-unique result for inheritance + _id

Root cause: mixed _id predicates were being handled by two paths at once. The provider used the _id key fast path and also executed the remaining predicate tree as SQL, so the same logical row could be returned twice when _id was combined with inheritance-related filtering.

After forcing mixed _id predicates onto the SQL path, two follow-on issues surfaced:

- mixed _id SQL initially targeted content._id, but Oracle NoSQL stores the key in the top-level id column
- mixed _id SQL initially bound the raw logical id instead of the stored namespaced value (EntityName:id)

Once the inheritance issue was fixed, the remaining TCK failure was:

- SelectNegateTemplateTest.shouldInsertIterableAndSelectWithNegatedComplexQueryOr(List)[1]
    - observed failure: ClassCastException: Fruit cannot be cast to Person

Root cause: composite AND/OR query fragments were not grouped, so SQL operator precedence could let rows from the wrong entity type satisfy part of the predicate. In practice, the entity='Person' filter did not bind tightly enough across a negated OR, and a non-Person row could leak through.

During investigation there was also a transient regression where the negate suite failed during cleanup, not query execution:

- SelectNegateTemplateTest.*
    - failing in AbstractTemplateTest.setUp
    - Invalid partition id in continuation key: 1 (5.4.18)

That turned out to be investigation noise while validating rebuilt artifacts, not the final provider behavior. With the final branch contents, that regression is gone.

##  Fix Rationale

The fix has three parts:

- _id fast path is now allowed only when the entire condition tree is _id-only.
    - Pure _id lookups still use direct key access.
    - Mixed _id queries stay entirely on the SQL path.
    - This removes duplicate retrieval and fixes BasicTemplateInheritanceTest.shouldFind(Drink)[1].
- SQL _id handling now matches Oracle NoSQL storage semantics.
    - _id maps to the top-level id column, not content._id.
    - _id values are bound as stored namespaced ids (EntityName:id), not raw ids.
    - This makes mixed _id predicates both valid and accurate.
- Composite AND / OR conditions are wrapped in parentheses.
    - This preserves the intended criteria-tree semantics.
    - It keeps the entity discriminator from being weakened by SQL precedence.
    - That fixes the negated complex OR case behind SelectNegateTemplateTest.shouldInsertIterableAndSelectWithNegatedComplexQueryOr(List)[1].

## Review Focus

Reviewers should verify these invariants:

- pure _id queries still use key lookup
- mixed _id queries do not combine key lookup with SQL
- SQL _id predicates target id
- SQL _id bindings use namespaced ids
- composite AND / OR groups are parenthesized so entity filtering cannot leak across OR

## Validation

Final validation on the branch:

- BasicTemplateInheritanceTest: pass
- SelectNegateTemplateTest: pass
- full nosql-tck: 112 tests, 0 failures, 0 errors
