### PR TITLE
chore: update database driver dependencies and changelog

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,15 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Changed
+
+- Upgraded Jedis to 7.5.3
+- Updated orientdb to 3.2.54
+- Updated MongoDB to 5.9.0
+- Updated Hbase 2.6.6
+- Updated DynamoDB to 2.47.3
+- Updated Couchbase to 3.12.1
+
 == [1.1.15] - 2026-07-03
 
 - Upgraded Cassandra 4.19.3

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.couchbase.client</groupId>
             <artifactId>java-client</artifactId>
-            <version>3.12.0</version>
+            <version>3.12.1</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.46.21</dynamodb.version>
+        <dynamodb.version>2.47.3</dynamodb.version>
     </properties>
 
     <dependencies>

--- a/jnosql-hbase/pom.xml
+++ b/jnosql-hbase/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>2.6.3</version>
+            <version>2.6.6</version>
         </dependency>
     </dependencies>
 

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.8.0</monbodb.driver>
+        <monbodb.driver>5.9.0</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.orientechnologies</groupId>
             <artifactId>orientdb-graphdb</artifactId>
-            <version>3.2.53</version>
+            <version>3.2.54</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>7.5.0</version>
+            <version>7.5.3</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This pull request updates several dependencies across different modules to their latest versions. These changes help ensure compatibility, access to new features, and important bug or security fixes.

**Dependency Upgrades:**

*Redis:*
- Upgraded `jedis` dependency to version 7.5.3 in `jnosql-redis/pom.xml`.

*OrientDB:*
- Updated `orientdb-graphdb` to version 3.2.54 in `jnosql-orientdb/pom.xml`.

*MongoDB:*
- Updated MongoDB driver to version 5.9.0 in `jnosql-mongodb/pom.xml`.

*HBase:*
- Updated `hbase-client` to version 2.6.6 in `jnosql-hbase/pom.xml`.

*DynamoDB:*
- Upgraded DynamoDB dependency version to 2.47.3 in `jnosql-dynamodb/pom.xml`.

*Couchbase:*
- Updated `java-client` to version 3.12.1 in `jnosql-couchbase/pom.xml`.

**Documentation:**

- Updated the `CHANGELOG.adoc` to reflect all the above dependency upgrades.