### PR TITLE
fix: support Character values in Oracle NoSQL

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
@@ -83,11 +83,11 @@ class FieldValueConverter {
 
     private static final class StringValueMapper implements FieldValueMapper {
         public boolean supports(Object value) {
-            return value instanceof String;
+            return value instanceof String || value instanceof Character;
         }
 
         public FieldValue toFieldValue(Object value) {
-            return new StringValue((String) value);
+            return new StringValue(value.toString());
         }
     }
 

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverterTest.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FieldValueConverterTest {
+
+    @Test
+    void shouldConvertCharacterToStringValue() {
+        var value = FieldValueConverter.of('j');
+
+        assertThat(value.isString()).isTrue();
+        assertThat(value.asString().getValue()).isEqualTo("j");
+    }
+}

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
@@ -77,4 +77,16 @@ class SelectBuilderTest {
                 .contains(" OR ")
                 .endsWith(")");
     }
+
+    @Test
+    void shouldConvertCharacterPredicateToStringValue() {
+        var query = select().from("asciiCharacter")
+                .where("thisCharacter").eq('j')
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "characters").get();
+
+        assertThat(oracleQuery.params()).singleElement()
+                .satisfies(value -> assertThat(value.asString().getValue()).isEqualTo("j"));
+    }
 }


### PR DESCRIPTION
 Fixes https://github.com/eclipse-jnosql/jnosql/issues/730

## What changed

- convert Java `Character` values to one-character Oracle NoSQL `StringValue` instances
- add direct converter regression coverage
- add database-free coverage for `Character` query predicates

## Verification

- `mvn -B -pl jnosql-oracle-nosql verify`
- 120 tests run, 0 failures, 0 errors, 54 skipped
- RAT, Checkstyle, and PMD passed
- cumulative Jakarta Data TCK validation confirms `testFindOne` and `testBy` now pass with no remaining `Character` conversion errors
