### PR TITLE
Update NoSQL Drivers

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,18 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Update N1QL queries for Magazine class
 - Add update query tests for ArangoDB, Neo4J, Couchbase, Cassandra, and MongoDB
 - Update jakarta data engine
+- Upgraded ArangoDB Java driver to 7.26.0
+- Upgraded Couchbase Java client to 3.11.3
+- Upgraded DynamoDB SDK to 2.44.11
+- Upgraded Hazelcast client to 5.7.0
+- Upgraded Infinispan client to 16.1.4
+- Upgraded MongoDB Java driver to 5.7.0
+- Upgraded Neo4j Java driver to 6.1.0
+- Upgraded Oracle NoSQL SDK to 5.4.21
+- Upgraded OrientDB graphdb to 3.2.52
+- Upgraded Jedis (Redis client) to 7.5.0
+- Upgraded Apache Tinkerpop to 3.8.1
+- Upgraded Apache HttpClient5 Cache to 5.6.1
 
 == [1.1.13] - 2026-04-06
 

--- a/jnosql-arangodb/pom.xml
+++ b/jnosql-arangodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to ArangoDB</description>
 
     <properties>
-        <arango.driver>7.25.0</arango.driver>
+        <arango.driver>7.26.0</arango.driver>
     </properties>
 
     <dependencies>

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -30,8 +30,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jnosql.mapping</groupId>

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.11.1</version>
+            <version>3.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -57,8 +57,5 @@
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-
-
 </project>

--- a/jnosql-couchdb/pom.xml
+++ b/jnosql-couchdb/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5-cache</artifactId>
-            <version>5.6</version>
+            <version>5.6.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.42.28</dynamodb.version>
+        <dynamodb.version>2.44.11</dynamodb.version>
 
     </properties>
 

--- a/jnosql-hazelcast/pom.xml
+++ b/jnosql-hazelcast/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>5.6.0</version>
+            <version>5.7.0</version>
         </dependency>
     </dependencies>
 

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -27,7 +27,7 @@
     <description>The Eclipse JNoSQL layer implementation for Infinispan</description>
 
     <properties>
-        <infinispan.version>16.1.3</infinispan.version>
+        <infinispan.version>16.1.4</infinispan.version>
     </properties>
 
     <dependencies>

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.6.4</monbodb.driver>
+        <monbodb.driver>5.7.0</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -27,7 +27,7 @@
     <name>JNoSQL Neo4J Driver</name>
 
     <properties>
-        <neo4j.driver>6.0.3</neo4j.driver>
+        <neo4j.driver>6.1.0</neo4j.driver>
     </properties>
 
     <dependencies>

--- a/jnosql-oracle-nosql/pom.xml
+++ b/jnosql-oracle-nosql/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.oracle.nosql.sdk</groupId>
             <artifactId>nosqldriver</artifactId>
-            <version>5.4.20</version>
+            <version>5.4.21</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
-            <version>3.2.51</version>
+            <version>3.2.52</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>7.4.1</version>
+            <version>7.5.0</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-solr/pom.xml
+++ b/jnosql-solr/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>10.0.0</version>
+            <version>9.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/jnosql-solr/pom.xml
+++ b/jnosql-solr/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-solrj</artifactId>
-            <version>9.10.1</version>
+            <version>10.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/jnosql-tinkerpop/pom.xml
+++ b/jnosql-tinkerpop/pom.xml
@@ -27,7 +27,7 @@
     <name>JNoSQL Apache Tinkerpop Driver</name>
 
     <properties>
-        <tinkerpop.version>3.8.0</tinkerpop.version>
+        <tinkerpop.version>3.8.1</tinkerpop.version>
         <neo4j.connector.version>0.9-3.4.0</neo4j.connector.version>
         <antlr4.version>4.9.1</antlr4.version>
         <!-- it's required by the 'org.neo4j' libraries  -->

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </scm>
 
     <properties>
-        <testcontainers.version>2.0.4</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <jnosql.test.integration>false</jnosql.test.integration>
         <pmd.url>https://raw.githubusercontent.com/eclipse/jnosql-databases/refs/heads/main/pmd/pmd-rules.xml</pmd.url>
     </properties>


### PR DESCRIPTION
This pull request updates several dependencies across multiple JNoSQL modules to their latest patch or minor versions. The main goal is to keep the project up-to-date with the latest improvements and bug fixes from upstream libraries.

Dependency version updates by module:

**Core and Shared Dependencies**
- Updated the `testcontainers.version` property in the root `pom.xml` from `2.0.4` to `2.0.5`.

**Driver and Client Library Updates**
- Upgraded ArangoDB Java driver to `7.26.0` in `jnosql-arangodb/pom.xml`.
- Upgraded Couchbase Java client to `3.11.3` in `jnosql-couchbase/pom.xml`.
- Upgraded DynamoDB SDK to `2.44.11` in `jnosql-dynamodb/pom.xml`.
- Upgraded Hazelcast client to `5.7.0` in `jnosql-hazelcast/pom.xml`.
- Upgraded Infinispan client to `16.1.4` in `jnosql-infinispan/pom.xml`.
- Upgraded MongoDB Java driver to `5.7.0` in `jnosql-mongodb/pom.xml`.
- Upgraded Neo4j Java driver to `6.1.0` in `jnosql-neo4j/pom.xml`.
- Upgraded Oracle NoSQL SDK to `5.4.21` in `jnosql-oracle-nosql/pom.xml`.
- Upgraded OrientDB graphdb to `3.2.52` in `jnosql-orientdb/pom.xml`.
- Upgraded Jedis (Redis client) to `7.5.0` in `jnosql-redis/pom.xml`.
- Upgraded Apache Tinkerpop to `3.8.1` in `jnosql-tinkerpop/pom.xml`.
- Upgraded Apache HttpClient5 Cache to `5.6.1` in `jnosql-couchdb/pom.xml`.

**Other Minor Cleanups**
- Minor XML formatting cleanups in `jnosql-couchbase/pom.xml`.

These updates help ensure compatibility, security, and access to the latest features and bug fixes from the underlying libraries.