### PR TITLE
fix: normalize Oracle NoSQL query values

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -16,6 +16,7 @@ package org.eclipse.jnosql.databases.oracle.communication;
 
 import oracle.nosql.driver.values.FieldValue;
 import org.eclipse.jnosql.communication.TypeReference;
+import org.eclipse.jnosql.communication.ValueUtil;
 import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
 import org.eclipse.jnosql.communication.semistructured.Element;
 
@@ -57,7 +58,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
                     ids.addAll(document.get(new TypeReference<List<String>>() {
                     }));
                 } else {
-                    predicate(query, " IN ", document, params);
+                    predicateIn(query, document, params);
                 }
                 return;
             case LESSER_THAN:
@@ -124,14 +125,23 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     protected void predicateBetween(StringBuilder query,List<FieldValue> params, Element document) {
         String name = identifierOf(document.name());
 
-        List<Object> values = new ArrayList<>();
-        ((Iterable<?>) document.get()).forEach(values::add);
+        List<Object> values = ValueUtil.convertToList(document.value());
 
         query.append(name).append(" BETWEEN ? AND ? ");
         FieldValue fieldValue = FieldValueConverter.of(values.get(ORIGIN));
         FieldValue fieldValue2 = FieldValueConverter.of(values.get(1));
         params.add(fieldValue);
         params.add(fieldValue2);
+    }
+
+    protected void predicateIn(StringBuilder query,
+                               Element document,
+                               List<FieldValue> params) {
+        String name = identifierOf(document.name());
+        Object value = sqlValuesOf(document);
+        FieldValue fieldValue = FieldValueConverter.of(value);
+        query.append(name).append(" IN ?[] ");
+        params.add(fieldValue);
     }
 
     protected void appendCondition(StringBuilder query, List<FieldValue> params,
@@ -213,17 +223,28 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     }
 
     private Object sqlValueOf(Element document) {
+        Object value = ValueUtil.convert(document.value());
         if (!DefaultOracleNoSQLDocumentManager.ID.equals(document.name())) {
-            return document.get();
+            return value;
         }
 
-        Object value = document.get();
         if (value instanceof Iterable<?> iterable) {
             List<String> ids = new ArrayList<>();
             iterable.forEach(id -> ids.add(generateId(String.valueOf(id))));
             return ids;
         }
         return generateId(String.valueOf(value));
+    }
+
+    private Object sqlValuesOf(Element document) {
+        List<Object> values = ValueUtil.convertToList(document.value());
+        if (!DefaultOracleNoSQLDocumentManager.ID.equals(document.name())) {
+            return values;
+        }
+
+        return values.stream()
+                .map(value -> generateId(String.valueOf(value)))
+                .toList();
     }
 
     private String generateId(String id) {

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/QueryValueNormalizationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/QueryValueNormalizationTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import org.eclipse.jnosql.communication.Params;
+import org.eclipse.jnosql.communication.query.data.DeleteProvider;
+import org.eclipse.jnosql.communication.query.data.SelectProvider;
+import org.eclipse.jnosql.communication.semistructured.CommunicationObserverParser;
+import org.eclipse.jnosql.communication.semistructured.DeleteQueryParams;
+import org.eclipse.jnosql.communication.semistructured.DeleteQueryParser;
+import org.eclipse.jnosql.communication.semistructured.QueryParams;
+import org.eclipse.jnosql.communication.semistructured.SelectQueryParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
+
+class QueryValueNormalizationTest {
+
+    @Test
+    void shouldNormalizeEnumScalarValue() {
+        var query = select().from("Person")
+                .where("kind").eq(NumberKind.PRIME)
+                .build();
+
+        var generated = new SelectBuilder(query, "entities").get();
+
+        assertThat(generated.params()).singleElement()
+                .satisfies(value -> assertThat(value.asString().getValue()).isEqualTo("PRIME"));
+    }
+
+    @Test
+    void shouldUnwrapNamedInParametersForCount() {
+        QueryParams queryParams = parseSelect("FROM Person WHERE age IN (:first, :second)",
+                params -> {
+                    params.bind("first", 21);
+                    params.bind("second", 42);
+                });
+
+        var generated = new SelectCountBuilder(queryParams.query(), "entities").get();
+
+        assertThat(generated.params()).singleElement()
+                .satisfies(value -> {
+                    assertThat(value.isArray()).isTrue();
+                    assertThat(value.asArray().get(0).asInteger().getValue()).isEqualTo(21);
+                    assertThat(value.asArray().get(1).asInteger().getValue()).isEqualTo(42);
+                });
+    }
+
+    @Test
+    void shouldUnwrapNamedBetweenParametersForDelete() {
+        DeleteQueryParams queryParams = delete("DELETE FROM Person WHERE age BETWEEN :minimum AND :maximum",
+                params -> {
+                    params.bind("minimum", 21);
+                    params.bind("maximum", 42);
+                });
+
+        var generated = new DeleteBuilder(queryParams.query(), "entities").get();
+
+        assertThat(generated.params()).hasSize(2);
+        assertThat(generated.params().get(0).asInteger().getValue()).isEqualTo(21);
+        assertThat(generated.params().get(1).asInteger().getValue()).isEqualTo(42);
+    }
+
+    @Test
+    void shouldKeepIdPrefixForMixedInQuery() {
+        var query = select().from("Person")
+                .where("_id").in(List.of("id-1", "id-2"))
+                .and("scope").eq("admin")
+                .build();
+
+        var generated = new SelectBuilder(query, "entities").get();
+
+        assertThat(generated.ids()).isEmpty();
+        assertThat(generated.params()).hasSize(2);
+        assertThat(generated.params().get(0).asArray().get(0).asString().getValue()).isEqualTo("Person:id-1");
+        assertThat(generated.params().get(0).asArray().get(1).asString().getValue()).isEqualTo("Person:id-2");
+    }
+
+    private static QueryParams parseSelect(String jdql, Consumer<Params> binder) {
+        var parsed = SelectProvider.INSTANCE.apply(jdql, "Person");
+        QueryParams queryParams = new SelectQueryParser()
+                .apply(parsed, CommunicationObserverParser.EMPTY);
+        binder.accept(queryParams.params());
+        return queryParams;
+    }
+
+    private static DeleteQueryParams delete(String jdql, Consumer<Params> binder) {
+        var parsed = DeleteProvider.INSTANCE.apply(jdql);
+        DeleteQueryParams queryParams = new DeleteQueryParser()
+                .apply(parsed, CommunicationObserverParser.EMPTY);
+        binder.accept(queryParams.params());
+        return queryParams;
+    }
+
+    private enum NumberKind {
+        PRIME
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-jnosql/jnosql/issues/729

## What changed

- normalize scalar Oracle NoSQL query values with `ValueUtil` before `FieldValue` conversion
- unwrap and normalize `IN` and `BETWEEN` parameter values, including named `ParamValue` lists
- preserve the `_id` fast path and entity-name prefix behavior
- add database-free regression tests for enum, `IN`, and `BETWEEN` values across select, count, and delete query builders

## Verification

- `mvn -B -pl jnosql-oracle-nosql verify`
- 122 tests run, 0 failures, 0 errors, 54 skipped
- Jakarta Data TCK validation confirms that the 12 `ParamValue` and 11 enum conversion errors reported by this issue no longer occur
