### PR TITLE
Update enhance code

### DIFF
--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBUtil.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBUtil.java
@@ -32,7 +32,13 @@ import org.eclipse.jnosql.communication.ValueUtil;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.Element;
 
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -50,9 +56,7 @@ public final class ArangoDBUtil {
     public static final String REV = "_rev";
     public static final String FROM = "_from";
     public static final String TO = "_to";
-    private static final Set<String> META_FIELDS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            ID, KEY, REV, FROM, TO
-    )));
+    private static final Set<String> META_FIELDS =Set.of(ID, KEY, REV, FROM, TO);
 
     private static final Logger LOGGER = Logger.getLogger(ArangoDBUtil.class.getName());
 

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
@@ -128,7 +128,7 @@ public class ArangoDBDocumentManagerTest {
         SelectQuery query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
-        CommunicationEntity documentEntity = entities.get(0);
+        CommunicationEntity documentEntity = entities.getFirst();
         assertEquals(entity.find(KEY_NAME).get().value().get(String.class), documentEntity.find(KEY_NAME).get()
                 .value().get(String.class));
         assertEquals(entity.find("name").get(), documentEntity.find("name").get());
@@ -143,7 +143,7 @@ public class ArangoDBDocumentManagerTest {
         CommunicationEntity entitySaved = entityManager.insert(entity);
         Element id = entitySaved.find(KEY_NAME).get();
         SelectQuery query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
-        CommunicationEntity entityFound = entityManager.select(query).toList().get(0);
+        CommunicationEntity entityFound = entityManager.select(query).toList().getFirst();
         Element subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -157,7 +157,7 @@ public class ArangoDBDocumentManagerTest {
         CommunicationEntity entitySaved = entityManager.insert(entity);
         Element id = entitySaved.find(KEY_NAME).get();
         SelectQuery query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
-        CommunicationEntity entityFound = entityManager.select(query).toList().get(0);
+        CommunicationEntity entityFound = entityManager.select(query).toList().getFirst();
         Element subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -477,7 +477,7 @@ public class ArangoDBDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -492,7 +492,7 @@ public class ArangoDBDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -507,7 +507,7 @@ public class ArangoDBDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
@@ -200,7 +200,7 @@ public class QueryAQLConverterTest {
             softly.assertThat(values.get("id")).isEqualTo(1);
             softly.assertThat(values.get("name")).isEqualTo("John");
             softly.assertThat(values.get("surname")).isEqualTo("Doe");
-            softly.assertThat(aql.replaceAll("  "," "))
+            softly.assertThat(aql.replace("  "," "))
                     .isEqualTo(
                             "FOR c IN collection FILTER c.id == @id " +
                                     "UPDATE c WITH { name: @name, surname: @surname } IN collection " +

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBEnumIntegrationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBEnumIntegrationTest.java
@@ -83,7 +83,7 @@ public class ArangoDBEnumIntegrationTest {
 
         SoftAssertions.assertSoftly(soft -> {
             Predicate<MailTemplate> isTimer = m -> m.getCategory().equals(MailCategory.TIMER);
-            Predicate<MailTemplate> isTrue = m -> m.isDefault();
+            Predicate<MailTemplate> isTrue = MailTemplate::isDefault;
             soft.assertThat(result).allMatch(isTimer.and(isTrue));
         });
     }
@@ -133,7 +133,7 @@ public class ArangoDBEnumIntegrationTest {
 
         SoftAssertions.assertSoftly(soft -> {
             Predicate<MailTemplate> isTimer = m -> m.getCategory().equals(MailCategory.TIMER);
-            Predicate<MailTemplate> isTrue = m -> m.isDefault();
+            Predicate<MailTemplate> isTrue = MailTemplate::isDefault;
             soft.assertThat(categoryAndIsDefaultTrue).hasSize(1).allMatch(
                     isTimer.and(isTrue));
         });

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/TemplateIntegrationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/TemplateIntegrationTest.java
@@ -144,11 +144,11 @@ class TemplateIntegrationTest {
             soft.assertThat(result.componentConfigurationKey()).isEqualTo("componentConfigurationKey");
             soft.assertThat(result.relationTypeKey()).isEqualTo("relationTypeKey");
             soft.assertThat(result.availableTransitions()).hasSize(1);
-            soft.assertThat(result.availableTransitions().get(0).targetWorkflowStepKey()).isEqualTo("TEST_WORKFLOW_STEP_KEY");
-            soft.assertThat(result.availableTransitions().get(0).stepTransitionReason()).isEqualTo(REPEAT);
-            soft.assertThat(result.availableTransitions().get(0).mailTemplateKey()).isNull();
-            soft.assertThat(result.availableTransitions().get(0).restrictedRoleGroups()).hasSize(1);
-            soft.assertThat(result.availableTransitions().get(0).restrictedRoleGroups().get(0)).isEqualTo("ADMIN");
+            soft.assertThat(result.availableTransitions().getFirst().targetWorkflowStepKey()).isEqualTo("TEST_WORKFLOW_STEP_KEY");
+            soft.assertThat(result.availableTransitions().getFirst().stepTransitionReason()).isEqualTo(REPEAT);
+            soft.assertThat(result.availableTransitions().getFirst().mailTemplateKey()).isNull();
+            soft.assertThat(result.availableTransitions().getFirst().restrictedRoleGroups()).hasSize(1);
+            soft.assertThat(result.availableTransitions().getFirst().restrictedRoleGroups().getFirst()).isEqualTo("ADMIN");
         });
     }
 

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerTest.java
@@ -201,7 +201,7 @@ public class CassandraColumnManagerTest {
             }
         }
 
-        var entityToUpdate = entities.get(0);
+        var entityToUpdate = entities.getFirst();
         var idField = entityToUpdate.find("id").orElseThrow();
 
         entityManager.update(
@@ -290,7 +290,7 @@ public class CassandraColumnManagerTest {
         var query = select().from(Constants.COLUMN_FAMILY).where("id").eq(10L).build();
         List<CommunicationEntity> columnEntity = entityManager.select(query).toList();
         assertFalse(columnEntity.isEmpty());
-        List<Element> columns = columnEntity.get(0).elements();
+        List<Element> columns = columnEntity.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList()))
                 .contains("name", "version", "options", "id");
         assertThat(columns.stream().map(Element::value).map(Value::get).collect(toList())).contains
@@ -305,7 +305,7 @@ public class CassandraColumnManagerTest {
         var query = select().from(Constants.COLUMN_FAMILY).where("id").eq(10L).build();
         List<CommunicationEntity> columnEntity = entityManager.select(query, CONSISTENCY_LEVEL).toList();
         assertFalse(columnEntity.isEmpty());
-        List<Element> columns = columnEntity.get(0).elements();
+        List<Element> columns = columnEntity.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList())).contains("name", "version", "options", "id");
         assertThat(columns.stream().map(Element::value).map(Value::get).collect(toList()))
                 .contains("Cassandra", 3.2, asList(1, 2, 3), 10L);
@@ -318,7 +318,7 @@ public class CassandraColumnManagerTest {
         List<CommunicationEntity> entities = entityManager.cql("select * from newKeySpace.newColumnFamily where id=10;")
                 .toList();
         assertFalse(entities.isEmpty());
-        List<Element> columns = entities.get(0).elements();
+        List<Element> columns = entities.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList())).contains("name", "version", "options", "id");
         assertThat(columns.stream().map(Element::value).map(Value::get).collect(toList()))
                 .contains("Cassandra", 3.2, asList(1, 2, 3), 10L);
@@ -330,7 +330,7 @@ public class CassandraColumnManagerTest {
         String query = "select * from newKeySpace.newColumnFamily where id = :id;";
         List<CommunicationEntity> entities = entityManager.cql(query, singletonMap("id", 10L)).toList();
         assertFalse(entities.isEmpty());
-        List<Element> columns = entities.get(0).elements();
+        List<Element> columns = entities.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList()))
                 .contains("name", "version", "options", "id");
         assertThat(columns.stream().map(Element::value).map(Value::get).collect(toList()))
