### PR TITLE
Update driver

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -44,12 +44,15 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Include support to UUID at Oracle NoSQL database
 
 
-== [1.1.14] - 2026-06-01
+== [1.1.15] - 2026-07-03
 
 === Changed
 
 - Upgraded Cassandra 4.19.3
 - Upgraded Couchbase 3.12.0
+- Upgraded Dynamodb 2.46.21
+- Upgraded Infinispan 16.2.1
+
 
 == [1.1.13] - 2026-04-06
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -48,18 +48,8 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 === Changed
 
-- Upgraded ArangoDB Java driver to 7.26.0
-- Upgraded Couchbase Java client to 3.11.3
-- Upgraded DynamoDB SDK to 2.44.11
-- Upgraded Hazelcast client to 5.7.0
-- Upgraded Infinispan client to 16.1.4
-- Upgraded MongoDB Java driver to 5.7.0
-- Upgraded Neo4j Java driver to 6.1.0
-- Upgraded Oracle NoSQL SDK to 5.4.21
-- Upgraded OrientDB graphdb to 3.2.52
-- Upgraded Jedis (Redis client) to 7.5.0
-- Upgraded Apache Tinkerpop to 3.8.1
-- Upgraded Apache HttpClient5 Cache to 5.6.1
+- Upgraded Cassandra 4.19.3
+- Upgraded Couchbase 3.12.0
 
 == [1.1.13] - 2026-04-06
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,7 +37,6 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Improve MongoDB document update tests
 - Validate required fields in N1QLUpdateQueryBuilder for Couchbase
 - Validate update query parameters in Couchbase driver
-- Add update query tests for ArangoDB, Neo4J, Couchbase, Cassandra, and MongoDB
 - Update jakarta data engine
 
 === Fixed

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -52,6 +52,9 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Upgraded Couchbase 3.12.0
 - Upgraded Dynamodb 2.46.21
 - Upgraded Infinispan 16.2.1
+- Upgraded Neo4J 6.2.0
+- Upgraded Oracle NoSQL 5.4.23
+- Upgraded OrientDB 3.2.53
 
 
 == [1.1.13] - 2026-04-06

--- a/jnosql-cassandra/pom.xml
+++ b/jnosql-cassandra/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to Cassandra</description>
 
     <properties>
-        <casandra.driver.version>4.19.2</casandra.driver.version>
+        <casandra.driver.version>4.19.3</casandra.driver.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.11.3</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/jnosql-couchdb/pom.xml
+++ b/jnosql-couchdb/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5-cache</artifactId>
-            <version>5.6.1</version>
+            <version>5.6.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.45.1</dynamodb.version>
+        <dynamodb.version>2.46.21</dynamodb.version>
 
     </properties>
 

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to Elasticsearch</description>
 
     <properties>
-        <elasticsearch-java.version>8.19.9</elasticsearch-java.version>
+        <elasticsearch-java.version>8.19.17</elasticsearch-java.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -27,7 +27,7 @@
     <description>The Eclipse JNoSQL layer implementation for Infinispan</description>
 
     <properties>
-        <infinispan.version>16.1.4</infinispan.version>
+        <infinispan.version>16.2.1</infinispan.version>
     </properties>
 
     <dependencies>

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -27,7 +27,7 @@
     <name>JNoSQL Neo4J Driver</name>
 
     <properties>
-        <neo4j.driver>6.1.0</neo4j.driver>
+        <neo4j.driver>6.2.0</neo4j.driver>
     </properties>
 
     <dependencies>

--- a/jnosql-oracle-nosql/pom.xml
+++ b/jnosql-oracle-nosql/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.oracle.nosql.sdk</groupId>
             <artifactId>nosqldriver</artifactId>
-            <version>5.4.21</version>
+            <version>5.4.23</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
-            <version>3.2.52</version>
+            <version>3.2.53</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This pull request updates several dependencies across multiple JNoSQL modules to ensure compatibility with the latest versions and to incorporate bug fixes and improvements from upstream libraries. It also removes a test-related changelog entry.

Dependency version upgrades:

* Upgraded Cassandra driver to version `4.19.3` in `jnosql-cassandra/pom.xml`.
* Upgraded Couchbase Java client to `3.12.0` in `jnosql-couchbase/pom.xml`.
* Upgraded AWS DynamoDB SDK to `2.46.21` in `jnosql-dynamodb/pom.xml`.
* Upgraded Elasticsearch Java client to `8.19.17` in `jnosql-elasticsearch/pom.xml`.
* Upgraded Infinispan to `16.2.1` in `jnosql-infinispan/pom.xml`.
* Upgraded Neo4J driver to `6.2.0` in `jnosql-neo4j/pom.xml`.
* Upgraded Oracle NoSQL SDK to `5.4.23` in `jnosql-oracle-nosql/pom.xml`.
* Upgraded OrientDB GraphDB to `3.2.53` in `jnosql-orientdb/pom.xml`.
* Upgraded Apache HttpClient5 Cache to `5.6.2` in `jnosql-couchdb/pom.xml`.

Changelog update:

* Removed the changelog entry for adding update query tests for ArangoDB, Neo4J, Couchbase, Cassandra, and MongoDB in `CHANGELOG.adoc`.