### PR TITLE
fix: support Character values in Oracle NoSQL

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
@@ -37,6 +37,8 @@ enum FieldValueConverter {
     FieldValue of(Object value) {
         if (value == null) {
             return NullValue.getInstance();
+        } else if (value instanceof Character character) {
+            return new StringValue(character.toString());
         } else if (value instanceof String string) {
             return new StringValue(string);
         } else if (value instanceof UUID uuid) {

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverterTest.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FieldValueConverterTest {
+
+    @Test
+    void shouldConvertCharacterToStringValue() {
+        var value = FieldValueConverter.INSTANCE.of('Q');
+
+        assertThat(value.isString()).isTrue();
+        assertThat(value.asString().getValue()).isEqualTo("Q");
+    }
+}

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
@@ -77,4 +77,18 @@ class SelectBuilderTest {
                 .contains(" OR ")
                 .endsWith(")");
     }
+
+    @Test
+    void shouldConvertCharacterPredicateToStringValue() {
+        var query = select().from("person")
+                .where("middleInitial").eq('Q')
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.params()).singleElement().satisfies(value -> {
+            assertThat(value.isString()).isTrue();
+            assertThat(value.asString().getValue()).isEqualTo("Q");
+        });
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jnosql/jnosql/issues/730

## What changed

- convert Java `Character` values to one-character Oracle NoSQL `StringValue` instances
- add direct converter regression coverage
- add database-free coverage for `Character` query predicates

## Verification

- `mvn -B -pl jnosql-oracle-nosql verify`
- 116 tests run, 0 failures, 0 errors, 50 skipped
- RAT, Checkstyle, and PMD passed
- exact 1.1.15 validation with fixes #728, #729, and #730: 129 tests run, 0 failures, 0 errors, 50 skipped
- cumulative Jakarta Data TCK result improved from 43 passes/20 failures/25 errors to 45 passes/20 failures/23 errors
- `testFindOne` and `testBy` now pass, with no new TCK regression