@@ -343,7 +343,7 @@ public class CassandraColumnManagerTest {
         CassandraPreparedStatement preparedStatement = entityManager.nativeQueryPrepare("select * from newKeySpace.newColumnFamily where id=?");
         preparedStatement.bind(10L);
         List<CommunicationEntity> entities = preparedStatement.executeQuery().toList();
-        List<Element> columns = entities.get(0).elements();
+        List<Element> columns = entities.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList()))
                 .contains("name", "version", "options", "id");
         assertThat(columns.stream().map(Element::value).map(Value::get)

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
@@ -196,7 +196,7 @@ public class CouchbaseDocumentManagerTest {
         CommunicationEntity entitySaved = entityManager.insert(entity);
         Element id = entitySaved.find("_id").get();
         SelectQuery query = select().from(COLLECTION_PERSON_NAME).where(id.name()).eq(id.get()).build();
-        CommunicationEntity entityFound = entityManager.select(query).toList().get(0);
+        CommunicationEntity entityFound = entityManager.select(query).toList().getFirst();
         Element subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -211,7 +211,7 @@ public class CouchbaseDocumentManagerTest {
         Thread.sleep(1_00L);
         Element id = entitySaved.find("_id").get();
         var query = select().from(COLLECTION_PERSON_NAME).where(id.name()).eq(id.get()).build();
-        CommunicationEntity entityFound = entityManager.select(query).toList().get(0);
+        CommunicationEntity entityFound = entityManager.select(query).toList().getFirst();
         Element subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -388,7 +388,7 @@ public class CouchbaseDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -407,7 +407,7 @@ public class CouchbaseDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -427,7 +427,7 @@ public class CouchbaseDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseDocumentRepositoryIntegrationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseDocumentRepositoryIntegrationTest.java
@@ -126,7 +126,7 @@ class CouchbaseDocumentRepositoryIntegrationTest {
         assertSoftly(softly -> {
             softly.assertThat(data).as("query result is a non-null instance").isNotNull();
             softly.assertThat(data.size()).as("query result size is correct").isEqualTo(1);
-            softly.assertThat(data.get(0)).as("returned data is correct").isEqualTo(magazine);
+            softly.assertThat(data.getFirst()).as("returned data is correct").isEqualTo(magazine);
         });
     }
 
@@ -144,7 +144,7 @@ class CouchbaseDocumentRepositoryIntegrationTest {
         assertSoftly(softly -> {
             softly.assertThat(booksFoundByEditionLessThan).as("query result from findByEditionLessThan() is a non-null instance").isNotNull();
             softly.assertThat(booksFoundByEditionLessThan.size()).as("query result size from findByEditionLessThan() is correct").isEqualTo(1);
-            softly.assertThat(booksFoundByEditionLessThan.get(0)).as("returned books from findByEditionLessThan() are correct").isEqualTo(magazine);
+            softly.assertThat(booksFoundByEditionLessThan.getFirst()).as("returned books from findByEditionLessThan() are correct").isEqualTo(magazine);
         });
 
         var booksFoundByEditionLessThanZero = library.findByEditionLessThan(0).toList();
@@ -159,7 +159,7 @@ class CouchbaseDocumentRepositoryIntegrationTest {
         assertSoftly(softly -> {
             softly.assertThat(booksFoundByEditionGreaterThan).as("query result from findByEditionGreaterThan() is a non-null instance").isNotNull();
             softly.assertThat(booksFoundByEditionGreaterThan.size()).as("query result size from findByEditionGreaterThan() is correct").isEqualTo(1);
-            softly.assertThat(booksFoundByEditionGreaterThan.get(0)).as("returned books from findByEditionGreaterThan() are correct").isEqualTo(magazine);
+            softly.assertThat(booksFoundByEditionGreaterThan.getFirst()).as("returned books from findByEditionGreaterThan() are correct").isEqualTo(magazine);
         });
 
 
@@ -185,7 +185,7 @@ class CouchbaseDocumentRepositoryIntegrationTest {
         assertSoftly(softly -> {
             softly.assertThat(booksFoundByEditionGreaterThanZero).as("query result from findByEditionGreaterThan() is a non-null instance").isNotNull();
             softly.assertThat(booksFoundByEditionGreaterThanZero.size()).as("query result size from findByEditionGreaterThan() is correct").isEqualTo(1);
-            softly.assertThat(booksFoundByEditionGreaterThanZero.get(0)).as("returned books from findByEditionGreaterThan() are correct").isEqualTo(magazine);
+            softly.assertThat(booksFoundByEditionGreaterThanZero.getFirst()).as("returned books from findByEditionGreaterThan() are correct").isEqualTo(magazine);
         });
 
 

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseTemplateIntegrationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseTemplateIntegrationTest.java
@@ -122,7 +122,7 @@ class CouchbaseTemplateIntegrationTest {
         assertSoftly(softly -> {
             softly.assertThat(data).as("query result is a non-null instance").isNotNull();
             softly.assertThat(data.size()).as("query result size is correct").isEqualTo(1);
-            softly.assertThat(data.get(0)).as("returned data is correct").isEqualTo(magazine);
+            softly.assertThat(data.getFirst()).as("returned data is correct").isEqualTo(magazine);
         });
     }
 
@@ -137,7 +137,7 @@ class CouchbaseTemplateIntegrationTest {
         assertSoftly(softly -> {
             softly.assertThat(data).as("query result is a non-null instance").isNotNull();
             softly.assertThat(data.size()).as("query result size is correct").isEqualTo(1);
-            softly.assertThat(data.get(0)).as("returned data is correct").isEqualTo(magazine);
+            softly.assertThat(data.getFirst()).as("returned data is correct").isEqualTo(magazine);
         });
     }
 

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
@@ -226,7 +226,7 @@ class DefaultCouchDBDocumentManagerTest {
                 .where("_id").eq(id.get())
                 .build();
 
-        var entityFound = entityManager.select(query).toList().get(0);
+        var entityFound = entityManager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -244,7 +244,7 @@ class DefaultCouchDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where(id.name()).eq(id.get())
                 .build();
-        var entityFound = entityManager.select(query).toList().get(0);
+        var entityFound = entityManager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConverter.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConverter.java
@@ -115,33 +115,42 @@ class DynamoDBConverter {
     }
 
     public static AttributeValue toAttributeValue(Object value) {
-        if (value == null)
-            return AttributeValue.builder().nul(true).build();
-        if (value instanceof String str)
-            return AttributeValue.builder().s(str).build();
-        if (value instanceof Number number)
-            return AttributeValue.builder().n(String.valueOf(number)).build();
-        if (value instanceof Boolean bool)
-            return AttributeValue.builder().bool(bool).build();
-        if (value instanceof List<?> list)
-            return AttributeValue.builder().l(list.stream().filter(Objects::nonNull)
-                    .map(DynamoDBConverter::toAttributeValue).toList()).build();
-        if (value instanceof Map<?, ?> mapValue) {
-            HashMap<String, AttributeValue> values = new HashMap<>();
-            mapValue.forEach((k, v) -> values.put(String.valueOf(k), toAttributeValue(v)));
-            return AttributeValue.builder().m(values).build();
-        }
-        if (value instanceof byte[] data) {
-            return AttributeValue.builder().b(SdkBytes.fromByteArray(data)).build();
-        }
-        if (value instanceof ByteBuffer byteBuffer) {
-            return AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build();
-        }
-        if (value instanceof InputStream input) {
-            return AttributeValue.builder().b(SdkBytes.fromInputStream(input)).build();
-        }
-        if (value instanceof Element element) {
-            return toAttributeValue(getMap(element));
+        switch (value) {
+            case null -> {
+                return AttributeValue.builder().nul(true).build();
+            }
+            case String str -> {
+                return AttributeValue.builder().s(str).build();
+            }
+            case Number number -> {
+                return AttributeValue.builder().n(String.valueOf(number)).build();
+            }
+            case Boolean bool -> {
+                return AttributeValue.builder().bool(bool).build();
+            }
+            case List<?> list -> {
+                return AttributeValue.builder().l(list.stream().filter(Objects::nonNull)
+                        .map(DynamoDBConverter::toAttributeValue).toList()).build();
+            }
+            case Map<?, ?> mapValue -> {
+                HashMap<String, AttributeValue> values = new HashMap<>();
+                mapValue.forEach((k, v) -> values.put(String.valueOf(k), toAttributeValue(v)));
+                return AttributeValue.builder().m(values).build();
+            }
+            case byte[] data -> {
+                return AttributeValue.builder().b(SdkBytes.fromByteArray(data)).build();
+            }
+            case ByteBuffer byteBuffer -> {
+                return AttributeValue.builder().b(SdkBytes.fromByteBuffer(byteBuffer)).build();
+            }
+            case InputStream input -> {
+                return AttributeValue.builder().b(SdkBytes.fromInputStream(input)).build();
+            }
+            case Element element -> {
+                return toAttributeValue(getMap(element));
+            }
+            default -> {
+            }
         }
         return AttributeValue.builder().s(String.valueOf(value)).build();
     }

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQueryBuilder.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQueryBuilder.java
@@ -149,7 +149,7 @@ abstract class DynamoDBQueryBuilder implements Supplier<DynamoDBQuery> {
         filterExpression.append(attributeName).append(" BETWEEN ");
 
         var fistAttributeValueName = ":" + name + "_" + expressionAttributeValues.size();
-        expressionAttributeValues.put(fistAttributeValueName, toAttributeValue(values.get(0)));
+        expressionAttributeValues.put(fistAttributeValueName, toAttributeValue(values.getFirst()));
         filterExpression.append(fistAttributeValueName).append(" AND ");
 
         var secondAttributeValueName = ":" + name + "_" + expressionAttributeValues.size();

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQuerySelectBuilder.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQuerySelectBuilder.java
@@ -42,12 +42,10 @@ class DynamoDBQuerySelectBuilder extends DynamoDBQueryBuilder {
         var expressionAttributeNames = new HashMap<String, String>();
         var expressionAttributeValues = new HashMap<String, AttributeValue>();
 
-        this.selectQuery.condition().ifPresent(c -> {
-            super.condition(c,
-                    filterExpression,
-                    expressionAttributeNames,
-                    expressionAttributeValues);
-        });
+        this.selectQuery.condition().ifPresent(c -> super.condition(c,
+                filterExpression,
+                expressionAttributeNames,
+                expressionAttributeValues));
 
         return new DynamoDBQuery(
                 table,

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryProxyTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryProxyTest.java
@@ -15,7 +15,6 @@
 
 package org.eclipse.jnosql.databases.dynamodb.mapping;
 
-import ee.jakarta.tck.nosql.entities.Person;
 import jakarta.data.repository.Param;
 import jakarta.inject.Inject;
 import org.assertj.core.api.Assertions;

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/BigProjects.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/BigProjects.java
@@ -17,9 +17,6 @@ package org.eclipse.jnosql.databases.dynamodb.mapping.inheritance;
 import jakarta.data.repository.*;
 import org.eclipse.jnosql.mapping.NoSQLRepository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface BigProjects extends NoSQLRepository<BigProject, String> {
 

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/InheritanceWithDifferentRepositoriesTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/InheritanceWithDifferentRepositoriesTest.java
@@ -34,7 +34,6 @@ import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerTest.java
@@ -368,7 +368,7 @@ public class ElasticsearchDocumentManagerTest {
 
         var entityFound = entityManager.select(query)
                 .toList()
-                .get(0);
+                .getFirst();
 
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/ListTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/ListTest.java
@@ -60,7 +60,7 @@ public class ListTest {
         assertTrue(fruits.isEmpty());
         fruits.add(banana);
         assertFalse(fruits.isEmpty());
-        ProductCart banana = fruits.get(0);
+        ProductCart banana = fruits.getFirst();
         assertNotNull(banana);
         assertEquals(banana.name(), "banana");
     }
@@ -69,7 +69,7 @@ public class ListTest {
     public void shouldSetList() {
 
         fruits.add(banana);
-        fruits.add(0, orange);
+        fruits.addFirst(orange);
         assertEquals(2, fruits.size());
 
         assertEquals(fruits.get(0).name(), "orange");
@@ -124,8 +124,8 @@ public class ListTest {
             count++;
         }
         assertEquals(2, count);
-        fruits.remove(0);
-        fruits.remove(0);
+        fruits.removeFirst();
+        fruits.removeFirst();
         count = 0;
         for (ProductCart fruiCart: fruits) {
             count++;

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
@@ -54,7 +54,7 @@ public class MapTest {
         vertebrates.put("mammals", mammals);
         Species species = vertebrates.get("mammals");
         assertNotNull(species);
-        assertEquals(species.getAnimals().get(0), mammals.getAnimals().get(0));
+        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
         assertEquals(1, vertebrates.size());
     }
 

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
@@ -37,9 +37,9 @@ public class MapTest {
 
     private BucketManagerFactory entityManagerFactory;
 
-    private Species mammals = new Species("lion", "cow", "dog");
-    private Species fishes = new Species("redfish", "glassfish");
-    private Species amphibians = new Species("crododile", "frog");
+    private final Species mammals = new Species("lion", "cow", "dog");
+    private final Species fishes = new Species("redfish", "glassfish");
+    private final Species amphibians = new Species("crododile", "frog");
 
     @BeforeEach
     public void init() {

--- a/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseFamilyManagerTest.java
+++ b/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseFamilyManagerTest.java
@@ -82,7 +82,7 @@ public class HBaseFamilyManagerTest {
         List<CommunicationEntity> columnFamilyEntities = manager.select(query).collect(Collectors.toList());
         assertNotNull(columnFamilyEntities);
         assertFalse(columnFamilyEntities.isEmpty());
-        var entity = columnFamilyEntities.get(0);
+        var entity = columnFamilyEntities.getFirst();
         assertEquals(FAMILY, entity.name());
         assertThat(entity.elements()).contains(Element.of(ID_FIELD, "otaviojava"),
                 Element.of("age", "26"), Element.of("country", "Brazil"));

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/MapTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/MapTest.java
@@ -54,7 +54,7 @@ public class MapTest {
         vertebrates.put("mammals", mammals);
         Species species = vertebrates.get("mammals");
         assertNotNull(species);
-        assertEquals(species.getAnimals().get(0), mammals.getAnimals().get(0));
+        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
         assertEquals(1, vertebrates.size());
     }
 

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
@@ -118,16 +118,13 @@ class MongoDBDocumentManagerTest {
             softly.assertThat(entityRef).isPresent();
             softly.assertThat(entityRef)
                     .get()
-                    .satisfies(updatedEntity -> {
-                        softly.assertThat(updatedEntity.find("newField"))
-                                .as("newField must be present")
-                                .isPresent()
-                                .get()
-                                .extracting(Element::get)
-                                .as("newField value is not correct")
-                                .isEqualTo("10");
-
-                    });
+                    .satisfies(updatedEntity -> softly.assertThat(updatedEntity.find("newField"))
+                            .as("newField must be present")
+                            .isPresent()
+                            .get()
+                            .extracting(Element::get)
+                            .as("newField value is not correct")
+                            .isEqualTo("10"));
         });
     }
 
@@ -156,15 +153,13 @@ class MongoDBDocumentManagerTest {
                 softly.assertThat(entityRef2).isPresent();
                 softly.assertThat(entityRef2)
                         .get()
-                        .satisfies(e -> {
-                            softly.assertThat(e.find("newField"))
-                                    .as("newField must be present")
-                                    .isPresent()
-                                    .get()
-                                    .extracting(Element::get)
-                                    .as("newField value is not correct")
-                                    .isEqualTo(_id.get());
-                        });
+                        .satisfies(e -> softly.assertThat(e.find("newField"))
+                                .as("newField must be present")
+                                .isPresent()
+                                .get()
+                                .extracting(Element::get)
+                                .as("newField value is not correct")
+                                .isEqualTo(_id.get()));
             });
         }
 

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
@@ -244,7 +244,7 @@ class MongoDBDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -261,7 +261,7 @@ class MongoDBDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -279,7 +279,7 @@ class MongoDBDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).contains(entities.get(0));
+        assertThat(entitiesFound).contains(entities.getFirst());
     }
 
     @Test
@@ -386,7 +386,7 @@ class MongoDBDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -414,7 +414,7 @@ class MongoDBDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -490,7 +490,7 @@ class MongoDBDocumentManagerTest {
         SelectQuery query = select("name").from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
-        final CommunicationEntity entity = entities.get(0);
+        final CommunicationEntity entity = entities.getFirst();
         assertEquals(2, entity.size());
         assertTrue(entity.find("name").isPresent());
         assertTrue(entity.find("_id").isPresent());
@@ -508,7 +508,7 @@ class MongoDBDocumentManagerTest {
                 .where("_id").eq(id.get())
                 .build();
 
-        CommunicationEntity entityFound = entityManager.select(query).toList().get(0);
+        CommunicationEntity entityFound = entityManager.select(query).toList().getFirst();
         Element subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -537,7 +537,7 @@ class MongoDBDocumentManagerTest {
         SelectQuery query = select().from(COLLECTION_NAME)
                 .where(id.name()).eq(id.get())
                 .build();
-        var entityFound = entityManager.select(query).toList().get(0);
+        var entityFound = entityManager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -560,7 +560,7 @@ class MongoDBDocumentManagerTest {
                 .where("_id").eq(id).build()).toList();
 
         assertEquals(1, entities.size());
-        CommunicationEntity documentEntity = entities.get(0);
+        CommunicationEntity documentEntity = entities.getFirst();
         assertEquals(id, documentEntity.find("_id").get().get());
 
         assertArrayEquals(contents, (byte[]) documentEntity.find("contents").get().get());
@@ -584,7 +584,7 @@ class MongoDBDocumentManagerTest {
                 .where("_id").eq(id).build()).toList();
 
         assertEquals(1, entities.size());
-        CommunicationEntity documentEntity = entities.get(0);
+        CommunicationEntity documentEntity = entities.getFirst();
         assertEquals(id, documentEntity.find("_id").get().get());
         assertEquals(date, documentEntity.find("date").get().get(Date.class));
         assertEquals(now, documentEntity.find("date").get().get(LocalDate.class));
@@ -719,7 +719,7 @@ class MongoDBDocumentManagerTest {
             }
         }
 
-        var entityToUpdate = entities.get(0);
+        var entityToUpdate = entities.getFirst();
         var idField = entityToUpdate.find(MongoDBUtils.ID_FIELD).orElseThrow();
 
         UpdateCommand updateCommand = new UpdateCommand(entityToUpdate.name(),
@@ -765,7 +765,7 @@ class MongoDBDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -780,7 +780,7 @@ class MongoDBDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -795,7 +795,7 @@ class MongoDBDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.Currency;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/TemplateIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/TemplateIntegrationTest.java
@@ -153,11 +153,11 @@ class TemplateIntegrationTest {
             soft.assertThat(result.componentConfigurationKey()).isEqualTo("componentConfigurationKey");
             soft.assertThat(result.relationTypeKey()).isEqualTo("relationTypeKey");
             soft.assertThat(result.availableTransitions()).hasSize(1);
-            soft.assertThat(result.availableTransitions().get(0).targetWorkflowStepKey()).isEqualTo("TEST_WORKFLOW_STEP_KEY");
-            soft.assertThat(result.availableTransitions().get(0).stepTransitionReason()).isEqualTo(REPEAT);
-            soft.assertThat(result.availableTransitions().get(0).mailTemplateKey()).isNull();
-            soft.assertThat(result.availableTransitions().get(0).restrictedRoleGroups()).hasSize(1);
-            soft.assertThat(result.availableTransitions().get(0).restrictedRoleGroups().get(0)).isEqualTo("ADMIN");
+            soft.assertThat(result.availableTransitions().getFirst().targetWorkflowStepKey()).isEqualTo("TEST_WORKFLOW_STEP_KEY");
+            soft.assertThat(result.availableTransitions().getFirst().stepTransitionReason()).isEqualTo(REPEAT);
+            soft.assertThat(result.availableTransitions().getFirst().mailTemplateKey()).isNull();
+            soft.assertThat(result.availableTransitions().getFirst().restrictedRoleGroups()).hasSize(1);
+            soft.assertThat(result.availableTransitions().getFirst().restrictedRoleGroups().getFirst()).isEqualTo("ADMIN");
         });
     }
 

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
@@ -197,9 +197,9 @@ class Neo4JDatabaseManagerTest {
         var entities = entityManager.select(query).toList();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(entities).hasSize(1);
-            softly.assertThat(entities.get(0).elements()).hasSize(2);
-            softly.assertThat(entities.get(0).contains("name")).isTrue();
-            softly.assertThat(entities.get(0).contains("city")).isTrue();
+            softly.assertThat(entities.getFirst().elements()).hasSize(2);
+            softly.assertThat(entities.getFirst().contains("name")).isTrue();
+            softly.assertThat(entities.getFirst().contains("city")).isTrue();
         });
     }
 
@@ -529,10 +529,10 @@ class Neo4JDatabaseManagerTest {
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).isNotEmpty();
-            softly.assertThat(result.get(0).name()).isEqualTo(COLLECTION_NAME);
-            softly.assertThat(result.get(0).find("name")).isPresent();
-            softly.assertThat(result.get(0).find("city")).isPresent();
-            softly.assertThat(result.get(0).find("_id")).isPresent(); // Ensuring _id exists
+            softly.assertThat(result.getFirst().name()).isEqualTo(COLLECTION_NAME);
+            softly.assertThat(result.getFirst().find("name")).isPresent();
+            softly.assertThat(result.getFirst().find("city")).isPresent();
+            softly.assertThat(result.getFirst().find("_id")).isPresent(); // Ensuring _id exists
         });
     }
 
@@ -680,7 +680,7 @@ class Neo4JDatabaseManagerTest {
         var result = entityManager.select(query).toList();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -695,7 +695,7 @@ class Neo4JDatabaseManagerTest {
         var result = entityManager.select(query).toList();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -710,7 +710,7 @@ class Neo4JDatabaseManagerTest {
         var result = entityManager.select(query).toList();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -110,18 +110,15 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
 
     protected boolean hasOnlyIdConditions(CriteriaCondition condition) {
         var document = condition.element();
-        switch (condition.condition()) {
-            case EQUALS:
-            case IN:
-                return document.name().equals(DefaultOracleNoSQLDocumentManager.ID);
-            case OR:
-            case AND:
+        return switch (condition.condition()) {
+            case EQUALS, IN -> document.name().equals(DefaultOracleNoSQLDocumentManager.ID);
+            case OR, AND -> {
                 var conditions = document.get(new TypeReference<List<CriteriaCondition>>() {
                 });
-                return !conditions.isEmpty() && conditions.stream().allMatch(this::hasOnlyIdConditions);
-            default:
-                return false;
-        }
+                yield !conditions.isEmpty() && conditions.stream().allMatch(this::hasOnlyIdConditions);
+            }
+            default -> false;
+        };
     }
 
     protected void predicateBetween(StringBuilder query,List<FieldValue> params, Element document) {

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
@@ -191,7 +191,7 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
         QueryResult queryResult = serviceHandle.query(queryRequest);
         List<MapValue> results = queryResult.getResults();
         if(results.size() == 1) {
-            return results.get(0).get("count").asLong().getValue();
+            return results.getFirst().get("count").asLong().getValue();
         }
         return 0;
     }
@@ -211,7 +211,7 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
         QueryResult queryResult = serviceHandle.query(new QueryRequest().setPreparedStatement(prepRes));
         List<MapValue> results = queryResult.getResults();
         if(results.size() == 1) {
-            return results.get(0).get(SelectCountBuilder.COUNT).asLong().getValue();
+            return results.getFirst().get(SelectCountBuilder.COUNT).asLong().getValue();
         }
         return 0;
     }

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
@@ -186,7 +186,7 @@ class OracleNoSQLDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -203,7 +203,7 @@ class OracleNoSQLDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -290,7 +290,7 @@ class OracleNoSQLDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -318,7 +318,7 @@ class OracleNoSQLDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -392,7 +392,7 @@ class OracleNoSQLDocumentManagerTest {
         var query = select("name").from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
-        final CommunicationEntity entity = entities.get(0);
+        final CommunicationEntity entity = entities.getFirst();
         assertSoftly(soft -> {
             soft.assertThat(entity.find("name")).isPresent();
             soft.assertThat(entity.find("_id")).isPresent();
@@ -411,7 +411,7 @@ class OracleNoSQLDocumentManagerTest {
                 .where("_id").eq(id.get())
                 .build();
 
-        var entityFound = entityManager.select(query).toList().get(0);
+        var entityFound = entityManager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").orElseThrow();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -428,7 +428,7 @@ class OracleNoSQLDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where(id.name()).eq(id.get())
                 .build();
-        var entityFound = entityManager.select(query).toList().get(0);
+        var entityFound = entityManager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").orElseThrow();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -452,7 +452,7 @@ class OracleNoSQLDocumentManagerTest {
                 .where("_id").eq(id).build()).toList();
 
         assertEquals(1, entities.size());
-        var documentEntity = entities.get(0);
+        var documentEntity = entities.getFirst();
         assertEquals(id, documentEntity.find("_id").orElseThrow().get(Long.class));
 
         assertArrayEquals(contents, documentEntity.find("contents").orElseThrow().get(byte[].class));
@@ -474,7 +474,7 @@ class OracleNoSQLDocumentManagerTest {
                 .where("_id").eq(id).build()).toList();
 
         assertEquals(1, entities.size());
-        var documentEntity = entities.get(0);
+        var documentEntity = entities.getFirst();
         assertSoftly(soft -> {
             soft.assertThat(id).isEqualTo(documentEntity.find("_id").orElseThrow().get(Long.class));
             soft.assertThat(now).isEqualTo(documentEntity.find("now").orElseThrow().get(LocalDate.class));
@@ -676,7 +676,7 @@ class OracleNoSQLDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -691,7 +691,7 @@ class OracleNoSQLDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -706,7 +706,7 @@ class OracleNoSQLDocumentManagerTest {
         var result = entityManager.select(query).toList();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverterTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
@@ -172,7 +172,7 @@ public class OrientDBDocumentManagerTest {
         var entitySaved = entityManager.insert(entity);
         var id = entitySaved.find("name").get();
         var query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
-        var entityFound = entityManager.select(query).toList().get(0);
+        var entityFound = entityManager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -186,7 +186,7 @@ public class OrientDBDocumentManagerTest {
         var entitySaved = entityManager.insert(entity);
         Element id = entitySaved.find("name").get();
         var query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
-        var entityFound = entityManager.select(query).toList().get(0);
+        var entityFound = entityManager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
@@ -515,12 +515,9 @@ public class OrientDBDocumentManagerTest {
                 .or(key2.name()).eq(key2.get())
                 .build();
 
-        assertSoftly(softly -> {
-            softly.assertThat(entityManager.count(query))
-                    .as("Count with query should be equal to 2")
-                    .isEqualTo(2L);
-
-        });
+        assertSoftly(softly -> softly.assertThat(entityManager.count(query))
+                .as("Count with query should be equal to 2")
+                .isEqualTo(2L));
     }
 
     @Test

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerTest.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerTest.java
@@ -191,7 +191,7 @@ public class RavenDBDocumentManagerTest {
 
         Thread.sleep(TIME_LIMIT);
         List<CommunicationEntity> entitiesFound = manager.select(query).collect(Collectors.toList());
-        assertThat(entitiesFound).hasSize(2).isNotIn(entities.get(0));
+        assertThat(entitiesFound).hasSize(2).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -209,7 +209,7 @@ public class RavenDBDocumentManagerTest {
         Thread.sleep(TIME_LIMIT);
         List<CommunicationEntity> entitiesFound = manager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -225,7 +225,7 @@ public class RavenDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = manager.select(query).collect(Collectors.toList());
-        assertThat(entitiesFound).hasSize(1).contains(entities.get(0));
+        assertThat(entitiesFound).hasSize(1).contains(entities.getFirst());
     }
 
     @Test
@@ -283,7 +283,7 @@ public class RavenDBDocumentManagerTest {
                 .where("_id").eq(id.get())
                 .build();
 
-        var entityFound = manager.select(query).toList().get(0);
+        var entityFound = manager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });
@@ -300,7 +300,7 @@ public class RavenDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where(id.name()).eq(id.get())
                 .build();
-        var entityFound = manager.select(query).toList().get(0);
+        var entityFound = manager.select(query).toList().getFirst();
         var subDocument = entityFound.find("phones").get();
         List<Element> documents = subDocument.get(new TypeReference<>() {
         });

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListStringTest.java
@@ -58,7 +58,7 @@ public class RedisListStringTest {
         assertTrue(fruits.isEmpty());
         fruits.add("banana");
         assertFalse(fruits.isEmpty());
-        String banana = fruits.get(0);
+        String banana = fruits.getFirst();
         assertNotNull(banana);
         assertEquals(banana, "banana");
     }
@@ -72,7 +72,7 @@ public class RedisListStringTest {
     @Test
     public void shouldSetList() {
         fruits.add("banana");
-        fruits.add(0, "orange");
+        fruits.addFirst("orange");
         assertEquals(2, fruits.size());
 
         assertEquals(fruits.get(0), "orange");
@@ -130,8 +130,8 @@ public class RedisListStringTest {
             count++;
         }
         assertEquals(2, count);
-        fruits.remove(0);
-        fruits.remove(0);
+        fruits.removeFirst();
+        fruits.removeFirst();
         count = 0;
         for (String fruiCart : fruits) {
             count++;

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListTest.java
@@ -65,7 +65,7 @@ public class RedisListTest {
         assertTrue(fruits.isEmpty());
         fruits.add(banana);
         assertFalse(fruits.isEmpty());
-        ProductCart banana = fruits.get(0);
+        ProductCart banana = fruits.getFirst();
         assertNotNull(banana);
         assertEquals(banana.name(), "banana");
     }
@@ -73,7 +73,7 @@ public class RedisListTest {
     @Test
     public void shouldSetList() {
         fruits.add(banana);
-        fruits.add(0, orange);
+        fruits.addFirst(orange);
         assertEquals(2, fruits.size());
 
         assertEquals(fruits.get(0).name(), "orange");
@@ -111,7 +111,7 @@ public class RedisListTest {
         fruits.add(banana);
         fruits.add(waterMelon);
 
-        fruits.remove(0);
+        fruits.removeFirst();
         assertThat(fruits).hasSize(2).isNotIn(orange);
     }
 
@@ -150,8 +150,8 @@ public class RedisListTest {
             count++;
         }
         assertEquals(2, count);
-        fruits.remove(0);
-        fruits.remove(0);
+        fruits.removeFirst();
+        fruits.removeFirst();
         count = 0;
         for (ProductCart fruiCart : fruits) {
             count++;

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapTest.java
@@ -57,7 +57,7 @@ public class RedisMapTest {
         assertNotNull(vertebrates.put("mammals", mammals));
         Species species = vertebrates.get("mammals");
         assertNotNull(species);
-        assertEquals(species.getAnimals().get(0), mammals.getAnimals().get(0));
+        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
         assertEquals(1, vertebrates.size());
     }
 

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
@@ -112,7 +112,7 @@ public class DefaultSolrDocumentManagerTest {
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
-        final CommunicationEntity result = entities.get(0);
+        final CommunicationEntity result = entities.getFirst();
 
         assertEquals(entity.find("name").get(), result.find("name").get());
         assertEquals(entity.find("city").get(), result.find("city").get());
@@ -131,7 +131,7 @@ public class DefaultSolrDocumentManagerTest {
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
-        final CommunicationEntity result = entities.get(0);
+        final CommunicationEntity result = entities.getFirst();
 
         assertEquals(entity.find("name").get(), result.find("name").get());
         assertEquals(entity.find("city").get(), result.find("city").get());
@@ -149,7 +149,7 @@ public class DefaultSolrDocumentManagerTest {
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
-        final CommunicationEntity result = entities.get(0);
+        final CommunicationEntity result = entities.getFirst();
         assertEquals(entity.find("name").get(), result.find("name").get());
         assertEquals(entity.find("city").get(), result.find("city").get());
     }
@@ -195,7 +195,7 @@ public class DefaultSolrDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -274,7 +274,7 @@ public class DefaultSolrDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -302,7 +302,7 @@ public class DefaultSolrDocumentManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -422,7 +422,7 @@ public class DefaultSolrDocumentManagerTest {
                 .where(ID).eq(id).build()).toList();
 
         assertEquals(1, entities.size());
-        var documentEntity = entities.get(0);
+        var documentEntity = entities.getFirst();
         assertEquals(date, documentEntity.find("date").get().get(Date.class));
         assertEquals(now, documentEntity.find("date").get().get(LocalDate.class));
     }

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversal.java
@@ -67,7 +67,7 @@ class DefaultValueMapTraversal implements ValueMapTraversal {
             return Optional.empty();
         }
         if (result.size() == 1) {
-            return Optional.of(result.get(0));
+            return Optional.of(result.getFirst());
         }
         throw new NonUniqueResultException("The Edge traversal query returns more than one result");
     }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
@@ -139,7 +139,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         assertNotNull(communicationEntities);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(communicationEntities).hasSize(2);
-            softly.assertThat(communicationEntities.get(0).find("name", String.class)).get().isEqualTo(name);
+            softly.assertThat(communicationEntities.getFirst().find("name", String.class)).get().isEqualTo(name);
             softly.assertThat(communicationEntities.get(0).find("age", int.class)).get().isEqualTo(age);
             softly.assertThat(communicationEntities.get(0).find(ID)).isPresent();
 
@@ -248,7 +248,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -265,7 +265,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(2, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
     @Test
@@ -283,7 +283,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).contains(entities.get(0));
+        assertThat(entitiesFound).contains(entities.getFirst());
     }
 
     @Test
@@ -355,7 +355,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -383,7 +383,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
         assertEquals(1, entitiesFound.size());
-        assertThat(entitiesFound).isNotIn(entities.get(0));
+        assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
                 .where("age").gt(22)
@@ -457,7 +457,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         SelectQuery query = select("name").from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
         assertFalse(entities.isEmpty());
-        final CommunicationEntity entity = entities.get(0);
+        final CommunicationEntity entity = entities.getFirst();
         assertEquals(3, entity.size());
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(entity.find("name")).isPresent();
@@ -583,7 +583,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         var result = entityManager.select(query).toList();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -598,7 +598,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         var result = entityManager.select(query).toList();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 
@@ -613,7 +613,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         var result = entityManager.select(query).toList();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.get(0).find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
+            softly.assertThat(result.getFirst().find("name").orElseThrow().get(String.class)).isEqualTo("Poliana");
         });
     }
 

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
@@ -58,7 +58,7 @@ public class RedisListStringTest {
         assertTrue(fruits.isEmpty());
         fruits.add("banana");
         assertFalse(fruits.isEmpty());
-        String banana = fruits.get(0);
+        String banana = fruits.getFirst();
         assertNotNull(banana);
         assertEquals(banana, "banana");
     }
@@ -72,7 +72,7 @@ public class RedisListStringTest {
     @Test
     public void shouldSetList() {
         fruits.add("banana");
-        fruits.add(0, "orange");
+        fruits.addFirst("orange");
         assertEquals(2, fruits.size());
 
         assertEquals(fruits.get(0), "orange");
@@ -130,8 +130,8 @@ public class RedisListStringTest {
             count++;
         }
         assertEquals(2, count);
-        fruits.remove(0);
-        fruits.remove(0);
+        fruits.removeFirst();
+        fruits.removeFirst();
         count = 0;
         for (String fruiCart : fruits) {
             count++;

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
@@ -65,7 +65,7 @@ public class RedisListTest {
         assertTrue(fruits.isEmpty());
         fruits.add(banana);
         assertFalse(fruits.isEmpty());
-        ProductCart banana = fruits.get(0);
+        ProductCart banana = fruits.getFirst();
         assertNotNull(banana);
         assertEquals(banana.name(), "banana");
     }
@@ -73,7 +73,7 @@ public class RedisListTest {
     @Test
     public void shouldSetList() {
         fruits.add(banana);
-        fruits.add(0, orange);
+        fruits.addFirst(orange);
         assertEquals(2, fruits.size());
 
         assertEquals(fruits.get(0).name(), "orange");
@@ -111,7 +111,7 @@ public class RedisListTest {
         fruits.add(banana);
         fruits.add(waterMelon);
 
-        fruits.remove(0);
+        fruits.removeFirst();
         assertThat(fruits).hasSize(2).isNotIn(orange);
     }
 
@@ -150,8 +150,8 @@ public class RedisListTest {
             count++;
         }
         assertEquals(2, count);
-        fruits.remove(0);
-        fruits.remove(0);
+        fruits.removeFirst();
+        fruits.removeFirst();
         count = 0;
         for (ProductCart fruiCart : fruits) {
             count++;

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
@@ -57,7 +57,7 @@ public class ValkeyMapTest {
         assertNotNull(vertebrates.put("mammals", mammals));
         Species species = vertebrates.get("mammals");
         assertNotNull(species);
-        assertEquals(species.getAnimals().get(0), mammals.getAnimals().get(0));
+        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
         assertEquals(1, vertebrates.size());
     }
 


### PR DESCRIPTION
This pull request primarily updates test code across multiple modules to use the new `getFirst()` method instead of `get(0)` when retrieving the first element from lists. This change improves clarity and safety by making the intention explicit and aligning with modern Java best practices. Additionally, there are minor code cleanups and simplifications in utility and test classes.

The most important changes are:

### Test code modernization

* Replaced usages of `get(0)` with `getFirst()` for retrieving the first element from lists in test classes for ArangoDB, Cassandra, and Couchbase modules, improving readability and reducing potential for errors. [[1]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL131-R131) [[2]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL146-R146) [[3]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL160-R160) [[4]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL480-R480) [[5]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL495-R495) [[6]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL510-R510) [[7]](diffhunk://#diff-1d5cb68976ec9fc0efaadf9c99b3bdab9362769feae819e009c8a4d30d8b3b7fL147-R151) [[8]](diffhunk://#diff-3b6e6a2f2464797ae2f956d350c286574ac9ca3c0693bc0e77de4258cd2d7b07L204-R204) [[9]](diffhunk://#diff-3b6e6a2f2464797ae2f956d350c286574ac9ca3c0693bc0e77de4258cd2d7b07L293-R293) [[10]](diffhunk://#diff-3b6e6a2f2464797ae2f956d350c286574ac9ca3c0693bc0e77de4258cd2d7b07L308-R308) [[11]](diffhunk://#diff-3b6e6a2f2464797ae2f956d350c286574ac9ca3c0693bc0e77de4258cd2d7b07L321-R321) [[12]](diffhunk://#diff-3b6e6a2f2464797ae2f956d350c286574ac9ca3c0693bc0e77de4258cd2d7b07L333-R333) [[13]](diffhunk://#diff-3b6e6a2f2464797ae2f956d350c286574ac9ca3c0693bc0e77de4258cd2d7b07L346-R346) [[14]](diffhunk://#diff-b8a20c6dc601de87951f836021c227ff11f56a535417f6218121a1cc79ec31e5L199-R199) [[15]](diffhunk://#diff-b8a20c6dc601de87951f836021c227ff11f56a535417f6218121a1cc79ec31e5L214-R214) [[16]](diffhunk://#diff-b8a20c6dc601de87951f836021c227ff11f56a535417f6218121a1cc79ec31e5L391-R391) [[17]](diffhunk://#diff-b8a20c6dc601de87951f836021c227ff11f56a535417f6218121a1cc79ec31e5L410-R410) [[18]](diffhunk://#diff-b8a20c6dc601de87951f836021c227ff11f56a535417f6218121a1cc79ec31e5L430-R430) [[19]](diffhunk://#diff-c05b096b20bace6c2813e684053f0e2c475ea8d90fc333a9d0b94972f8546554L129-R129) [[20]](diffhunk://#diff-c05b096b20bace6c2813e684053f0e2c475ea8d90fc333a9d0b94972f8546554L147-R147)

### Code simplification and cleanup

* Simplified the definition of `META_FIELDS` in `ArangoDBUtil` by using `Set.of(...)` instead of creating an unmodifiable set from a `HashSet`, making the code more concise and efficient.
* Updated import statements in `ArangoDBUtil` to use explicit imports instead of wildcard imports, improving code clarity.
* Replaced a lambda with a method reference for predicate creation in `ArangoDBEnumIntegrationTest`, making the code more concise. [[1]](diffhunk://#diff-056395dbdb5e5a3354dff8520352307179b4ece360eee3fd8ac5ab918b454a27L86-R86) [[2]](diffhunk://#diff-056395dbdb5e5a3354dff8520352307179b4ece360eee3fd8ac5ab918b454a27L136-R136)
* Changed a string replacement in an assertion to use `replace` instead of `replaceAll`, which is more appropriate for the intended usage.

These changes collectively modernize the codebase, improve readability, and ensure safer handling of list operations in tests.