### PR TITLE
fix: escape Oracle NoSQL regex literals

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverter.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverter.java
@@ -30,7 +30,7 @@ enum OracleNoSqlLikeConverter {
      *   "%Lu"   -> ".*Lu"
      *   "%Lu%"  -> ".*Lu.*"
      *   "Lu"    -> "Lu"        // exact match equivalent in regex_like
-     *   "a.c"   -> "a\\.c"     // '.' escaped
+     *   "a.c"   -> "a\\.c"     // '.' escaped for the Oracle NoSQL SQL literal and regex parser
      */
     String convert(Object value) {
         if (value == null) return ""; // let caller decide behavior for empty
@@ -43,8 +43,7 @@ enum OracleNoSqlLikeConverter {
                 case '%': out.append(".*"); break; // zero or more
                 case '_': out.append('.');  break; // exactly one
                 default:
-                    if (META.contains(c)) out.append('\\');
-                    out.append(c);
+                    appendEscaped(out, c);
             }
         }
         return out.toString();
@@ -69,9 +68,15 @@ enum OracleNoSqlLikeConverter {
     private String escape(String s) {
         StringBuilder out = new StringBuilder(s.length());
         for (char c : s.toCharArray()) {
-            if (META.contains(c)) out.append('\\');
-            out.append(c);
+            appendEscaped(out, c);
         }
         return out.toString();
+    }
+
+    private void appendEscaped(StringBuilder out, char c) {
+        if (META.contains(c)) {
+            out.append("\\\\");
+        }
+        out.append(c);
     }
 }

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverterTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -50,7 +51,7 @@ class OracleNoSqlLikeConverterTest {
                 arguments("_ta", ".ta"),
 
                 // escaping of regex metacharacters
-                arguments("%a.c%", ".*a\\.c.*"),
+                arguments("%a.c%", ".*a\\\\.c.*"),
                 arguments("100% match", "100.* match"),
 
                 // edge cases
@@ -83,9 +84,9 @@ class OracleNoSqlLikeConverterTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> containsCases() {
         return Stream.of(
                 arguments("Lu", ".*Lu.*"),
-                arguments("a.c", ".*a\\.c.*"),
-                arguments("price$", ".*price\\$.*"),
-                arguments("(hello)", ".*\\(hello\\).*"),
+                arguments("a.c", ".*a\\\\.c.*"),
+                arguments("price$", ".*price\\\\$.*"),
+                arguments("(hello)", ".*\\\\(hello\\\\).*"),
                 arguments("", ".*.*")
         );
     }
@@ -101,9 +102,9 @@ class OracleNoSqlLikeConverterTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> startsWithCases() {
         return Stream.of(
                 arguments("Lu", "Lu.*"),
-                arguments("a.c", "a\\.c.*"),
-                arguments("price$", "price\\$.*"),
-                arguments("(hello)", "\\(hello\\).*"),
+                arguments("a.c", "a\\\\.c.*"),
+                arguments("price$", "price\\\\$.*"),
+                arguments("(hello)", "\\\\(hello\\\\).*"),
                 arguments("", ".*")
         );
     }
@@ -120,9 +121,9 @@ class OracleNoSqlLikeConverterTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> endsWithCases() {
         return Stream.of(
                 arguments("Lu", ".*Lu"),
-                arguments("a.c", ".*a\\.c"),
-                arguments("price$", ".*price\\$"),
-                arguments("(hello)", ".*\\(hello\\)"),
+                arguments("a.c", ".*a\\\\.c"),
+                arguments("price$", ".*price\\\\$"),
+                arguments("(hello)", ".*\\\\(hello\\\\)"),
                 arguments("", ".*")
         );
     }
@@ -131,8 +132,9 @@ class OracleNoSqlLikeConverterTest {
     @DisplayName("All regex metacharacters are escaped in contains/startsWith/endsWith")
     void escapesAllMetaCharacters() {
         String term = ".^$*+?()[]{}\\|";
-        // Expected escaped chunk: \.\^\$\*\+\?\(\)\[\]\{\}\\\|
-        String escaped = "\\.\\^\\$\\*\\+\\?\\(\\)\\[\\]\\{\\}\\\\\\|";
+        String escaped = Stream.of(".", "^", "$", "*", "+", "?", "(", ")", "[", "]", "{", "}", "\\", "|")
+                .map(c -> "\\\\" + c)
+                .collect(joining());
 
         assertThat(OracleNoSqlLikeConverter.INSTANCE.contains(term))
                 .isEqualTo(".*" + escaped + ".*");


### PR DESCRIPTION
## Summary

Fix Oracle NoSQL `regex_like` query generation for LIKE-style predicates when the search value contains regex metacharacters.

Oracle NoSQL SQL string literals require regex escape backslashes to be escaped as well. Previously values such as `a.c` generated `a\.c`, which Oracle NoSQL rejects with:

```text
PREPARE: Illegal Argument: Error: Illegal escape sequence: '\.'
```

This change emits doubled backslashes, e.g. a\\.c, so the SQL literal is accepted and the regex engine receives the intended escaped metacharacter.

## Changes

- Escape regex metacharacters with doubled backslashes for Oracle NoSQL SQL string literals.
- Apply the same escaping behavior to LIKE, contains, startsWith, and endsWith conversion helpers.
- Update OracleNoSqlLikeConverterTest expectations to cover SQL-literal-safe escaping.

## Validation

mvn -pl jnosql-oracle-nosql -Dtest=OracleNoSqlLikeConverterTest test

Result: 29 tests passed, 0 failures.

