### PR TITLE
Update driver dependencies for 1.1.15

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,17 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+== [1.1.15] - 2026-07-03
+
+- Upgraded Cassandra 4.19.3
+- Upgraded Couchbase 3.12.0
+- Upgraded Dynamodb 2.46.21
+- Upgraded Infinispan 16.2.1
+- Upgraded Neo4J 6.2.0
+- Upgraded Oracle NoSQL 5.4.23
+- Upgraded OrientDB 3.2.53
+
+
 == [1.1.14] - 2026-06-01
 
 === Changed

--- a/jnosql-cassandra/pom.xml
+++ b/jnosql-cassandra/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to Cassandra</description>
 
     <properties>
-        <casandra.driver.version>4.19.2</casandra.driver.version>
+        <casandra.driver.version>4.19.3</casandra.driver.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.11.3</version>
+            <version>3.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/jnosql-couchdb/pom.xml
+++ b/jnosql-couchdb/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5-cache</artifactId>
-            <version>5.6.1</version>
+            <version>5.6.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.45.1</dynamodb.version>
+        <dynamodb.version>2.46.21</dynamodb.version>
     </properties>
 
     <dependencies>

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -27,7 +27,7 @@
     <description>The Eclipse JNoSQL layer implementation for Infinispan</description>
 
     <properties>
-        <infinispan.version>16.1.4</infinispan.version>
+        <infinispan.version>16.2.1</infinispan.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -27,7 +27,7 @@
     <name>JNoSQL Neo4J Driver</name>
 
     <properties>
-        <neo4j.driver>6.0.2</neo4j.driver>
+        <neo4j.driver>6.2.0</neo4j.driver>
     </properties>
 
     <dependencies>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
-            <version>3.2.52</version>
+            <version>3.2.53</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This pull request updates several dependencies across multiple modules to their latest versions, enhancing compatibility and stability with the supported NoSQL databases. The updates are reflected in the changelog and respective `pom.xml` files.

Dependency upgrades:

* Cassandra: Upgraded the driver version to `4.19.3` in `jnosql-cassandra/pom.xml`
* Couchbase: Upgraded the Java client to `3.12.0` in `jnosql-couchbase/pom.xml`
* DynamoDB: Upgraded the SDK version to `2.46.21` in `jnosql-dynamodb/pom.xml`
* Infinispan: Upgraded the version to `16.2.1` in `jnosql-infinispan/pom.xml`
* Neo4J: Upgraded the driver to `6.2.0` in `jnosql-neo4j/pom.xml`
* Oracle NoSQL: (Reflected in changelog, not shown in diffs above)
* OrientDB: Upgraded the graphdb dependency to `3.2.53` in `jnosql-orientdb/pom.xml`

Documentation:

* Updated `CHANGELOG.adoc` to document all major dependency upgrades for version 1.1.15

Additionally, a minor version bump for `httpclient5-cache` to `5.6.2` in `jnosql-couchdb/pom.xml` improves HTTP client stability.