### PR TITLE
chore: include valkey

### DIFF
--- a/jnosql-valkey/pom.xml
+++ b/jnosql-valkey/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Otavio Santana
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.jnosql.databases</groupId>
+        <artifactId>jnosql-databases-parent</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jnosql-valkey</artifactId>
+    <name>JNoSQL Valkey Driver</name>
+    <description>The Eclipse JNoSQL layer implementation Valkey</description>
+
+    <properties>
+
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jnosql.mapping</groupId>
+            <artifactId>jnosql-mapping-key-value</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.valkey</groupId>
+            <artifactId>valkey-java</artifactId>
+            <version>5.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jnosql-database-commons</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jnosql-valkey/pom.xml
+++ b/jnosql-valkey/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.1.16-SNAPSHOT</version>
     </parent>
 
     <artifactId>jnosql-valkey</artifactId>

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Counter.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Counter.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import java.time.Duration;
+
+/**
+ * The redis counter structure
+ */
+public interface Counter {
+
+    /**
+     * Returns the counter value
+     *
+     * @return The counter value
+     */
+    Number get();
+
+    /**
+     * Increments by one the counter
+     *
+     * @return the increment by one result
+     */
+    Number increment();
+
+    /**
+     * Increments the counter
+     *
+     * @param value the value to be increased
+     * @return the increment result
+     * @throws NullPointerException when value is null
+     */
+    Number increment(Number value) throws NullPointerException;
+
+    /**
+     * Decrements by one the counter
+     *
+     * @return the increment by one result
+     */
+    Number decrement();
+
+    /**
+     * Decrements
+     *
+     * @param value the value to be decreased
+     * @return the decrement result
+     */
+    Number decrement(Number value);
+
+    /**
+     * Delete this Counter
+     */
+    void delete();
+
+
+    /**
+     * Defines a ttl to SortedSet
+     *
+     * @param ttl the ttl
+     * @throws NullPointerException when either key and ttl are null
+     */
+    void expire(Duration ttl) throws NullPointerException;
+
+    /**
+     * Removes the ttl
+     */
+    void persist();
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounter.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounter.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import io.valkey.UnifiedJedis;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+
+/**
+ * The default {@link Counter}
+ */
+class DefaultCounter implements Counter {
+
+    private static final Predicate<String> IS_EMPTY = String::isEmpty;
+    private static final Predicate<String> IS_NOT_EMPTY = IS_EMPTY.negate();
+
+    private final String key;
+
+    private final UnifiedJedis jedis;
+
+    DefaultCounter(String key, UnifiedJedis jedis) {
+        this.key = key;
+        this.jedis = jedis;
+    }
+
+    @Override
+    public Number get() {
+        return Optional.ofNullable(jedis.get(key))
+                .filter(IS_NOT_EMPTY)
+                .map(Double::valueOf)
+                .orElse(0D);
+    }
+
+    @Override
+    public Number increment() {
+        return increment(1);
+    }
+
+    @Override
+    public Number increment(Number value) throws NullPointerException {
+        Objects.requireNonNull(value, "value is required");
+        return jedis.incrByFloat(key, value.doubleValue());
+    }
+
+    @Override
+    public Number decrement() {
+        return increment(-1);
+    }
+
+    @Override
+    public Number decrement(Number value) {
+        Objects.requireNonNull(value, "value is required");
+        return jedis.incrByFloat(key, -value.doubleValue());
+    }
+
+    @Override
+    public void delete() {
+        jedis.del(key);
+    }
+
+    @Override
+    public void expire(Duration ttl) throws NullPointerException {
+        Objects.requireNonNull(ttl, "ttl is required");
+        jedis.expire(key, (int) ttl.getSeconds());
+    }
+
+    @Override
+    public void persist() {
+        jedis.persist(key);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultCounter that)) {
+            return false;
+        }
+        return Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(key);
+    }
+
+    @Override
+    public String toString() {
+        return "Counter{" + "key='" + key + '\'' +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultRanking.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultRanking.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import java.util.Objects;
+
+class DefaultRanking implements Ranking {
+
+    private final Number point;
+
+    private final String member;
+
+    DefaultRanking(String member, Number point) {
+        this.point = Objects.requireNonNull(point, "point is required");
+        this.member = Objects.requireNonNull(member, "member is required");
+    }
+
+    @Override
+    public Number getPoints() {
+        return point;
+    }
+
+    @Override
+    public String getMember() {
+        return member;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Ranking that)) {
+            return false;
+        }
+        return Objects.equals(point, that.getPoints()) &&
+                Objects.equals(member, that.getMember());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(point, member);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultRanking{" + "point=" + point +
+                ", member='" + member + '\'' +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSet.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSet.java
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+
+import io.valkey.UnifiedJedis;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * The default {@link SortedSet} implementation
+ */
+class DefaultSortedSet implements SortedSet {
+
+
+    private static final int LAST_ELEMENT = -1;
+    private final String key;
+    private final UnifiedJedis jedis;
+
+    DefaultSortedSet(UnifiedJedis jedis, String keyspace) {
+        Objects.requireNonNull(jedis, "jedis is required");
+        Objects.requireNonNull(keyspace, "keyspace is required");
+        this.key = keyspace;
+        this.jedis = jedis;
+    }
+
+    @Override
+    public void add(String member, Number value) throws NullPointerException {
+        Objects.requireNonNull(member, "member is required");
+        Objects.requireNonNull(value, "value is required");
+        jedis.zadd(key, value.doubleValue(), member);
+    }
+
+    @Override
+    public void add(Ranking ranking) throws NullPointerException {
+        Objects.requireNonNull(ranking, "ranking is required");
+        jedis.zadd(key, ranking.getPoints().doubleValue(), ranking.getMember());
+    }
+
+    @Override
+    public Number increment(String member, Number value) throws NullPointerException {
+        Objects.requireNonNull(member, "member is required");
+        Objects.requireNonNull(value, "value is required");
+        return jedis.zincrby(key, value.doubleValue(), member);
+    }
+
+    @Override
+    public Number decrement(String member, Number value) throws NullPointerException {
+        Objects.requireNonNull(member, "member is required");
+        Objects.requireNonNull(value, "value is required");
+        return increment(member, -value.longValue());
+    }
+
+    @Override
+    public void remove(String member) throws NullPointerException {
+        jedis.zrem(key, member);
+    }
+
+    @Override
+    public int size() {
+        return (int) jedis.zcard(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public void delete() {
+        jedis.del(key);
+    }
+
+
+    @Override
+    public void expire(Duration ttl) throws NullPointerException {
+        Objects.requireNonNull(ttl, "ttl is required");
+        jedis.expire(key, (int) ttl.getSeconds());
+    }
+
+    @Override
+    public void persist() {
+        jedis.persist(key);
+    }
+
+    @Override
+    public List<Ranking> range(long start, long end) {
+        return jedis.zrangeWithScores(key, start, end).stream()
+                .map(t -> new DefaultRanking(t.getElement(), t.getScore()))
+                .collect(toList());
+    }
+
+    @Override
+    public List<Ranking> revRange(long start, long end) {
+        return jedis.zrevrangeWithScores(key, start, end).stream()
+                .map(t -> new DefaultRanking(t.getElement(), t.getScore()))
+                .collect(toList());
+    }
+
+    @Override
+    public List<Ranking> getRanking() {
+        return range(0, LAST_ELEMENT);
+    }
+
+    @Override
+    public List<Ranking> getRevRanking() {
+        return revRange(0, LAST_ELEMENT);
+    }
+
+    @Override
+    public void clear() {
+        jedis.del(key);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DefaultSortedSet that)) {
+            return false;
+        }
+        return Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(key);
+    }
+
+    @Override
+    public String toString() {
+        return "SortedSet{" + "key='" + key + '\'' +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultValkeyBucketManagerFactory.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultValkeyBucketManagerFactory.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import io.valkey.UnifiedJedis;
+import jakarta.json.bind.Jsonb;
+import org.eclipse.jnosql.communication.driver.JsonbSupplier;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+class DefaultValkeyBucketManagerFactory implements ValkeyBucketManagerFactory {
+
+    private static final Jsonb JSON = JsonbSupplier.getInstance().get();
+
+    private final UnifiedJedis jedis;
+
+    DefaultValkeyBucketManagerFactory(UnifiedJedis jedis) {
+        this.jedis = jedis;
+    }
+
+
+    @Override
+    public ValkeyBucketManager apply(String bucketName) {
+        requireNonNull(bucketName, "bucket name is required");
+
+        return new ValkeyBucketManager(bucketName, JSON, jedis);
+    }
+
+    @Override
+    public <T> List<T> getList(String bucketName, Class<T> clazz) {
+        requireNonNull(bucketName, "bucket name is required");
+        requireNonNull(clazz, "Class type is required");
+        return new ValkeyList<>(jedis, clazz, bucketName);
+    }
+
+    @Override
+    public <T> Set<T> getSet(String bucketName, Class<T> clazz) {
+        requireNonNull(bucketName, "bucket name is required");
+        requireNonNull(clazz, "Class type is required");
+        return new ValkeySet<>(jedis, clazz, bucketName);
+    }
+
+    @Override
+    public <T> Queue<T> getQueue(String bucketName, Class<T> clazz) {
+        requireNonNull(bucketName, "bucket name is required");
+        requireNonNull(clazz, "Class type is required");
+        return new ValkeyQueue<>(jedis, clazz, bucketName);
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(String bucketName, Class<K> keyValue, Class<V> valueValue) {
+        requireNonNull(bucketName, "bucket name is required");
+        requireNonNull(valueValue, "Class type is required");
+        return new ValkeyMap<>(jedis, keyValue, valueValue, bucketName);
+    }
+
+    @Override
+    public SortedSet getSortedSet(String key) throws NullPointerException {
+        requireNonNull(key, "key is required");
+        return new DefaultSortedSet(jedis, key);
+    }
+
+    @Override
+    public Counter getCounter(String key) throws NullPointerException {
+        requireNonNull(key, "key is required");
+        return new DefaultCounter(key, jedis);
+    }
+
+
+    @Override
+    public void close() {
+        jedis.close();
+    }
+
+    @Override
+    public String toString() {
+        return "RedisBucketManagerFactory{" + "jedisPool=" + jedis +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/IrregularKeyValue.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/IrregularKeyValue.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+/**
+ * An exception when has irregular key value problem
+ */
+public class IrregularKeyValue extends RuntimeException {
+
+    private static final long serialVersionUID = 6161854579438859925L;
+
+    IrregularKeyValue(String message) {
+        super(message);
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Ranking.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Ranking.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+/**
+ * Represents an element of a sorted set, composed of a member and its associated score.
+ * <p>
+ * In data stores such as Valkey, a sorted set maintains elements ordered
+ * by a numeric value (commonly referred to as a <em>score</em>). This interface models
+ * that concept in a domain-oriented way, abstracting the underlying storage details
+ * while preserving ordering semantics.
+ * </p>
+ *
+ * <p>
+ * <strong>Design note:</strong> This type is a value object and should be treated as immutable.
+ * Implementations are expected to provide consistent {@code equals} and {@code hashCode}
+ * semantics based on both member and score.
+ * </p>
+ *
+ * @see <a href="https://valkey.io/">Valkey documentation</a>
+ */
+public interface Ranking {
+
+    /**
+     * Returns the numeric score associated with this member.
+     * <p>
+     * The score determines the ordering of elements within the sorted set.
+     * </p>
+     *
+     * @return the score used for ordering; never {@code null}
+     */
+    Number getPoints();
+
+    /**
+     * Returns the unique member identifier within the sorted set.
+     *
+     * @return the member identifier; never {@code null}
+     */
+    String getMember();
+
+    /**
+     * Creates a new {@link Ranking} instance with the given member and score.
+     * <p>
+     * This factory method provides a consistent way to create immutable
+     * {@code Ranking} instances.
+     * </p>
+     *
+     * @param member the member identifier; must not be {@code null}
+     * @param points the score associated with the member; must not be {@code null}
+     * @return a new {@link Ranking} instance
+     * @throws NullPointerException if either {@code member} or {@code points} is {@code null}
+     */
+    static Ranking of(String member, Number points) throws NullPointerException {
+        return new DefaultRanking(member, points);
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/SortedSet.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/SortedSet.java
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Sorted sets are a data type which is similar to a mix between a Set and a Hash.
+ * Like sets, sorted sets are composed of unique, non-repeating string elements,
+ * so in some sense a sorted set is a set as well.
+ */
+public interface SortedSet {
+
+    /**
+     * Adds all the specified members with the specified scores to the sorted set stored at key.
+     * Creates a score.
+     *
+     * @param member the name
+     * @param value  the value
+     * @throws NullPointerException when either member or value are null
+     */
+    void add(String member, Number value) throws NullPointerException;
+
+
+    /**
+     * Adds all the specified members with the specified scores to the sorted set stored at key.
+     * Creates a score.
+     *
+     * @param ranking the element
+     * @throws NullPointerException when ranking is null
+     */
+    void add(Ranking ranking) throws NullPointerException;
+
+    /**
+     * Increments the score of member in the sorted set stored at member by increment.
+     *
+     * @param member the member
+     * @param value  the vaue
+     * @return the new score member
+     * @throws NullPointerException when either member or value are null
+     */
+    Number increment(String member, Number value) throws NullPointerException;
+
+    /**
+     * Increments the score of member in the sorted set stored at member by increment.
+     *
+     * @param member the member
+     * @param value  the vaue
+     * @return the new score member
+     * @throws NullPointerException when either member or value are null
+     */
+    Number decrement(String member, Number value) throws NullPointerException;
+
+    /**
+     * Removes a member
+     *
+     * @param member the member
+     * @throws NullPointerException when member is null
+     */
+    void remove(String member) throws NullPointerException;
+
+    /**
+     * @return the number of members on this
+     */
+    int size();
+
+    /**
+     * @return Returns true if this SortedSet contains no elements.
+     */
+    boolean isEmpty();
+
+    /**
+     * Delete this SortedSet
+     *
+     * @deprecated As of release 0.0.5, replaced by {@link #clear()}
+     */
+    @Deprecated
+    void delete();
+
+    /**
+     * Defines a ttl to SortedSet
+     *
+     * @param ttl the ttl
+     * @throws NullPointerException when either key and ttl are null
+     */
+    void expire(Duration ttl) throws NullPointerException;
+
+    /**
+     * Removes the ttl
+     */
+    void persist();
+
+    /**
+     * Returns the specified range of elements in the sorted set stored at key.
+     * The elements are considered to be ordered from the lowest to the highest score.
+     * Lexicographical order is used for elements with equal score.
+     * Both start and stop are zero-based indexes
+     *
+     * @param start the index to start
+     * @param end   the index to end
+     * @return the Ranking
+     */
+    List<Ranking> range(long start, long end);
+
+    /**
+     * Returns the specified range of elements in the sorted set
+     * stored at key. The elements are considered to be ordered from the
+     * highest to the lowest score. Descending lexicographical order is used for elements with equal score.
+     * Both start and stop are zero-based indexes
+     *
+     * @param start the index to start
+     * @param end   the index to end
+     * @return the Ranking
+     */
+    List<Ranking> revRange(long start, long end);
+
+    /**
+     * Returns all elements using {@link SortedSet#range(long, long)}
+     *
+     * @return the rankings
+     * @see SortedSet#range(long, long)
+     */
+    List<Ranking> getRanking();
+
+    /**
+     * Returns all elements using {@link SortedSet#revRange(long, long)}
+     *
+     * @return the rankings
+     * @see SortedSet#revRange(long, long)
+     */
+    List<Ranking> getRevRanking();
+
+    /**
+     * Removes all of the elements from this sortedset
+     */
+    void clear();
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManager.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManager.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import io.valkey.UnifiedJedis;
+import jakarta.json.bind.Jsonb;
+import org.eclipse.jnosql.communication.Value;
+import org.eclipse.jnosql.communication.driver.ValueJSON;
+import org.eclipse.jnosql.communication.keyvalue.BucketManager;
+import org.eclipse.jnosql.communication.keyvalue.KeyValueEntity;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * The redis implementation to {@link BucketManager}
+ */
+public class ValkeyBucketManager implements BucketManager {
+
+    private final String nameSpace;
+    private final Jsonb jsonB;
+
+    private final UnifiedJedis jedis;
+
+    ValkeyBucketManager(String nameSpace, Jsonb provider, UnifiedJedis jedis) {
+        this.nameSpace = nameSpace;
+        this.jsonB = provider;
+        this.jedis = jedis;
+    }
+
+    @Override
+    public String name() {
+        return nameSpace;
+    }
+
+    @Override
+    public <K, V> void put(K key, V value) throws NullPointerException {
+        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(key, "key is required");
+        String valideKey = ValkeyUtils.createKeyWithNameSpace(key.toString(), nameSpace);
+        jedis.set(valideKey, jsonB.toJson(value));
+    }
+
+    @Override
+    public void put(KeyValueEntity entity) throws NullPointerException {
+        put(entity.key(), entity.value());
+    }
+
+    @Override
+    public void put(KeyValueEntity entity, Duration ttl) throws NullPointerException, UnsupportedOperationException {
+        put(entity);
+        String valideKey = ValkeyUtils.createKeyWithNameSpace(entity.key().toString(), nameSpace);
+        jedis.expire(valideKey, (int) ttl.getSeconds());
+    }
+
+    @Override
+    public void put(Iterable<KeyValueEntity> entities) throws NullPointerException {
+        StreamSupport.stream(entities.spliterator(), false).forEach(this::put);
+    }
+
+    @Override
+    public void put(Iterable<KeyValueEntity> entities, Duration ttl) throws NullPointerException, UnsupportedOperationException {
+        StreamSupport.stream(entities.spliterator(), false).forEach(this::put);
+        StreamSupport.stream(entities.spliterator(), false).map(KeyValueEntity::key)
+                .map(k -> ValkeyUtils.createKeyWithNameSpace(k.toString(), nameSpace))
+                .forEach(k -> jedis.expire(k, (int) ttl.getSeconds()));
+    }
+
+    @Override
+    public <K> Optional<Value> get(K key) throws NullPointerException {
+        String value = jedis.get(ValkeyUtils.createKeyWithNameSpace(key.toString(), nameSpace));
+        if (value != null && !value.isEmpty()) {
+            return Optional.of(ValueJSON.of(value));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public <K> Iterable<Value> get(Iterable<K> keys) throws NullPointerException {
+        return StreamSupport.stream(keys.spliterator(), false)
+                .map(k -> jedis.get(ValkeyUtils.createKeyWithNameSpace(k.toString(), nameSpace)))
+                .filter(value -> value != null && !value.isEmpty())
+                .map(ValueJSON::of).collect(toList());
+    }
+
+    @Override
+    public <K> void delete(K key) {
+        jedis.del(ValkeyUtils.createKeyWithNameSpace(key.toString(), nameSpace));
+    }
+
+    @Override
+    public <K> void delete(Iterable<K> keys) {
+        StreamSupport.stream(keys.spliterator(), false).forEach(this::delete);
+    }
+
+    @Override
+    public void close() {
+        jedis.close();
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactory.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactory.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+
+/**
+ * The redis implementation to {@link BucketManagerFactory} where returns {@link ValkeyBucketManager}
+ */
+public interface ValkeyBucketManagerFactory extends BucketManagerFactory {
+
+
+    /**
+     * Creates a {@link SortedSet} from key
+     *
+     * @param key the key
+     * @return the SortedSet from key
+     * @throws NullPointerException when key is null
+     */
+    SortedSet getSortedSet(String key) throws NullPointerException;
+    /**
+     * Creates {@link Counter}
+     *
+     * @param key the key to counter
+     * @return a counter instance from key
+     * @throws NullPointerException when key is null
+     */
+    Counter getCounter(String key) throws NullPointerException;
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyClusterConfigurations.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyClusterConfigurations.java
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import java.util.function.Supplier;
+
+/**
+ * An enumeration to show the available options to connect to the Redis database by cluster configuration.
+ * It implements {@link Supplier}, where its it returns the property name that might be
+ * overwritten by the system environment using Eclipse Microprofile or Jakarta Config API.
+ *
+ * @see org.eclipse.jnosql.communication.Settings
+ */
+public enum ValkeyClusterConfigurations implements Supplier<String> {
+    /**
+     * The key property that defines if the redis cluster configuration should be loaded
+     */
+    CLUSTER("jnosql.valkey.cluster"),
+    /**
+     * The value for the sentinel HOST:PORT (separated by comma) configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    CLUSTER_HOSTS("jnosql.valkey.cluster.hosts"),
+    /**
+     * The cluster client's name. The default value is 0.
+     */
+    CLIENT_NAME("jnosql.valkey.cluster.client.name"),
+    /**
+     * The cluster redis timeout, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT} on milliseconds
+     */
+    TIMEOUT("jnosql.valkey.cluster.timeout"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the cluster jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    CONNECTION_TIMEOUT("jnosql.valkey.cluster.connection.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the cluster jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    SOCKET_TIMEOUT("jnosql.valkey.cluster.socket.timeout"),
+    /**
+     * The value for the user configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The user on {@link io.valkey.JedisClientConfig}
+     */
+    USER("jnosql.valkey.cluster.user"),
+    /**
+     * The value for the password configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The user on {@link io.valkey.JedisClientConfig}
+     */
+    PASSWORD("jnosql.valkey.cluster.password"),
+    /**
+     * The value for the ssl configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The ssl on {@link io.valkey.JedisClientConfig}, the default value is false.
+     */
+    SSL("jnosql.valkey.cluster.ssl"),
+    /**
+     * The value for the protocol configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The ssl on {@link io.valkey.JedisClientConfig}. The default value is false.
+     * The default value is not defined.
+     */
+    REDIS_PROTOCOL("jnosql.valkey.cluster.protocol"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link io.valkey.JedisClientConfig}
+     * The default value is false.
+     */
+    CLIENTSET_INFO_CONFIG_DISABLED("jnosql.valkey.cluster.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the cluster jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link io.valkey.JedisClientConfig}
+     * The default value is not defined.
+     */
+    CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.valkey.cluster.clientset.info.config.libname.suffix"),
+
+    /**
+     * The value for the max attempts configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * Default is {@link io.valkey.JedisCluster#DEFAULT_MAX_ATTEMPTS}
+     */
+    CLUSTER_MAX_ATTEMPTS("jnosql.valkey.cluster.max.attempts"),
+    /**
+     * The value for the max total retries configuration attribute for the cluster jedis client configuration with this configuration instance.
+     * Default is {@link ValkeyClusterConfigurations#SOCKET_TIMEOUT} * {@link ValkeyClusterConfigurations#CLUSTER_MAX_ATTEMPTS}
+     */
+    CLUSTER_MAX_TOTAL_RETRIES_DURATION("jnosql.valkey.cluster.max.total.retries.duration");
+
+    private final String configuration;
+
+    ValkeyClusterConfigurations(String configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String get() {
+        return configuration;
+    }
+
+    public static enum ClusterConfigurationsResolver implements
+            ValkeyConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return ValkeyClusterConfigurations.CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return ValkeyClusterConfigurations.SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return ValkeyClusterConfigurations.CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return ValkeyClusterConfigurations.USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return ValkeyClusterConfigurations.PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return ValkeyClusterConfigurations.TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return ValkeyClusterConfigurations.SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return ValkeyClusterConfigurations.REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return ValkeyClusterConfigurations.CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return ValkeyClusterConfigurations.CLIENTSET_INFO_CONFIG_DISABLED;
+        }
+    }
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyCollection.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyCollection.java
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import io.valkey.UnifiedJedis;
+import jakarta.json.bind.Jsonb;
+import org.eclipse.jnosql.communication.driver.JsonbSupplier;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+abstract class ValkeyCollection<T> implements Collection<T> {
+
+    protected static final  Jsonb JSONB = JsonbSupplier.getInstance().get();
+
+    protected final Class<T> clazz;
+
+    protected final String keyWithNameSpace;
+
+    protected final UnifiedJedis jedis;
+
+    protected final boolean isString;
+
+    ValkeyCollection(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
+        this.clazz = clazz;
+        this.keyWithNameSpace = keyWithNameSpace;
+        this.jedis = jedis;
+        this.isString = String.class.equals(clazz);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        Objects.requireNonNull(c);
+        for (T bean : c) {
+            if (bean != null) {
+                add(bean);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int size() {
+        return (int) jedis.llen(keyWithNameSpace);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return indexOf(o) != -1;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return toArrayList().iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return toArrayList().toArray();
+    }
+
+    @Override
+    public <E> E[] toArray(E[] a) {
+        return toArrayList().toArray(a);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Use add all instead");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean containsAll(Collection<?> elements) {
+        Objects.requireNonNull(elements);
+        boolean containsAll = true;
+        for (T element : (Collection<T>) elements) {
+            if (!contains(element)) {
+                containsAll = false;
+                break;
+            }
+        }
+        return containsAll;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean removeAll(Collection<?> elements) {
+        Objects.requireNonNull(elements);
+        boolean result = false;
+        for (T element : (Collection<T>) elements) {
+            if (remove(element)) {
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (!clazz.isInstance(o)) {
+            throw new ClassCastException("The object required is " + clazz.getName());
+        }
+        int index = indexOf(o);
+
+        if (index == -1) {
+            return false;
+        } else {
+            remove(index);
+        }
+
+        return true;
+    }
+
+    protected T remove(int index) {
+        String value = jedis.lindex(keyWithNameSpace, (long) index);
+        if (value != null && !value.isEmpty()) {
+            jedis.lrem(keyWithNameSpace, 1, value);
+            return serialize(value);
+        }
+        return null;
+    }
+
+
+    protected int indexOf(Object o) {
+        if (!clazz.isInstance(o)) {
+            return -1;
+        }
+
+        String value = serialize(o);
+        for (int index = 0; index < size(); index++) {
+            String findedValue = jedis.lindex(keyWithNameSpace, (long) index);
+            if (value.equals(findedValue)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+
+    protected List<T> toArrayList() {
+        List<T> list = new ArrayList<>();
+        for (int index = 0; index < size(); index++) {
+            T element = get(index);
+            if (element != null) {
+                list.add(element);
+            }
+        }
+        return list;
+    }
+
+    protected T get(int index) {
+        String value = jedis.lindex(keyWithNameSpace, index);
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return serialize(value);
+    }
+
+
+    protected T serialize(String value) {
+        if(isString) {
+            return (T) value;
+        }
+        return JSONB.fromJson(value,clazz);
+    }
+
+    protected String serialize(Object value) {
+        if(value instanceof String) {
+            return value.toString();
+        }
+        return JSONB.toJson(value);
+    }
+
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(keyWithNameSpace);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (ValkeyCollection.class.isInstance(obj)) {
+            ValkeyCollection otherRedis = ValkeyCollection.class.cast(obj);
+            return Objects.equals(otherRedis.keyWithNameSpace, keyWithNameSpace);
+        }
+        return false;
+    }
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfiguration.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfiguration.java
@@ -1,0 +1,241 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import io.valkey.ClientSetInfoConfig;
+import io.valkey.ConnectionPoolConfig;
+import io.valkey.DefaultJedisClientConfig;
+import io.valkey.HostAndPort;
+import io.valkey.JedisClientConfig;
+import io.valkey.JedisCluster;
+import io.valkey.JedisPooled;
+import io.valkey.JedisSentineled;
+import io.valkey.RedisProtocol;
+import io.valkey.UnifiedJedis;
+import org.eclipse.jnosql.communication.Configurations;
+import org.eclipse.jnosql.communication.Settings;
+import org.eclipse.jnosql.communication.SettingsBuilder;
+import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
+
+
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+
+/**
+ * The redis implementation of {@link KeyValueConfiguration} whose returns {@link ValkeyBucketManagerFactory}.
+ *
+ * @see ValkeyConfigurations
+ */
+public final class ValkeyConfiguration implements KeyValueConfiguration {
+
+    private static final int DEFAULT_PORT = 6379;
+    private static final String DEFAULT_HOST = "localhost";
+
+    /**
+     * Creates a {@link ValkeyConfiguration} from map configuration
+     *
+     * @param configurations the map configuration
+     * @return the RedisConfiguration instance
+     */
+    public ValkeyBucketManagerFactory getManagerFactory(Map<String, String> configurations) {
+        Objects.requireNonNull(configurations, "configurations is required");
+        SettingsBuilder builder = Settings.builder();
+        configurations.forEach(builder::put);
+        return apply(builder.build());
+    }
+
+    @Override
+    public ValkeyBucketManagerFactory apply(Settings settings) {
+        Objects.requireNonNull(settings, "settings is required");
+
+        if (settings.keySet()
+                .stream()
+                .anyMatch(s -> s.startsWith(ValkeySentinelConfigurations.SENTINEL.get()))) {
+            return applyForSentinel(settings);
+        }
+
+        if (settings.keySet()
+                .stream()
+                .anyMatch(s -> s.startsWith(ValkeyClusterConfigurations.CLUSTER.get()))) {
+            return applyForCluster(settings);
+        }
+
+        var simpleJedisConfig = getJedisClientConfig(
+                ValkeyConfigurations.SingleValkeyConfigurationsResolver.INSTANCE, settings);
+
+        HostAndPort hostAndPort = getHostAndPort(settings);
+
+        ConnectionPoolConfig connectionPoolConfig = getConnectionPoolConfig(settings);
+
+        UnifiedJedis jedis = new JedisPooled(
+                connectionPoolConfig,
+                hostAndPort,
+                simpleJedisConfig);
+
+        return new DefaultValkeyBucketManagerFactory(jedis);
+    }
+
+    private HostAndPort getHostAndPort(Settings settings) {
+        String localhost = settings
+                .getSupplier(asList(ValkeyConfigurations.HOST, Configurations.HOST))
+                .map(Object::toString).orElse(DEFAULT_HOST);
+
+        Integer port = settings.get(ValkeyConfigurations.PORT)
+                .map(Object::toString).map(Integer::parseInt)
+                .orElse(DEFAULT_PORT);
+        return new HostAndPort(localhost, port);
+    }
+
+    private ValkeyBucketManagerFactory applyForCluster(Settings settings) {
+
+        Set<HostAndPort> clusterNodes = settings.get(ValkeyClusterConfigurations.CLUSTER_HOSTS)
+                .map(Object::toString)
+                .map(h -> h.split(","))
+                .map(h -> Arrays.stream(h).map(HostAndPort::from).collect(Collectors.toSet()))
+                .orElseThrow(() -> new IllegalArgumentException("The cluster nodes are required"));
+
+        JedisClientConfig clientConfig = getJedisClientConfig(
+                ValkeyClusterConfigurations.ClusterConfigurationsResolver.INSTANCE, settings);
+
+        int maxAttempts = settings.get(ValkeyClusterConfigurations.CLUSTER_MAX_ATTEMPTS)
+                .map(Object::toString).map(Integer::parseInt)
+                .orElse(JedisCluster.DEFAULT_MAX_ATTEMPTS);
+
+        Duration maxTotalRetriesDuration = settings
+                .get(ValkeyClusterConfigurations.CLUSTER_MAX_TOTAL_RETRIES_DURATION)
+                .map(Object::toString).map(Duration::parse)
+                .orElse(Duration.ofMillis((long) clientConfig.getSocketTimeoutMillis() * maxAttempts));
+
+        ConnectionPoolConfig poolConfig = getConnectionPoolConfig(settings);
+
+        JedisCluster jedis = new JedisCluster(
+                clusterNodes,
+                clientConfig,
+                maxAttempts,
+                maxTotalRetriesDuration,
+                poolConfig);
+        return new DefaultValkeyBucketManagerFactory(jedis);
+    }
+
+    private ValkeyBucketManagerFactory applyForSentinel(Settings settings) {
+
+        String masterName = settings.get(ValkeySentinelConfigurations.SENTINEL_MASTER_NAME)
+                .map(Object::toString)
+                .orElseThrow(() -> new IllegalArgumentException("The sentinel master name is required"));
+
+        Set<HostAndPort> hostAndPorts = settings.get(ValkeySentinelConfigurations.SENTINEL_HOSTS)
+                .map(Object::toString)
+                .map(h -> h.split(","))
+                .map(h -> Arrays.stream(h).map(HostAndPort::from).collect(Collectors.toSet()))
+                .orElseThrow(() -> new IllegalArgumentException("The sentinel hosts are required"));
+
+        ConnectionPoolConfig connectionPoolConfig = getConnectionPoolConfig(settings);
+
+        var masterJedisClientConfig = getJedisClientConfig(
+                ValkeySentinelConfigurations.SentinelMasterConfigurationsResolver.INSTANCE,settings);
+
+        var slaveJedisClientConfig = getJedisClientConfig(
+                ValkeySentinelConfigurations.SentinelMasterConfigurationsResolver.INSTANCE, settings);
+
+        JedisSentineled jedis = new JedisSentineled(masterName,
+                masterJedisClientConfig,
+                connectionPoolConfig,
+                hostAndPorts,
+                slaveJedisClientConfig);
+
+        return new DefaultValkeyBucketManagerFactory(jedis);
+    }
+
+    private JedisClientConfig getJedisClientConfig(ValkeyConfigurationsResolver resolver, Settings settings) {
+
+        DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder();
+
+        settings.get(resolver.connectionTimeoutSupplier())
+                .map(Object::toString).map(Integer::parseInt)
+                .ifPresent(builder::connectionTimeoutMillis);
+
+        settings.get(resolver.socketTimeoutSupplier())
+                .map(Object::toString).map(Integer::parseInt)
+                .ifPresent(builder::socketTimeoutMillis);
+
+        settings.get(resolver.clientNameSupplier())
+                .map(Object::toString)
+                .ifPresent(builder::clientName);
+
+        settings.get(resolver.userSupplier())
+                .map(Object::toString)
+                .ifPresent(builder::user);
+
+        settings.get(resolver.passwordSupplier())
+                .map(Object::toString)
+                .ifPresent(builder::password);
+
+        settings.get(resolver.timeoutSupplier())
+                .map(Object::toString).map(Integer::parseInt)
+                .ifPresent(builder::timeoutMillis);
+
+        settings.get(resolver.sslSupplier())
+                .map(Object::toString).map(Boolean::parseBoolean)
+                .ifPresent(builder::ssl);
+
+        settings.get(resolver.redisProtocolSupplier())
+                .map(Object::toString).map(RedisProtocol::valueOf)
+                .ifPresent(builder::protocol);
+
+        settings.get(resolver.clientsetInfoConfigLibNameSuffixSupplier())
+                .map(Object::toString)
+                .ifPresentOrElse(
+                        libNameSuffix -> builder.clientSetInfoConfig(new ClientSetInfoConfig(libNameSuffix)),
+                        () -> settings.get(resolver.clientsetInfoConfigDisabled())
+                                .map(Object::toString)
+                                .map(Boolean::parseBoolean)
+                                .map(disabled -> disabled ? ClientSetInfoConfig.DISABLED : ClientSetInfoConfig.DEFAULT)
+                                .ifPresent(builder::clientSetInfoConfig));
+
+        return builder.build();
+    }
+
+    private ConnectionPoolConfig getConnectionPoolConfig(Settings settings) {
+
+        ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+
+        settings.get(ValkeyConfigurations.MAX_TOTAL)
+                .map(Object::toString).map(Integer::parseInt)
+                .ifPresent(poolConfig::setMaxTotal);
+
+        settings.get(ValkeyConfigurations.MAX_IDLE)
+                .map(Object::toString).map(Integer::parseInt)
+                .ifPresent(poolConfig::setMaxIdle);
+
+        settings.get(ValkeyConfigurations.MIN_IDLE)
+                .map(Object::toString).map(Integer::parseInt)
+                .ifPresent(poolConfig::setMinIdle);
+
+        settings.get(ValkeyConfigurations.MAX_WAIT_MILLIS)
+                .map(Object::toString).map(Integer::parseInt)
+                .ifPresent(poolConfig::setMaxWaitMillis);
+
+        return poolConfig;
+    }
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurations.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurations.java
@@ -1,0 +1,180 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import java.util.function.Supplier;
+
+/**
+ * An enumeration to show the available options to connect to the Redis database.
+ * It implements {@link Supplier}, where its it returns the property name that might be
+ * overwritten by the system environment using Eclipse Microprofile or Jakarta Config API.
+ *
+ * @see org.eclipse.jnosql.communication.Settings
+ */
+public enum ValkeyConfigurations implements Supplier<String> {
+
+    /**
+     * The database host
+     */
+    HOST("jnosql.valkey.host"),
+    /**
+     * The database port
+     */
+    PORT("jnosql.valkey.port"),
+    /**
+     * The redis timeout, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT} on milliseconds
+     */
+    TIMEOUT("jnosql.valkey.timeout"),
+    /**
+     * The password's credential
+     */
+    PASSWORD("jnosql.valkey.password"),
+    /**
+     * The redis database number
+     */
+    DATABASE("jnosql.valkey.database"),
+    /**
+     * The cluster client's name. The default value is 0.
+     */
+    CLIENT_NAME("jnosql.valkey.client.name"),
+    /**
+     * The value for the maxTotal configuration attribute for pools created with this configuration instance.
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MAX_TOTAL}
+     */
+    MAX_TOTAL("jnosql.valkey.max.total"),
+    /**
+     * The value for the maxIdle configuration attribute for pools created with this configuration instance.
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MAX_IDLE}
+     */
+    MAX_IDLE("jnosql.valkey.max.idle"),
+    /**
+     * The value for the minIdle configuration attribute for pools created with this configuration instance.
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MIN_IDLE}
+     */
+    MIN_IDLE("jnosql.valkey.min.idle"),
+    /**
+     * The value for the {@code maxWait} configuration attribute for pools created with this configuration instance.
+     * The default value is {@link org.apache.commons.pool2.impl.GenericObjectPoolConfig#DEFAULT_MAX_WAIT_MILLIS}
+     */
+    MAX_WAIT_MILLIS("jnosql.valkey.max.wait.millis"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    CONNECTION_TIMEOUT("jnosql.valkey.connection.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    SOCKET_TIMEOUT("jnosql.valkey.socket.timeout"),
+    /**
+     * The value for the user configuration attribute for the jedis client configuration with this configuration instance.
+     * The user on {@link io.valkey.JedisClientConfig}
+     */
+    USER("jnosql.valkey.user"),
+    /**
+     * The value for the ssl configuration attribute for the jedis client configuration with this configuration instance.
+     * The ssl on {@link io.valkey.JedisClientConfig}. The default value is false.
+     */
+    SSL("jnosql.valkey.ssl"),
+    /**
+     * The value for the protocol configuration attribute for the jedis client configuration with this configuration instance.
+     * The protocol on {@link io.valkey.JedisClientConfig}.
+     * The default value is not defined.
+     */
+    REDIS_PROTOCOL("jnosql.valkey.protocol"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link io.valkey.JedisClientConfig}.
+     * The default value is false.
+     */
+    CLIENTSET_INFO_CONFIG_DISABLED("jnosql.valkey.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link io.valkey.JedisClientConfig}.
+     * The default value is not defined.
+     */
+    CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.valkey.clientset.info.config.libname.suffix"),;
+
+    private final String configuration;
+
+    ValkeyConfigurations(String configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String get() {
+        return configuration;
+    }
+
+    public static enum SingleValkeyConfigurationsResolver
+            implements ValkeyConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return ValkeyConfigurations.CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return ValkeyConfigurations.SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return ValkeyConfigurations.CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return ValkeyConfigurations.USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return ValkeyConfigurations.PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return ValkeyConfigurations.TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return ValkeyConfigurations.SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return ValkeyConfigurations.REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return ValkeyConfigurations.CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return ValkeyConfigurations.CLIENTSET_INFO_CONFIG_DISABLED;
+        }
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationsResolver.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationsResolver.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import java.util.function.Supplier;
+
+public sealed interface ValkeyConfigurationsResolver permits
+        ValkeyConfigurations.SingleValkeyConfigurationsResolver,
+        ValkeyClusterConfigurations.ClusterConfigurationsResolver,
+        ValkeySentinelConfigurations.SentinelMasterConfigurationsResolver,
+        ValkeySentinelConfigurations.SentinelSlaveConfigurationsResolver {
+
+    Supplier<String> connectionTimeoutSupplier();
+
+    Supplier<String> socketTimeoutSupplier();
+
+    Supplier<String> clientNameSupplier();
+
+    Supplier<String> userSupplier();
+
+    Supplier<String> passwordSupplier();
+
+    Supplier<String> timeoutSupplier();
+
+    Supplier<String> sslSupplier();
+
+    Supplier<String> redisProtocolSupplier();
+
+    Supplier<String> clientsetInfoConfigLibNameSuffixSupplier();
+
+    Supplier<String> clientsetInfoConfigDisabled();
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyList.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyList.java
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import io.valkey.UnifiedJedis;
+import io.valkey.args.ListPosition;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+
+class ValkeyList<T> extends ValkeyCollection<T> implements List<T> {
+
+
+    ValkeyList(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
+        super(jedis, clazz, keyWithNameSpace);
+    }
+
+    @Override
+    public int size() {
+        return (int) jedis.llen(keyWithNameSpace);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+
+    @Override
+    public ListIterator<T> listIterator() {
+        return toArrayList().listIterator();
+    }
+
+    @Override
+    public ListIterator<T> listIterator(int index) {
+        return toArrayList().listIterator(index);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return toArrayList().iterator();
+    }
+
+    @Override
+    public boolean add(T e) {
+        Objects.requireNonNull(e);
+        int index = size();
+        if (index == 0) {
+            if(isString) {
+                jedis.lpush(keyWithNameSpace, e.toString());
+            } else {
+                jedis.lpush(keyWithNameSpace, JSONB.toJson(e));
+            }
+        } else {
+            String previewValue = jedis.lindex(keyWithNameSpace, index - 1);
+            if(isString) {
+                jedis.linsert(keyWithNameSpace, ListPosition.AFTER, previewValue, e.toString());
+            }else {
+                jedis.linsert(keyWithNameSpace, ListPosition.AFTER, previewValue,
+                        JSONB.toJson(e));
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends T> elements) {
+        Objects.requireNonNull(elements);
+        for (T element : elements) {
+            add(index++, element);
+        }
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        jedis.del(keyWithNameSpace);
+    }
+
+    @Override
+    public T get(int index) {
+        return super.get(index);
+    }
+
+    @Override
+    public T set(int index, T element) {
+        Objects.requireNonNull(element);
+        if(isString) {
+            jedis.lset(keyWithNameSpace, index, element.toString());
+        } else {
+            jedis.lset(keyWithNameSpace, index, JSONB.toJson(element));
+        }
+
+        return element;
+    }
+
+    @Override
+    public void add(int index, T element) {
+        Objects.requireNonNull(element);
+        String previewValue = jedis.lindex(keyWithNameSpace, index);
+        if (previewValue != null && !previewValue.isEmpty()) {
+            if(isString) {
+                jedis.linsert(keyWithNameSpace, ListPosition.BEFORE, previewValue, element.toString());
+            } else {
+                jedis.linsert(keyWithNameSpace, ListPosition.BEFORE, previewValue, JSONB.toJson(element));
+            }
+
+        } else {
+            add(element);
+        }
+
+    }
+
+    @Override
+    public T remove(int index) {
+        return super.remove(index);
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return super.indexOf(o);
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        Objects.requireNonNull(o);
+
+        String value = serialize(o);
+        for (int index = size(); index > 0; --index) {
+            String findedValue = jedis.lindex(keyWithNameSpace, (long) index);
+            if (value.equals(findedValue)) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public List<T> subList(int fromIndex, int toIndex) {
+        List<T> subList = new ArrayList<>();
+        List<String> elements = jedis.lrange(keyWithNameSpace, fromIndex, toIndex);
+        for (String element : elements) {
+            if(isString) {
+                subList.add((T) element);
+            } else {
+                subList.add(JSONB.fromJson(element, clazz));
+            }
+        }
+        return subList;
+    }
+
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMap.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMap.java
@@ -1,0 +1,237 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import io.valkey.UnifiedJedis;
+import jakarta.json.bind.Jsonb;
+import org.eclipse.jnosql.communication.driver.JsonbSupplier;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+class ValkeyMap<K, V> implements Map<K, V> {
+
+
+    protected static final Jsonb JSONB = JsonbSupplier.getInstance().get();
+
+    private final Class<K> keyClass;
+
+    private final Class<V> valueClass;
+
+    private final String nameSpace;
+
+    private final UnifiedJedis jedis;
+
+    private final boolean isKeyString;
+
+    private final boolean isValueString;
+
+    ValkeyMap(UnifiedJedis jedis, Class<K> keyValue, Class<V> valueClass, String keyWithNameSpace) {
+        this.keyClass = keyValue;
+        this.valueClass = valueClass;
+        this.nameSpace = keyWithNameSpace;
+        this.jedis = jedis;
+        this.isKeyString = String.class.equals(keyClass);
+        this.isValueString = String.class.equals(valueClass);
+    }
+
+    @Override
+    public int size() {
+        return jedis.hgetAll(nameSpace).size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size() == 0;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        requireNonNull(key, "key is required");
+        if (isKeyString) {
+            return jedis.hexists(nameSpace, key.toString());
+        } else {
+            return jedis.hexists(nameSpace, JSONB.toJson(key));
+        }
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        requireNonNull(value);
+        String valueString;
+        if (isValueString) {
+            valueString = value.toString();
+        } else {
+            valueString = JSONB.toJson(value);
+        }
+
+        Map<String, String> map = createRedisMap();
+        return map.containsValue(valueString);
+    }
+
+    @Override
+    public V get(Object key) {
+        requireNonNull(key, "Key is required");
+
+        String value = jedis.hget(nameSpace, JSONB.toJson(key));
+        if (isKeyString) {
+            value = jedis.hget(nameSpace, key.toString());
+        } else {
+            value = jedis.hget(nameSpace, JSONB.toJson(key));
+        }
+        if (value != null && !value.isEmpty()) {
+            if (isValueString) {
+                return (V) value;
+            } else {
+                return JSONB.fromJson(value, valueClass);
+            }
+
+        }
+        return null;
+    }
+
+    @Override
+    public V put(K key, V value) {
+        requireNonNull(value, "Value is required");
+        requireNonNull(value, "Key is required");
+
+        String keyJson;
+        if(isKeyString) {
+            keyJson = key.toString();
+        } else {
+             keyJson = JSONB.toJson(key);
+        }
+        String valueJSON;
+
+        if(isValueString) {
+            valueJSON = value.toString();
+        } else {
+            valueJSON = JSONB.toJson(value);
+        }
+        jedis.hset(nameSpace, keyJson, valueJSON);
+        return value;
+    }
+
+    @Override
+    public V remove(Object key) {
+        requireNonNull(key, "Key is required");
+        V value = get(key);
+        if (value != null) {
+            if (isKeyString) {
+                jedis.hdel(nameSpace, key.toString());
+            } else {
+                jedis.hdel(nameSpace, JSONB.toJson(key));
+            }
+
+            return value;
+        }
+        return null;
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
+        requireNonNull(map, "map is required");
+
+        for (K key : map.keySet()) {
+            V value = map.get(key);
+            if (value != null) {
+                put(key, value);
+            }
+        }
+    }
+
+    @Override
+    public void clear() {
+        jedis.del(nameSpace);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return createHashMap().keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return createHashMap().values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return createHashMap().entrySet();
+    }
+
+    private Map<String, String> createRedisMap() {
+        return jedis.hgetAll(nameSpace);
+    }
+
+    private Map<K, V> createHashMap() {
+        Map<K, V> values = new HashMap<>();
+        Map<String, String> redisMap = createRedisMap();
+        final Function<String, K> keyFunction = k -> {
+            if(isKeyString) {
+                return (K) k;
+            } else {
+                return JSONB.fromJson(k, keyClass);
+            }
+        };
+        final Function<String, V> valueFunction = k -> {
+            if(isValueString) {
+                return (V) redisMap.get(k);
+            } else {
+                return JSONB.fromJson(redisMap.get(k), valueClass);
+            }
+        };
+        return redisMap.keySet().stream().collect(Collectors
+                .toMap(keyFunction, valueFunction));
+    }
+
+
+    @Override
+    public String toString() {
+        return "RedisMap{" + "keyClass=" + keyClass +
+                ", valueClass=" + valueClass +
+                ", nameSpace='" + nameSpace + '\'' +
+                ", jedis=" + jedis +
+                ", JsonB=" + JSONB +
+                '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(nameSpace);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (ValkeyMap.class.isInstance(obj)) {
+            ValkeyMap otherRedis = ValkeyMap.class.cast(obj);
+            return Objects.equals(otherRedis.nameSpace, nameSpace);
+        }
+        return false;
+    }
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyQueue.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyQueue.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import io.valkey.UnifiedJedis;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Queue;
+
+class ValkeyQueue<T> extends ValkeyCollection<T> implements Queue<T> {
+
+    ValkeyQueue(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
+        super(jedis, clazz, keyWithNameSpace);
+    }
+
+    @Override
+    public void clear() {
+        jedis.del(keyWithNameSpace);
+    }
+
+    @Override
+    public boolean add(T e) {
+        Objects.requireNonNull(e);
+        if(isString){
+            jedis.rpush(keyWithNameSpace, e.toString());
+        } else {
+            jedis.rpush(keyWithNameSpace, JSONB.toJson(e));
+        }
+        return true;
+    }
+
+    @Override
+    public boolean offer(T e) {
+        return add(e);
+    }
+
+    @Override
+    public T remove() {
+        T value = poll();
+        if (value == null) {
+            throw new NoSuchElementException("No element in Redis Queue");
+        }
+        return value;
+    }
+
+    @Override
+    public T poll() {
+        String value = jedis.lpop(keyWithNameSpace);
+        if (value != null && !value.isEmpty()) {
+            if(isString){
+                return (T) value;
+            } else {
+                return JSONB.fromJson(value, clazz);
+            }
+
+        }
+        return null;
+    }
+
+    @Override
+    public T element() {
+        T value = peek();
+        if (value == null) {
+            throw new NoSuchElementException("No element in Redis Queue");
+        }
+        return value;
+    }
+
+    @Override
+    public T peek() {
+        int index = size();
+        if (index == 0) {
+            return null;
+        }
+        if(isString) {
+            return (T) jedis.lindex(keyWithNameSpace, (long) index - 1);
+        } else {
+            return JSONB.fromJson(jedis.lindex(keyWithNameSpace, (long) index - 1), clazz);
+        }
+
+
+    }
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySentinelConfigurations.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySentinelConfigurations.java
@@ -1,0 +1,261 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import java.util.function.Supplier;
+
+/**
+ * An enumeration to show the available options to connect to the Redis database by Sentinel configuration .
+ * It implements {@link Supplier}, where its it returns the property name that might be
+ * overwritten by the system environment using Eclipse Microprofile or Jakarta Config API.
+ *
+ * @see org.eclipse.jnosql.communication.Settings
+ */
+public enum ValkeySentinelConfigurations implements Supplier<String> {
+    /**
+     * The key property that defines if the redis sentinel configuration should be loaded
+     * */
+    SENTINEL("jnosql.valkey.sentinel"),
+    /**
+     * The value for the master name configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    SENTINEL_MASTER_NAME("jnosql.valkey.sentinel.master.name"),
+    /**
+     * The value for the sentinel HOST:PORT (separated by comma) configuration attribute for the jedis client configuration with this configuration instance.
+     */
+    SENTINEL_HOSTS("jnosql.valkey.sentinel.hosts"),
+    /**
+     * The master client's name, the default value is 0
+     */
+    MASTER_CLIENT_NAME("jnosql.valkey.sentinel.master.client.name"),
+    /**
+     * The slave client's name, the default value is 0
+     */
+    SLAVE_CLIENT_NAME("jnosql.valkey.sentinel.slave.client.name"),
+    /**
+     * The master redis timeout, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT} on milliseconds
+     */
+    MASTER_TIMEOUT("jnosql.valkey.sentinel.master.timeout"),
+    /**
+     * The slave redis timeout, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT} on milliseconds
+     */
+    SLAVE_TIMEOUT("jnosql.valkey.sentinel.slave.timeout"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the master jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    MASTER_CONNECTION_TIMEOUT("jnosql.valkey.sentinel.master.connection.timeout"),
+    /**
+     * The value for the connection timeout in milliseconds configuration attribute for the slave jedis client configuration
+     * created with this configuration instance.
+     * The connection timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    SLAVE_CONNECTION_TIMEOUT("jnosql.valkey.sentinel.slave.connection.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the master jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    MASTER_SOCKET_TIMEOUT("jnosql.valkey.sentinel.master.socket.timeout"),
+    /**
+     * The value for the socket timeout in milliseconds configuration attribute for the slave jedis client configuration with
+     * this configuration instance.
+     * The socket timeout on millis on {@link io.valkey.JedisClientConfig}, the default value is {@link io.valkey.Protocol#DEFAULT_TIMEOUT}
+     */
+    SLAVE_SOCKET_TIMEOUT("jnosql.valkey.sentinel.slave.socket.timeout"),
+    /**
+     * The value for the user configuration attribute for the master jedis client configuration with this configuration instance.
+     * The user on {@link io.valkey.JedisClientConfig}
+     */
+    MASTER_USER("jnosql.valkey.sentinel.master.user"),
+    /**
+     * The value for the user configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The user on {@link io.valkey.JedisClientConfig}
+     */
+    SLAVE_USER("jnosql.valkey.sentinel.slave.user"),
+    /**
+     * The value for the password configuration attribute for the master jedis client configuration with this configuration instance.
+     * The user on {@link io.valkey.JedisClientConfig}
+     */
+    MASTER_PASSWORD("jnosql.valkey.sentinel.master.password"),
+    /**
+     * The value for the password configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The user on {@link io.valkey.JedisClientConfig}
+     */
+    SLAVE_PASSWORD("jnosql.valkey.sentinel.slave.password"),
+    /**
+     * The value for the ssl configuration attribute for the master jedis client configuration with this configuration instance.
+     * The ssl on {@link io.valkey.JedisClientConfig}. The default value is false.
+     */
+    MASTER_SSL("jnosql.valkey.sentinel.master.ssl"),
+    /**
+     * The value for the ssl configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The ssl on {@link io.valkey.JedisClientConfig}. The default value is false
+     */
+    SLAVE_SSL("jnosql.valkey.sentinel.slave.ssl"),
+    /**
+     * The value for the protocol configuration attribute for the master jedis client configuration with this configuration instance.
+     * The protocol on {@link io.valkey.JedisClientConfig}
+     */
+    MASTER_REDIS_PROTOCOL("jnosql.valkey.sentinel.master.protocol"),
+    /**
+     * The value for the protocol configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The protocol on {@link io.valkey.JedisClientConfig}
+     */
+    SLAVE_REDIS_PROTOCOL("jnosql.valkey.sentinel.slave.protocol"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the master jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link io.valkey.JedisClientConfig}
+     */
+    MASTER_CLIENTSET_INFO_CONFIG_DISABLED("jnosql.valkey.sentinel.master.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info disabled configuration attribute for the slave jedis client configuration with this configuration instance.
+     * The clientset info disabled on {@link io.valkey.JedisClientConfig}
+     */
+    SLAVE_CLIENTSET_INFO_CONFIG_DISABLED("jnosql.valkey.sentinel.slave.clientset.info.config.disabled"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the master jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link io.valkey.JedisClientConfig}
+     */
+    MASTER_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.valkey.sentinel.master.clientset.info.config.libname.suffix"),
+    /**
+     * The value for the clientset info configuration libname suffix attribute for the slave jedis client configuration with this configuration instance.
+     * The clientset info libname suffix on {@link io.valkey.JedisClientConfig}
+     */
+    SLAVE_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX("jnosql.valkey.sentinel.slave.clientset.info.config.libname.suffix");
+
+    private final String configuration;
+
+    ValkeySentinelConfigurations(String configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String get() {
+        return configuration;
+    }
+
+    public static enum SentinelMasterConfigurationsResolver implements ValkeyConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return ValkeySentinelConfigurations.MASTER_CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return ValkeySentinelConfigurations.MASTER_SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return ValkeySentinelConfigurations.MASTER_CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return ValkeySentinelConfigurations.MASTER_USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return ValkeySentinelConfigurations.MASTER_PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return ValkeySentinelConfigurations.MASTER_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return ValkeySentinelConfigurations.MASTER_SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return ValkeySentinelConfigurations.MASTER_REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return ValkeySentinelConfigurations.MASTER_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return ValkeySentinelConfigurations.MASTER_CLIENTSET_INFO_CONFIG_DISABLED;
+        }
+    }
+
+    public enum SentinelSlaveConfigurationsResolver implements ValkeyConfigurationsResolver {
+
+        INSTANCE;
+
+        @Override
+        public Supplier<String> connectionTimeoutSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_CONNECTION_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> socketTimeoutSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_SOCKET_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> clientNameSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_CLIENT_NAME;
+        }
+
+        @Override
+        public Supplier<String> userSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_USER;
+        }
+
+        @Override
+        public Supplier<String> passwordSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_PASSWORD;
+        }
+
+        @Override
+        public Supplier<String> timeoutSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_TIMEOUT;
+        }
+
+        @Override
+        public Supplier<String> sslSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_SSL;
+        }
+
+        @Override
+        public Supplier<String> redisProtocolSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_REDIS_PROTOCOL;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigLibNameSuffixSupplier() {
+            return ValkeySentinelConfigurations.SLAVE_CLIENTSET_INFO_CONFIG_LIBNAME_SUFFIX;
+        }
+
+        @Override
+        public Supplier<String> clientsetInfoConfigDisabled() {
+            return ValkeySentinelConfigurations.SLAVE_CLIENTSET_INFO_CONFIG_DISABLED;
+        }
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySet.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySet.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import io.valkey.UnifiedJedis;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+class ValkeySet<T> extends ValkeyCollection<T> implements Set<T> {
+
+    ValkeySet(UnifiedJedis jedis, Class<T> clazz, String keyWithNameSpace) {
+        super(jedis, clazz, keyWithNameSpace);
+    }
+
+    @Override
+    public boolean add(T e) {
+        Objects.requireNonNull(e);
+        if (isString) {
+            jedis.sadd(keyWithNameSpace, e.toString());
+        } else {
+            jedis.sadd(keyWithNameSpace, JSONB.toJson(e));
+        }
+        return true;
+    }
+
+    @Override
+    public void clear() {
+        jedis.del(keyWithNameSpace);
+    }
+
+    @Override
+    public int size() {
+        return (int) jedis.scard(keyWithNameSpace);
+    }
+
+    @Override
+    protected int indexOf(Object o) {
+        Objects.requireNonNull(o);
+
+        String find = serialize(o);
+        Set<String> values = jedis.smembers(keyWithNameSpace);
+        int index = 0;
+        for (String value : values) {
+            if (value.contains(find)) {
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }
+
+    @Override
+    protected T remove(int index) {
+        throw new UnsupportedOperationException("Remove with index is not supported on Redis Set");
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (!clazz.isInstance(o)) {
+            throw new ClassCastException("The object required is " + clazz.getName());
+        }
+        String find = serialize(o);
+        Set<String> values = jedis.smembers(keyWithNameSpace);
+        for (String value : values) {
+            if (value.contains(find)) {
+                jedis.srem(keyWithNameSpace, value);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected List<T> toArrayList() {
+        Set<String> redisValues = jedis.smembers(keyWithNameSpace);
+        List<T> list = new ArrayList<>();
+        for (String redisValue : redisValues) {
+            if (isString) {
+                list.add((T) redisValue);
+            } else {
+                list.add(JSONB.fromJson(redisValue, clazz));
+            }
+
+        }
+        return list;
+    }
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtils.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtils.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+abstract class ValkeyUtils {
+
+
+    public static String createKeyWithNameSpace(String key, String nameSpace) {
+        if (key == null || key.isEmpty()) {
+            throw new IrregularKeyValue("Key in KeyvalueStructure cannont be empty");
+        }
+        return nameSpace + ":" + key;
+    }
+
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/package-info.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/package-info.java
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+/**
+ * The Redis key-value implementation
+ */
+package org.eclipse.jnosql.databases.valkey.communication;

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/BucketManagerFactorySupplier.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/BucketManagerFactorySupplier.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2023 Eclipse Contribuitor
+ * All rights reserved. This program and the accompanying materials
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.valkey.mapping;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.Typed;
+import org.eclipse.jnosql.communication.Settings;
+import org.eclipse.jnosql.databases.valkey.communication.ValkeyBucketManagerFactory;
+import org.eclipse.jnosql.databases.valkey.communication.ValkeyConfiguration;
+import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@ApplicationScoped
+class BucketManagerFactorySupplier implements Supplier<ValkeyBucketManagerFactory> {
+
+    private static final Logger LOGGER = Logger.getLogger(BucketManagerFactorySupplier.class.getName());
+
+    @Override
+    @Produces
+    @Typed(ValkeyBucketManagerFactory.class)
+    public ValkeyBucketManagerFactory get() {
+        Settings settings = MicroProfileSettings.INSTANCE;
+        ValkeyConfiguration configuration = new ValkeyConfiguration();
+        return configuration.apply(settings);
+    }
+
+    public void close(@Disposes ValkeyBucketManagerFactory factory) {
+        LOGGER.log(Level.FINEST, "Closing RedisBucketManagerFactory resource");
+        factory.close();
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/CollectionSupplier.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/CollectionSupplier.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2023 Eclipse Contribuitor
+ * All rights reserved. This program and the accompanying materials
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.valkey.mapping;
+
+import jakarta.data.exceptions.MappingException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.databases.valkey.communication.Counter;
+import org.eclipse.jnosql.databases.valkey.communication.ValkeyBucketManagerFactory;
+import org.eclipse.jnosql.databases.valkey.communication.SortedSet;
+import org.eclipse.jnosql.mapping.keyvalue.KeyValueDatabase;
+
+
+@ApplicationScoped
+class CollectionSupplier {
+
+
+    @Inject
+    private ValkeyBucketManagerFactory factory;
+
+
+    @Produces
+    @KeyValueDatabase("")
+    public Counter getSet(InjectionPoint injectionPoint) {
+        return factory.getCounter(bucketName(injectionPoint));
+    }
+
+    @Produces
+    @KeyValueDatabase("")
+    public SortedSet getRanking(InjectionPoint injectionPoint) {
+        return factory.getSortedSet(bucketName(injectionPoint));
+    }
+
+
+    private static String bucketName(InjectionPoint injectionPoint) {
+
+        KeyValueDatabase keyValue = injectionPoint.getQualifiers()
+                .stream().filter(KeyValueDatabase.class::isInstance)
+                .map(KeyValueDatabase.class::cast)
+                .findFirst().orElseThrow(() -> new MappingException("There is an issue to load " +
+                        "a Collection from the database"));
+        return keyValue.value();
+    }
+}

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/package-info.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+/**
+ * Valkey is a software project that implements data structure servers. It is open-source, networked, in-memory,
+ * and stores keys with optional durability.
+ */
+package org.eclipse.jnosql.databases.valkey;

--- a/jnosql-valkey/src/main/resources/META-INF/beans.xml
+++ b/jnosql-valkey/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Otavio Santana
+  -->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
+</beans>

--- a/jnosql-valkey/src/main/resources/META-INF/services/org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration
+++ b/jnosql-valkey/src/main/resources/META-INF/services/org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration
@@ -1,0 +1,1 @@
+org.eclipse.jnosql.databases.valkey.communication.ValkeyConfiguration

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounterTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounterTest.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.time.Duration;
+
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class DefaultCounterTest {
+
+    private ValkeyBucketManagerFactory keyValueEntityManagerFactory;
+    private Counter counter;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        counter = keyValueEntityManagerFactory.getCounter("counter-redis");
+        counter.delete();
+    }
+
+    @Test
+    public void shouldIncrement() {
+        assertEquals(1D, counter.increment());
+        assertEquals(10D, counter.increment(9));
+    }
+
+    @Test
+    public void shouldDecrement() {
+        counter.increment(10.15);
+        assertEquals(9.15D, counter.decrement());
+        assertEquals(0.15D, counter.decrement(9));
+    }
+
+    @Test
+    public void shouldGet() {
+        counter.increment(10.15);
+        assertEquals(10.15D, counter.get().doubleValue());
+    }
+
+    @Test
+    public void shouldShouldExpires() throws InterruptedException {
+        counter.increment(10.15);
+        counter.expire(Duration.ofSeconds(1));
+        Thread.sleep(2_000L);
+        assertEquals(0D, counter.get().doubleValue());
+    }
+
+    @Test
+    public void shouldPersist() throws InterruptedException {
+        counter.increment(10.15);
+        counter.expire(Duration.ofSeconds(1));
+        counter.persist();
+        Thread.sleep(2_000L);
+        assertEquals(10.15D, counter.get().doubleValue());
+    }
+
+    @Test
+    public void shouldDelete() {
+        counter.increment(10.15);
+        counter.delete();
+        assertEquals(0D, counter.get().doubleValue());
+    }
+
+    @AfterEach
+    public void removeCounter(){
+        counter.delete();
+    }
+
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSetTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSetTest.java
@@ -1,0 +1,177 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class DefaultSortedSetTest {
+
+    private static final String BRAZIL = "Brazil";
+    private static final String USA = "USA";
+    private static final String ENGLAND = "England";
+
+    private ValkeyBucketManagerFactory keyValueEntityManagerFactory;
+    private SortedSet sortedSet;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        sortedSet = keyValueEntityManagerFactory.getSortedSet("world-cup-2018");
+        sortedSet.clear();
+    }
+
+    @Test
+    public void shouldAdd() {
+        sortedSet.add(BRAZIL, 10);
+    }
+
+    @Test
+    public void shouldSize() {
+        assertTrue(sortedSet.isEmpty());
+        sortedSet.add(BRAZIL, 10);
+        assertEquals(Integer.valueOf(sortedSet.size()), Integer.valueOf(1));
+    }
+
+    @Test
+    public void shouldCheckIfEmpty() {
+
+        assertTrue(sortedSet.isEmpty());
+        sortedSet.add(BRAZIL, 1);
+        sortedSet.add(USA, 2);
+        sortedSet.add(ENGLAND, 3);
+        assertFalse(sortedSet.isEmpty());
+
+    }
+
+    @Test
+    public void souldDelete() {
+        sortedSet.add(BRAZIL, 1);
+        sortedSet.add(USA, 2);
+        sortedSet.add(ENGLAND, 3);
+        assertFalse(sortedSet.isEmpty());
+        sortedSet.delete();
+        assertTrue(sortedSet.isEmpty());
+    }
+
+    @Test
+    public void souldClear() {
+        sortedSet.add(BRAZIL, 1);
+        sortedSet.add(USA, 2);
+        sortedSet.add(ENGLAND, 3);
+        assertFalse(sortedSet.isEmpty());
+        sortedSet.clear();
+        assertTrue(sortedSet.isEmpty());
+    }
+
+    @Test
+    public void shouldIncrement() {
+        sortedSet.add(BRAZIL, 10);
+        Number points = sortedSet.increment(BRAZIL, 2);
+        assertEquals(Long.valueOf(12), Long.valueOf(points.longValue()));
+    }
+
+    @Test
+    public void shouldDecrement() {
+        sortedSet.add(BRAZIL, 10);
+        Number points = sortedSet.decrement(BRAZIL, 2);
+        assertEquals(Long.valueOf(8), Long.valueOf(points.longValue()));
+    }
+
+    @Test
+    public void shouldRemoveMember() {
+        sortedSet.add(BRAZIL, 10);
+        sortedSet.remove(BRAZIL);
+        assertEquals(0, sortedSet.size());
+    }
+
+    @Test
+    public void shouldShouldExpires() throws InterruptedException {
+        sortedSet.add(BRAZIL, 10);
+        sortedSet.expire(Duration.ofSeconds(1));
+        Thread.sleep(2_000L);
+        assertEquals(0, sortedSet.size());
+    }
+
+    @Test
+    public void shouldPersist() throws InterruptedException {
+        sortedSet.add(BRAZIL, 10);
+        sortedSet.expire(Duration.ofSeconds(1));
+        sortedSet.persist();
+        Thread.sleep(2_000L);
+        assertEquals(1, sortedSet.size());
+    }
+
+    @Test
+    public void shouldRange() {
+        sortedSet.add(BRAZIL, 1);
+        sortedSet.add(USA, 2);
+        sortedSet.add(ENGLAND, 3);
+
+        assertThat(sortedSet.range(2, 3)).contains(Ranking.of(ENGLAND, 3.0));
+    }
+
+    @Test
+    public void shoulgetRanges() {
+        Ranking brazil = Ranking.of(BRAZIL, 1.0);
+        Ranking usa = Ranking.of(USA, 2.0);
+        Ranking england = Ranking.of(ENGLAND, 3.0);
+        sortedSet.add(brazil);
+        sortedSet.add(usa);
+        sortedSet.add(england);
+
+        assertThat(sortedSet.getRanking()).contains(brazil, usa, england);
+    }
+
+    @Test
+    public void shouldRevRange() {
+        sortedSet.add(BRAZIL, 1);
+        sortedSet.add(USA, 2);
+        sortedSet.add(ENGLAND, 3);
+
+        assertThat(sortedSet.revRange(2, 3)).contains(Ranking.of(BRAZIL, 1.0));
+    }
+
+    @Test
+    public void shoulgetRevRanges() {
+        Ranking brazil = Ranking.of(BRAZIL, 1.0);
+        Ranking usa = Ranking.of(USA, 2.0);
+        Ranking england = Ranking.of(ENGLAND, 3.0);
+        sortedSet.add(brazil);
+        sortedSet.add(usa);
+        sortedSet.add(england);
+
+        assertThat(sortedSet.getRevRanking()).contains(england, usa, brazil);
+    }
+
+    @AfterEach
+    public void remove() {
+        sortedSet.clear();
+    }
+
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Human.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Human.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import java.io.Serializable;
+
+
+public record Human(String name, Integer age) implements Serializable {
+
+    private static final long serialVersionUID = 5089852596376703955L;
+
+
+    @JsonbCreator
+    public Human(@JsonbProperty("name") String name, @JsonbProperty("age") Integer age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    @Override
+    public String toString() {
+        return "Person{" + "name='" + name + '\'' +
+                ", age=" + age +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/KeyValueDatabase.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/KeyValueDatabase.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import org.eclipse.jnosql.communication.Settings;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public enum KeyValueDatabase implements Supplier<ValkeyBucketManagerFactory> {
+    INSTANCE;
+
+    private final GenericContainer<?> valkey =
+            new GenericContainer<>("valkey/valkey:latest")
+                    .withExposedPorts(6379)
+                    .waitingFor(Wait.defaultWaitStrategy());
+
+    {
+        valkey.start();
+    }
+
+    public String host() {
+        return valkey.getHost();
+    }
+
+    public String port() {
+        return String.valueOf(valkey.getFirstMappedPort());
+    }
+
+    @Override
+    public ValkeyBucketManagerFactory get() {
+        ValkeyConfiguration configuration = new ValkeyConfiguration();
+        Map<String, Object> settings = new HashMap<>();
+
+        settings.put(ValkeyConfigurations.HOST.get(), valkey.getHost());
+        settings.put(ValkeyConfigurations.PORT.get(), valkey.getFirstMappedPort());
+        return configuration.apply(Settings.of(settings));
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/LineBank.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/LineBank.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import java.util.Objects;
+
+public record LineBank(String name, Integer age) {
+
+
+    @JsonbCreator
+    public LineBank(@JsonbProperty("name") String name, @JsonbProperty("age") Integer age) {
+        this.name = name;
+        this.age = age;
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof LineBank lineBank)) {
+            return false;
+        }
+        return Objects.equals(name, lineBank.name) &&
+                Objects.equals(age, lineBank.age);
+    }
+
+    @Override
+    public String toString() {
+        return "LineBank{" + "name='" + name + '\'' +
+                ", age=" + age +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ProductCart.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ProductCart.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+public record ProductCart(String name, BigDecimal price) implements Serializable {
+
+    private static final long serialVersionUID = 4087960613230439836L;
+
+
+    @JsonbCreator
+    public ProductCart(@JsonbProperty("name") String name, @JsonbProperty("price") BigDecimal price) {
+        this.name = name;
+        this.price = price;
+    }
+
+    @Override
+    public String toString() {
+        return "ProductCart{" + "name='" + name + '\'' +
+                ", price=" + price +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
@@ -72,7 +72,7 @@ public class RedisListStringTest {
     @Test
     public void shouldSetList() {
         fruits.add("banana");
-        fruits.addFirst("orange");
+        fruits.add(0, "orange");
         assertEquals(2, fruits.size());
 
         assertEquals(fruits.get(0), "orange");
@@ -133,7 +133,7 @@ public class RedisListStringTest {
         fruits.remove(0);
         fruits.remove(0);
         count = 0;
-        for (String fruiCart : fruits) {
+        for (String fruit : fruits) {
             count++;
         }
         assertEquals(0, count);

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
@@ -58,7 +58,7 @@ public class RedisListStringTest {
         assertTrue(fruits.isEmpty());
         fruits.add("banana");
         assertFalse(fruits.isEmpty());
-        String banana = fruits.getFirst();
+        String banana = fruits.get(0);
         assertNotNull(banana);
         assertEquals(banana, "banana");
     }
@@ -130,8 +130,8 @@ public class RedisListStringTest {
             count++;
         }
         assertEquals(2, count);
-        fruits.removeFirst();
-        fruits.removeFirst();
+        fruits.remove(0);
+        fruits.remove(0);
         count = 0;
         for (String fruiCart : fruits) {
             count++;

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class RedisListStringTest {
+
+
+    private static final String FRUITS = "fruits-string";
+
+    private BucketManagerFactory keyValueEntityManagerFactory;
+
+    private List<String> fruits;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        fruits = keyValueEntityManagerFactory.getList(FRUITS, String.class);
+    }
+
+    @Test
+    public void shouldReturnsList() {
+        assertNotNull(fruits);
+    }
+
+    @Test
+    public void shouldAddList() {
+        assertTrue(fruits.isEmpty());
+        fruits.add("banana");
+        assertFalse(fruits.isEmpty());
+        String banana = fruits.getFirst();
+        assertNotNull(banana);
+        assertEquals(banana, "banana");
+    }
+    
+    @Test
+    public void shouldAddAll() {
+        fruits.addAll(Arrays.asList("banana", "orange"));
+        assertEquals(2, fruits.size());
+    }
+
+    @Test
+    public void shouldSetList() {
+        fruits.add("banana");
+        fruits.addFirst("orange");
+        assertEquals(2, fruits.size());
+
+        assertEquals(fruits.get(0), "orange");
+        assertEquals(fruits.get(1), "banana");
+
+        fruits.set(0, "waterMelon");
+        assertEquals(fruits.get(0), "waterMelon");
+        assertEquals(fruits.get(1), "banana");
+
+    }
+
+    @Test
+    public void shouldRemoveList() {
+        fruits.add("banana");
+        fruits.add("orange");
+        fruits.add("watermellon");
+
+        fruits.remove("banana");
+        assertThat(fruits).isNotIn("banana");
+    }
+
+    @Test
+    public void shouldReturnIndexOf() {
+        fruits.add("orange");
+        fruits.add("banana");
+        fruits.add("watermellon");
+        fruits.add("banana");
+        assertEquals(1, fruits.indexOf("banana"));
+        assertEquals(3, fruits.lastIndexOf("banana"));
+
+        assertTrue(fruits.contains("banana"));
+        assertEquals(-1, fruits.indexOf("melon"));
+        assertEquals(-1, fruits.lastIndexOf("melon"));
+    }
+
+    @Test
+    public void shouldReturnContains() {
+        fruits.add("orange");
+        fruits.add("banana");
+        fruits.add("watermellon");
+        assertTrue(fruits.contains("banana"));
+        assertFalse(fruits.contains("melon"));
+        assertTrue(fruits.containsAll(Arrays.asList("banana", "orange")));
+        assertFalse(fruits.containsAll(Arrays.asList("banana", "melon")));
+
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void shouldIterate() {
+        fruits.add("melon");
+        fruits.add("banana");
+        int count = 0;
+        for (String fruiCart : fruits) {
+            count++;
+        }
+        assertEquals(2, count);
+        fruits.removeFirst();
+        fruits.removeFirst();
+        count = 0;
+        for (String fruiCart : fruits) {
+            count++;
+        }
+        assertEquals(0, count);
+    }
+
+    @Test
+    public void shouldClear(){
+        fruits.add("orange");
+        fruits.add("banana");
+        fruits.add("watermellon");
+
+        fruits.clear();
+        assertTrue(fruits.isEmpty());
+    }
+
+    @AfterEach
+    public void end() {
+        fruits.clear();
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
@@ -1,0 +1,181 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class RedisListTest {
+
+
+    private static final String FRUITS = "fruits";
+    private ProductCart banana = new ProductCart("banana", BigDecimal.ONE);
+    private ProductCart orange = new ProductCart("orange", BigDecimal.ONE);
+    private ProductCart waterMelon = new ProductCart("waterMelon", BigDecimal.TEN);
+    private ProductCart melon = new ProductCart("melon", BigDecimal.ONE);
+
+    private BucketManagerFactory keyValueEntityManagerFactory;
+
+    private List<ProductCart> fruits;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        fruits = keyValueEntityManagerFactory.getList(FRUITS, ProductCart.class);
+    }
+
+    @Test
+    public void shouldReturnsList() {
+        assertNotNull(fruits);
+    }
+
+    @Test
+    public void shouldAddList() {
+        assertTrue(fruits.isEmpty());
+        fruits.add(banana);
+        assertFalse(fruits.isEmpty());
+        ProductCart banana = fruits.getFirst();
+        assertNotNull(banana);
+        assertEquals(banana.name(), "banana");
+    }
+
+    @Test
+    public void shouldSetList() {
+        fruits.add(banana);
+        fruits.addFirst(orange);
+        assertEquals(2, fruits.size());
+
+        assertEquals(fruits.get(0).name(), "orange");
+        assertEquals(fruits.get(1).name(), "banana");
+
+        fruits.set(0, waterMelon);
+        assertEquals(fruits.get(0).name(), "waterMelon");
+        assertEquals(fruits.get(1).name(), "banana");
+    }
+
+    @Test
+    public void shouldRemoveList() {
+        fruits.add(orange);
+        fruits.add(banana);
+        fruits.add(waterMelon);
+
+        fruits.remove(waterMelon);
+        assertThat(fruits).isNotIn(waterMelon);
+    }
+
+    @Test
+    public void shouldRemoveAll() {
+        fruits.add(orange);
+        fruits.add(banana);
+        fruits.add(waterMelon);
+
+        fruits.removeAll(Arrays.asList(orange, banana));
+        assertEquals(1, fruits.size());
+        assertThat(fruits).contains(waterMelon);
+    }
+
+    @Test
+    public void shouldRemoveWithIndex() {
+        fruits.add(orange);
+        fruits.add(banana);
+        fruits.add(waterMelon);
+
+        fruits.removeFirst();
+        assertThat(fruits).hasSize(2).isNotIn(orange);
+    }
+
+    @Test
+    public void shouldReturnIndexOf() {
+        fruits.add(new ProductCart("orange", BigDecimal.ONE));
+        fruits.add(banana);
+        fruits.add(new ProductCart("watermellon", BigDecimal.ONE));
+        fruits.add(banana);
+        assertEquals(1, fruits.indexOf(banana));
+        assertEquals(3, fruits.lastIndexOf(banana));
+
+        assertTrue(fruits.contains(banana));
+        assertEquals(-1, fruits.indexOf(melon));
+        assertEquals(-1, fruits.lastIndexOf(melon));
+    }
+
+    @Test
+    public void shouldReturnContains() {
+        fruits.add(orange);
+        fruits.add(banana);
+        fruits.add(waterMelon);
+        assertTrue(fruits.contains(banana));
+        assertFalse(fruits.contains(melon));
+        assertTrue(fruits.containsAll(Arrays.asList(banana, orange)));
+        assertFalse(fruits.containsAll(Arrays.asList(banana, melon)));
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void shouldIterate() {
+        fruits.add(melon);
+        fruits.add(banana);
+        int count = 0;
+        for (ProductCart fruiCart : fruits) {
+            count++;
+        }
+        assertEquals(2, count);
+        fruits.removeFirst();
+        fruits.removeFirst();
+        count = 0;
+        for (ProductCart fruiCart : fruits) {
+            count++;
+        }
+        assertEquals(0, count);
+    }
+
+    @Test
+    public void shouldClear(){
+        fruits.add(orange);
+        fruits.add(banana);
+        fruits.add(waterMelon);
+
+        fruits.clear();
+        assertTrue(fruits.isEmpty());
+    }
+
+    @Test
+    public void shouldThrowExceptionRetainAll() {
+        assertThrows(UnsupportedOperationException.class, () -> fruits.retainAll(Collections.singletonList(orange)));
+    }
+
+    @AfterEach
+    public void end() {
+        fruits.clear();
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
@@ -65,7 +65,7 @@ public class RedisListTest {
         assertTrue(fruits.isEmpty());
         fruits.add(banana);
         assertFalse(fruits.isEmpty());
-        ProductCart banana = fruits.getFirst();
+        ProductCart banana = fruits.get(0);
         assertNotNull(banana);
         assertEquals(banana.name(), "banana");
     }
@@ -111,7 +111,7 @@ public class RedisListTest {
         fruits.add(banana);
         fruits.add(waterMelon);
 
-        fruits.removeFirst();
+        fruits.remove(0);
         assertThat(fruits).hasSize(2).isNotIn(orange);
     }
 
@@ -150,8 +150,8 @@ public class RedisListTest {
             count++;
         }
         assertEquals(2, count);
-        fruits.removeFirst();
-        fruits.removeFirst();
+        fruits.remove(0);
+        fruits.remove(0);
         count = 0;
         for (ProductCart fruiCart : fruits) {
             count++;

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
@@ -73,7 +73,7 @@ public class RedisListTest {
     @Test
     public void shouldSetList() {
         fruits.add(banana);
-        fruits.addFirst(orange);
+        fruits.add(0, orange);
         assertEquals(2, fruits.size());
 
         assertEquals(fruits.get(0).name(), "orange");

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueStringTest.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class RedisQueueStringTest {
+
+
+    private BucketManagerFactory keyValueEntityManagerFactory;
+
+    private Queue<String> lineBank;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        lineBank = keyValueEntityManagerFactory.getQueue("physical-bank-string", String.class);
+    }
+
+    @Test
+    public void shouldPushInTheLine() {
+        assertTrue(lineBank.add("Otavio"));
+        assertEquals(1, lineBank.size());
+        String otavio = lineBank.poll();
+        assertEquals(otavio, "Otavio");
+        assertNull(lineBank.poll());
+        assertTrue(lineBank.isEmpty());
+    }
+
+    @Test
+    public void shouldPeekInTheLine() {
+        lineBank.add("Otavio");
+        String otavio = lineBank.peek();
+        assertNotNull(otavio);
+        assertNotNull(lineBank.peek());
+        String otavio2 = lineBank.remove();
+        assertEquals(otavio, otavio2);
+        boolean happendException = false;
+        try {
+            lineBank.remove();
+        } catch (NoSuchElementException e) {
+            happendException = true;
+        }
+        assertTrue(happendException);
+    }
+
+    @Test
+    public void shouldElementInTheLine() {
+        lineBank.add("Otavio");
+        assertNotNull(lineBank.element());
+        assertNotNull(lineBank.element());
+        lineBank.remove("Otavio");
+        boolean happendException = false;
+        try {
+            lineBank.element();
+        } catch (NoSuchElementException e) {
+            happendException = true;
+        }
+        assertTrue(happendException);
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void shouldIterate() {
+        lineBank.add("Otavio");
+        lineBank.add("Gama");
+        int count = 0;
+        for (String line : lineBank) {
+            count++;
+        }
+        assertEquals(2, count);
+        lineBank.remove();
+        lineBank.remove();
+        count = 0;
+        for (String line : lineBank) {
+            count++;
+        }
+        assertEquals(0, count);
+    }
+
+    @Test
+    public void shouldClear() {
+        lineBank.add("Otavio");
+        lineBank.clear();
+        assertTrue(lineBank.isEmpty());
+    }
+
+    @AfterEach
+    public void dispose() {
+        lineBank.clear();
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueTest.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.NoSuchElementException;
+import java.util.Queue;
+
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class RedisQueueTest {
+
+
+    private BucketManagerFactory keyValueEntityManagerFactory;
+
+    private Queue<LineBank> lineBank;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        lineBank = keyValueEntityManagerFactory.getQueue("physical-bank", LineBank.class);
+    }
+
+    @Test
+    public void shouldPushInTheLine() {
+        assertTrue(lineBank.add(new LineBank("Otavio", 25)));
+        assertEquals(1, lineBank.size());
+        LineBank otavio = lineBank.poll();
+        assertEquals(otavio.name(), "Otavio");
+        assertNull(lineBank.poll());
+        assertTrue(lineBank.isEmpty());
+    }
+
+    @Test
+    public void shouldPeekInTheLine() {
+        lineBank.add(new LineBank("Otavio", 25));
+        LineBank otavio = lineBank.peek();
+        assertNotNull(otavio);
+        assertNotNull(lineBank.peek());
+        LineBank otavio2 = lineBank.remove();
+        assertEquals(otavio.name(), otavio2.name());
+        boolean happendException = false;
+        try {
+            lineBank.remove();
+        } catch (NoSuchElementException e) {
+            happendException = true;
+        }
+        assertTrue(happendException);
+    }
+
+    @Test
+    public void shouldElementInTheLine() {
+        lineBank.add(new LineBank("Otavio", 25));
+        assertNotNull(lineBank.element());
+        assertNotNull(lineBank.element());
+        lineBank.remove(new LineBank("Otavio", 25));
+        boolean happendException = false;
+        try {
+            lineBank.element();
+        } catch (NoSuchElementException e) {
+            happendException = true;
+        }
+        assertTrue(happendException);
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void shouldIterate() {
+        lineBank.add(new LineBank("Otavio", 25));
+        lineBank.add(new LineBank("Gama", 26));
+        int count = 0;
+        for (LineBank line : lineBank) {
+            count++;
+        }
+        assertEquals(2, count);
+        lineBank.remove();
+        lineBank.remove();
+        count = 0;
+        for (LineBank line : lineBank) {
+            count++;
+        }
+        assertEquals(0, count);
+    }
+
+    @Test
+    public void shouldClear() {
+        lineBank.add(new LineBank("Otavio", 25));
+        lineBank.clear();
+        assertTrue(lineBank.isEmpty());
+    }
+
+    @AfterEach
+    public void dispose() {
+        lineBank.clear();
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetStringTest.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class RedisSetStringTest {
+
+
+    private BucketManagerFactory keyValueEntityManagerFactory;
+
+    private Set<String> users;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        users = keyValueEntityManagerFactory.getSet("social-media-string", String.class);
+    }
+
+    @Test
+    public void shouldAddUsers() {
+        users.add("otaviojava");
+        assertEquals(1, users.size());
+
+        String user = users.iterator().next();
+        assertEquals("otaviojava", user);
+    }
+
+    @Test
+    public void shouldRemoveSet() {
+        users.add("otaviojava");
+        users.remove("otaviojava");
+        assertTrue(users.isEmpty());
+    }
+
+
+    @SuppressWarnings("unused")
+    @Test
+    public void shouldIterate() {
+        users.add("otaviojava");
+        users.add("otaviojava");
+        users.add("felipe");
+        users.add("otaviojava");
+        users.add("felipe");
+        int count = 0;
+        for (String user : users) {
+            count++;
+        }
+        assertEquals(2, count);
+        users.remove("otaviojava");
+        users.remove("felipe");
+        count = 0;
+        for (String user : users) {
+            count++;
+        }
+        assertEquals(0, count);
+    }
+
+    @Test
+    public void shouldClear() {
+        users.add("otaviojava");
+        users.clear();
+        assertTrue(users.isEmpty());
+    }
+
+    @Test
+    public void shouldContains() {
+        users.add("otaviojava");
+        assertTrue(users.contains("otaviojava"));
+    }
+
+    @Test
+    public void shouldContainsAll() {
+        users.add("otaviojava");
+        users.add("furlaneto");
+        users.add("joao");
+        assertTrue(users.containsAll(Arrays.asList("furlaneto", "otaviojava")));
+    }
+
+    @Test
+    public void shouldReturnSize() {
+        users.add("otaviojava");
+        users.add("furlaneto");
+        users.add("joao");
+        assertEquals(3, users.size());
+    }
+    
+    @AfterEach
+    public void dispose() {
+        users.clear();
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetTest.java
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class RedisSetTest {
+
+    private BucketManagerFactory keyValueEntityManagerFactory;
+    private User userOtavioJava = new User("otaviojava");
+    private User felipe = new User("ffrancesquini");
+    private Set<User> users;
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        users = keyValueEntityManagerFactory.getSet("social-media", User.class);
+    }
+
+    @Test
+    public void shouldAddUsers() {
+        users.add(userOtavioJava);
+        assertEquals(1, users.size());
+    }
+
+    @Test
+    public void shouldRemove() {
+        users.add(userOtavioJava);
+        users.add(felipe);
+        users.remove(felipe);
+
+        assertEquals(1, users.size());
+        assertThat(users).isNotIn(felipe);
+   }
+
+    @Test
+    public void shouldRemoveAll() {
+        users.add(userOtavioJava);
+        users.add(felipe);
+        users.removeAll(Arrays.asList(felipe, userOtavioJava));
+
+        assertEquals(0, users.size());
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void shouldIterate() {
+        users.add(userOtavioJava);
+        users.add(userOtavioJava);
+        users.add(felipe);
+        users.add(userOtavioJava);
+        users.add(felipe);
+        int count = 0;
+        for (User user : users) {
+            count++;
+        }
+        assertEquals(2, count);
+    }
+
+    @Test
+    public void shouldContains() {
+        users.add(userOtavioJava);
+        assertTrue(users.contains(userOtavioJava));
+    }
+
+    @Test
+    public void shouldContainsAll() {
+        users.add(userOtavioJava);
+        users.add(felipe);
+        assertTrue(users.containsAll(Arrays.asList(userOtavioJava, felipe)));
+    }
+
+    @Test
+    public void shouldReturnSize() {
+        users.add(userOtavioJava);
+        users.add(felipe);
+        assertEquals(2, users.size());
+    }
+
+    @Test
+    public void shouldClear() {
+        users.add(userOtavioJava);
+        users.add(felipe);
+
+        users.clear();
+        assertTrue(users.isEmpty());
+    }
+
+    @Test
+    public void shouldThrowExceptionRetainAll() {
+        assertThrows(UnsupportedOperationException.class, () -> users.retainAll(Collections.singletonList(userOtavioJava)));
+    }
+
+    @AfterEach
+    public void dispose() {
+        users.clear();
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Species.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Species.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public class Species implements Serializable {
+
+    private static final long serialVersionUID = -1493508757572337719L;
+
+    private final List<String> animals;
+
+    @JsonbCreator
+    public Species(@JsonbProperty("animals") String... animals) {
+        this.animals = Arrays.asList(animals);
+    }
+
+    public List<String> getAnimals() {
+        return animals;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Species species = (Species) o;
+        return Objects.equals(animals, species.animals);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(animals);
+    }
+
+    @Override
+    public String toString() {
+        return "Species{" + "animals=" + animals +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/User.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/User.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import jakarta.json.bind.annotation.JsonbCreator;
+import jakarta.json.bind.annotation.JsonbProperty;
+
+import java.util.Objects;
+
+
+public record User(String nickName) {
+
+    @JsonbCreator
+    public User(@JsonbProperty("nickName") String nickName) {
+        this.nickName = nickName;
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(nickName, user.nickName);
+    }
+
+    @Override
+    public String toString() {
+        return "User{" + "nickName='" + nickName + '\'' +
+                '}';
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactoryTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManager;
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class ValkeyBucketManagerFactoryTest {
+
+    public static final String BUCKET_NAME = "bucketName";
+    private BucketManagerFactory managerFactory;
+
+    @BeforeEach
+    public void setUp() {
+        managerFactory = KeyValueDatabase.INSTANCE.get();
+    }
+
+    @Test
+    public void shouldCreateKeyValueEntityManager() {
+        BucketManager keyValueEntityManager = managerFactory.apply(BUCKET_NAME);
+        assertNotNull(keyValueEntityManager);
+    }
+
+    @Test
+    public void shouldCreateMap() {
+        Map<String, String> map = managerFactory.getMap(BUCKET_NAME, String.class, String.class);
+        assertNotNull(map);
+    }
+
+    @Test
+    public void shouldCreateSet() {
+        Set<String> set = managerFactory.getSet(BUCKET_NAME, String.class);
+        assertNotNull(set);
+    }
+
+    @Test
+    public void shouldCreateList() {
+        List<String> list = managerFactory.getList(BUCKET_NAME, String.class);
+        assertNotNull(list);
+    }
+
+    @Test
+    public void shouldCreateQueue() {
+        Queue<String> queue = managerFactory.getQueue(BUCKET_NAME, String.class);
+        assertNotNull(queue);
+    }
+
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+
+import org.eclipse.jnosql.communication.Value;
+import org.eclipse.jnosql.communication.keyvalue.BucketManager;
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.eclipse.jnosql.communication.keyvalue.KeyValueEntity;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class ValkeyBucketManagerTest {
+
+    private BucketManager keyValueEntityManager;
+
+    private BucketManagerFactory keyValueEntityManagerFactory;
+
+    private User userOtavio = new User("otavio");
+    private KeyValueEntity keyValueOtavio = KeyValueEntity.of("otavio", Value.of(userOtavio));
+
+    private User userSoro = new User("soro");
+    private KeyValueEntity keyValueSoro = KeyValueEntity.of("soro", Value.of(userSoro));
+
+    @BeforeEach
+    public void init() {
+        keyValueEntityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        keyValueEntityManager = keyValueEntityManagerFactory.apply("users-entity");
+    }
+
+
+    @Test
+    public void shouldPutValue() {
+        keyValueEntityManager.put("otavio", userOtavio);
+        Optional<Value> otavio = keyValueEntityManager.get("otavio");
+        assertTrue(otavio.isPresent());
+        assertEquals(userOtavio, otavio.get().get(User.class));
+    }
+
+    @Test
+    public void shouldPutKeyValue() {
+        keyValueEntityManager.put(keyValueOtavio);
+        Optional<Value> otavio = keyValueEntityManager.get("otavio");
+        assertTrue(otavio.isPresent());
+        assertEquals(userOtavio, otavio.get().get(User.class));
+    }
+
+    @Test
+    public void shouldPutIterableKeyValue() {
+        keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
+        Optional<Value> otavio = keyValueEntityManager.get("otavio");
+        assertTrue(otavio.isPresent());
+        assertEquals(userOtavio, otavio.get().get(User.class));
+
+        Optional<Value> soro = keyValueEntityManager.get("soro");
+        assertTrue(soro.isPresent());
+        assertEquals(userSoro, soro.get().get(User.class));
+    }
+
+    @Test
+    public void shouldMultiGet() {
+        User user = new User("otavio");
+        KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
+        keyValueEntityManager.put(keyValue);
+        assertNotNull(keyValueEntityManager.get("otavio"));
+    }
+
+    @Test
+    public void shouldRemoveKey() {
+        keyValueEntityManager.put(keyValueOtavio);
+        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        keyValueEntityManager.delete("otavio");
+        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+    }
+
+    @Test
+    public void shouldRemoveMultiKey() {
+        keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
+        List<String> keys = asList("otavio", "soro");
+        Iterable<Value> values = keyValueEntityManager.get(keys);
+        assertThat(StreamSupport.stream(values.spliterator(), false)
+                .map(value -> value.get(User.class)).collect(Collectors.toList()))
+                .contains(userOtavio, userSoro);
+        keyValueEntityManager.delete(keys);
+        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+    }
+
+    @AfterEach
+    public void remove() {
+        keyValueEntityManager.delete(Arrays.asList("otavio", "soro"));
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ValkeyConfigurationTest {
+
+    private ValkeyConfiguration configuration;
+
+    @BeforeEach
+    public void setUp() {
+        configuration = new ValkeyConfiguration();
+    }
+
+    @Test
+    public void shouldCreateKeyValueFactory() {
+        Map<String, String> map = new HashMap<>();
+        map.put("redis-master-hoster", "localhost");
+        BucketManagerFactory managerFactory = configuration.getManagerFactory(map);
+        assertNotNull(managerFactory);
+    }
+
+
+    @Test
+    public void shouldReturnFromConfiguration() {
+        KeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
+        Assertions.assertNotNull(configuration);
+        Assertions.assertTrue(configuration instanceof KeyValueConfiguration);
+    }
+
+    @Test
+    public void shouldReturnFromConfigurationQuery() {
+        ValkeyConfiguration configuration = KeyValueConfiguration
+                .getConfiguration(ValkeyConfiguration.class);
+        Assertions.assertNotNull(configuration);
+        Assertions.assertTrue(configuration instanceof ValkeyConfiguration);
+    }
+
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapStringTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class ValkeyMapStringTest {
+
+    private BucketManagerFactory entityManagerFactory;
+
+    private static final String MAMMALS = "mammals";
+    private static final String FISHES = "fishes";
+    private static final String AMPHIBIANS = "amphibians";
+    private static final String BUCKET_NAME = "vertebrates_string";
+
+    private Map<String, String> vertebrates;
+
+    @BeforeEach
+    public void init() {
+        entityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        vertebrates = entityManagerFactory.getMap(BUCKET_NAME, String.class, String.class);
+    }
+
+    @Test
+    public void shouldPutAndGetMap() {
+        assertNotNull(vertebrates.put(MAMMALS, MAMMALS));
+        String species = vertebrates.get(MAMMALS);
+        assertNotNull(species);
+        assertEquals(MAMMALS, vertebrates.get(MAMMALS));
+        assertEquals(1, vertebrates.size());
+    }
+
+    @Test
+    public void shouldVerifyExist() {
+        vertebrates.put(MAMMALS, MAMMALS);
+        assertTrue(vertebrates.containsKey(MAMMALS));
+        assertFalse(vertebrates.containsKey(FISHES));
+
+        assertTrue(vertebrates.containsValue(MAMMALS));
+        assertFalse(vertebrates.containsValue(FISHES));
+    }
+
+    @Test
+    public void shouldShowKeyAndValues() {
+        vertebrates.put(MAMMALS, MAMMALS);
+        vertebrates.put(FISHES, FISHES);
+        vertebrates.put(AMPHIBIANS, AMPHIBIANS);
+
+        Set<String> keys = vertebrates.keySet();
+        Collection<String> collectionSpecies = vertebrates.values();
+
+        assertEquals(3, keys.size());
+        assertEquals(3, collectionSpecies.size());
+        assertNotNull(vertebrates.remove(MAMMALS));
+        assertNull(vertebrates.remove(MAMMALS));
+        assertNull(vertebrates.get(MAMMALS));
+        assertEquals(2, vertebrates.size());
+    }
+
+    @Test
+    public void shouldRemove() {
+        vertebrates.put(MAMMALS, MAMMALS);
+        vertebrates.put(FISHES, FISHES);
+        vertebrates.put(AMPHIBIANS, AMPHIBIANS);
+
+        vertebrates.remove(FISHES);
+        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates).isNotIn(FISHES);
+    }
+
+    @Test
+    public void shouldClear() {
+        vertebrates.put(MAMMALS, MAMMALS);
+        vertebrates.put(FISHES, FISHES);
+
+        vertebrates.clear();
+        assertTrue(vertebrates.isEmpty());
+    }
+
+    @AfterEach
+    public void dispose() {
+        vertebrates.clear();
+    }
+
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
@@ -63,11 +63,11 @@ public class ValkeyMapTest {
 
     @Test
     public void shouldPutAll() {
-        Map toPutAll = new HashMap<String, Species>();
-        toPutAll.put("mammals", mammals);
-        toPutAll.put("fishes", fishes);
+        var animalCategories = new HashMap<String, Species>();
+        animalCategories.put("mammals", mammals);
+        animalCategories.put("fishes", fishes);
 
-        vertebrates.putAll(toPutAll);
+        vertebrates.putAll(animalCategories);
         assertEquals(2, vertebrates.size());
     }
 

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
+import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
+public class ValkeyMapTest {
+
+    private BucketManagerFactory entityManagerFactory;
+
+    private Species mammals = new Species("lion", "cow", "dog");
+    private Species fishes = new Species("redfish", "glassfish");
+    private Species amphibians = new Species("crododile", "frog");
+
+    private Map<String, Species> vertebrates;
+
+    @BeforeEach
+    public void init() {
+        entityManagerFactory = KeyValueDatabase.INSTANCE.get();
+        vertebrates = entityManagerFactory.getMap("vertebrates", String.class, Species.class);
+    }
+
+    @Test
+    public void shouldPutAndGetMap() {
+        assertNotNull(vertebrates.put("mammals", mammals));
+        Species species = vertebrates.get("mammals");
+        assertNotNull(species);
+        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
+        assertEquals(1, vertebrates.size());
+    }
+
+    @Test
+    public void shouldPutAll() {
+        Map toPutAll = new HashMap<String, Species>();
+        toPutAll.put("mammals", mammals);
+        toPutAll.put("fishes", fishes);
+
+        vertebrates.putAll(toPutAll);
+        assertEquals(2, vertebrates.size());
+    }
+
+    @Test
+    public void shouldVerifyExist() {
+        vertebrates.put("mammals", mammals);
+        assertTrue(vertebrates.containsKey("mammals"));
+        assertFalse(vertebrates.containsKey("redfish"));
+
+        assertTrue(vertebrates.containsValue(mammals));
+        assertFalse(vertebrates.containsValue(fishes));
+    }
+
+    @Test
+    public void shouldShowKeyAndValues() {
+        vertebrates.put("mammals", mammals);
+        vertebrates.put("fishes", fishes);
+        vertebrates.put("amphibians", amphibians);
+
+        Set<String> keys = vertebrates.keySet();
+        Collection<Species> collectionSpecies = vertebrates.values();
+
+        assertEquals(3, keys.size());
+        assertEquals(3, collectionSpecies.size());
+        assertNotNull(vertebrates.remove("mammals"));
+        assertNull(vertebrates.remove("mammals"));
+        assertNull(vertebrates.get("mammals"));
+        assertEquals(2, vertebrates.size());
+    }
+
+    @Test
+    public void shouldRemove() {
+        vertebrates.put("mammals", mammals);
+        vertebrates.put("fishes", fishes);
+        vertebrates.put("amphibians", amphibians);
+
+        vertebrates.remove("fishes");
+        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates).isNotIn(fishes);
+    }
+
+    @Test
+    public void shouldClear() {
+        vertebrates.put("mammals", mammals);
+        vertebrates.put("fishes", fishes);
+
+        vertebrates.clear();
+        assertTrue(vertebrates.isEmpty());
+    }
+
+    @AfterEach
+    public void dispose() {
+        vertebrates.clear();
+    }
+
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
@@ -57,7 +57,7 @@ public class ValkeyMapTest {
         assertNotNull(vertebrates.put("mammals", mammals));
         Species species = vertebrates.get("mammals");
         assertNotNull(species);
-        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
+        assertEquals(species.getAnimals().get(0), mammals.getAnimals().get(0));
         assertEquals(1, vertebrates.size());
     }
 

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtilsTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtilsTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+package org.eclipse.jnosql.databases.valkey.communication;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ValkeyUtilsTest {
+
+    @Test
+    public void shouldReturnNameSpace() {
+        assertEquals("namespace:key", ValkeyUtils.createKeyWithNameSpace("key", "namespace"));
+    }
+
+    @Test
+    public void shouldThrowWithNullKey() {
+        assertThrows(IrregularKeyValue.class, () -> ValkeyUtils.createKeyWithNameSpace(null, ""));
+    }
+}

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/tck/ValkeyDBTemplateSupplier.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/tck/ValkeyDBTemplateSupplier.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *   Alessandro Moscatelli
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.databases.valkey.tck;
+
+import ee.jakarta.tck.nosql.TemplateSupplier;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.nosql.Template;
+import org.eclipse.jnosql.databases.valkey.communication.KeyValueDatabase;
+import org.eclipse.jnosql.databases.valkey.communication.ValkeyConfigurations;
+import org.eclipse.jnosql.mapping.core.config.MappingConfigurations;
+
+
+public class ValkeyDBTemplateSupplier implements TemplateSupplier {
+
+    static {
+        System.setProperty(ValkeyConfigurations.HOST.get(), KeyValueDatabase.INSTANCE.host());
+        System.setProperty(ValkeyConfigurations.PORT.get(), KeyValueDatabase.INSTANCE.port());
+        System.setProperty(MappingConfigurations.KEY_VALUE_DATABASE.get(), "jakarta-nosql-tck");
+        SeContainerInitializer.newInstance().initialize();
+    }
+
+    @Override
+    public Template get() {
+        return CDI.current().select(Template.class).get();
+    }
+}

--- a/jnosql-valkey/src/test/resources/META-INF/beans.xml
+++ b/jnosql-valkey/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Otavio Santana
+  -->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
+</beans>

--- a/jnosql-valkey/src/test/resources/META-INF/services/ee.jakarta.tck.nosql.TemplateSupplier
+++ b/jnosql-valkey/src/test/resources/META-INF/services/ee.jakarta.tck.nosql.TemplateSupplier
@@ -1,0 +1,1 @@
+org.eclipse.jnosql.databases.valkey.tck.ValkeyDBTemplateSupplier

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <module>jnosql-orientdb</module>
         <module>jnosql-ravendb</module>
         <module>jnosql-redis</module>
+        <module>jnosql-valkey</module>
         <module>jnosql-riak</module>
         <module>jnosql-solr</module>
         <module>jnosql-oracle-nosql</module>


### PR DESCRIPTION
This pull request introduces a new Valkey (Redis-compatible) driver module for Eclipse JNoSQL, providing support for advanced Redis data structures such as counters and sorted sets. The implementation includes interfaces and default classes for managing counters, rankings, and sorted sets, as well as a factory for creating and managing these structures. The changes also add exception handling for irregular key-value scenarios.

The most important changes are:

**Valkey Driver Module Introduction**
- Added a new Maven module `jnosql-valkey` with its own `pom.xml`, specifying dependencies for Valkey and JNoSQL mapping.

**Core Data Structure Implementations**
- Introduced the `Counter` interface and its implementation `DefaultCounter` for atomic numeric operations (increment, decrement, TTL, etc.) on Redis keys. [[1]](diffhunk://#diff-2d5df1ffb4685c77183aea4fd8b77c400cb73cad6a440d25235fb289b41d4031R1-R81) [[2]](diffhunk://#diff-61ad1e5ccf3709c4499ea07da8c2945e2a4338beb1235ba921aa3c5f735c074bR1-R109)
- Added the `Ranking` interface and its implementation `DefaultRanking` to represent elements in a sorted set with a member and score, including a static factory method for instantiation. [[1]](diffhunk://#diff-df25b558fd65ebd0aa6cb90260e7bdb237e6240ef310158eeb264fe7dadd7d62R1-R68) [[2]](diffhunk://#diff-cbc166c35d91b15783eaeb9f145c85cf0144229be8f7dc7e42613ea9e4ff9724R1-R64)
- Implemented the `SortedSet` interface via `DefaultSortedSet`, supporting operations like adding, incrementing, decrementing, and retrieving ranked members.

**Factory and Management**
- Created `DefaultValkeyBucketManagerFactory` for constructing Valkey-backed collections (lists, sets, queues, maps, sorted sets, counters) and managing their lifecycle.

**Error Handling**
- Added the `IrregularKeyValue` exception to handle cases where key-value pairs do not meet expected criteria.