### PR TITLE
Fix Oracle NoSQL typed ID routing

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -66,16 +66,16 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
                 }
                 return;
             case LESSER_THAN:
-                predicate(query, " < ", document, params);
+                predicateRelational(query, " < ", document, params);
                 return;
             case GREATER_THAN:
-                predicate(query, " > ", document, params);
+                predicateRelational(query, " > ", document, params);
                 return;
             case LESSER_EQUALS_THAN:
-                predicate(query, " <= ", document, params);
+                predicateRelational(query, " <= ", document, params);
                 return;
             case GREATER_EQUALS_THAN:
-                predicate(query, " >= ", document, params);
+                predicateRelational(query, " >= ", document, params);
                 return;
             case LIKE:
                 predicateLike(query, document);
@@ -152,7 +152,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     }
 
     protected void predicateBetween(StringBuilder query,List<FieldValue> params, Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
 
         List<Object> values = ValueUtil.convertToList(document.value());
 
@@ -174,7 +174,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     }
 
     private void predicateBetweenIgnoreCase(StringBuilder query, List<FieldValue> params, Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
 
         List<Object> values = ValueUtil.convertToList(document.value());
 
@@ -245,16 +245,27 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
         return value;
     }
 
+    private void predicateRelational(StringBuilder query,
+                                     String condition,
+                                     Element document,
+                                     List<FieldValue> params) {
+        String name = relationalIdentifierOf(document.name());
+        Object value = ValueUtil.convert(document.value());
+        FieldValue fieldValue = FieldValueConverter.of(value);
+        query.append(name).append(condition).append(" ? ");
+        params.add(fieldValue);
+    }
+
     protected void predicateLike(StringBuilder query,
                              Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         Object value = OracleNoSqlLikeConverter.INSTANCE.convert(document.get());
         query.append("regex_like(").append(name).append(", \"").append(value).append("\")");
     }
 
     protected void predicateStartsWith(StringBuilder query,
                                  Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         var value = document.get() == null ? "" : document.get(String.class);
         query.append("regex_like(").append(name).append(", \"").append(OracleNoSqlLikeConverter.INSTANCE.startsWith(value)).append(
                 "\")");
@@ -262,7 +273,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
 
     protected void predicateEndsWith(StringBuilder query,
                                        Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         var value = document.get() == null ? "" : document.get(String.class);
         query.append("regex_like(").append(name).append(", \"").append(OracleNoSqlLikeConverter.INSTANCE.endsWith(value)).append(
                 "\")");
@@ -270,7 +281,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
 
     protected void predicateContains(StringBuilder query,
                                      Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         var value = document.get() == null ? "" : document.get(String.class);
         query.append("regex_like(").append(name).append(", \"").append(OracleNoSqlLikeConverter.INSTANCE.contains(value)).append(
                 "\")");
@@ -280,7 +291,16 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
         if (DefaultOracleNoSQLDocumentManager.ID.equals(name)) {
             return ' ' + table + "." + ID_FIELD + ' ';
         }
-        return ' ' + table + "." + JSON_FIELD + "." + name + ' ';
+        return relationalIdentifierOf(name);
+    }
+
+    protected String sortIdentifierOf(String name) {
+        return relationalIdentifierOf(name);
+    }
+
+    private String relationalIdentifierOf(String name) {
+        String identifier = DefaultOracleNoSQLDocumentManager.ID.equals(name) ? '"' + name + '"' : name;
+        return ' ' + table + "." + JSON_FIELD + "." + identifier + ' ';
     }
 
     private Object sqlValueOf(Element document) {

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
@@ -54,7 +54,7 @@ final class SelectBuilder extends AbstractQueryBuilder {
             query.append(" ORDER BY ");
 
             String order = this.documentQuery.sorts().stream()
-                    .map(s -> identifierOf(s.property()) + " " + (s.isAscending() ? Direction.ASC : Direction.DESC))
+                    .map(s -> sortIdentifierOf(s.property()) + " " + (s.isAscending() ? Direction.ASC : Direction.DESC))
                     .collect(Collectors.joining(", "));
             query.append(order);
         }

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
@@ -118,6 +118,89 @@ class SelectBuilderTest {
     }
 
     @Test
+    void shouldUseTypedJsonIdForRelationalQuery() {
+        var query = select().from("person")
+                .where("_id").gte(54L)
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.ids()).isEmpty();
+        assertThat(oracleQuery.query())
+                .contains("people.content.\"_id\"")
+                .doesNotContain("people.id");
+        assertThat(oracleQuery.params()).singleElement().satisfies(value -> {
+            assertThat(value.isLong()).isTrue();
+            assertThat(value.toJson()).isEqualTo("54");
+        });
+    }
+
+    @Test
+    void shouldUseTypedJsonIdForBetweenQuery() {
+        var query = select().from("person")
+                .where("_id").between(52L, 57L)
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.ids()).isEmpty();
+        assertThat(oracleQuery.query())
+                .contains("people.content.\"_id\"")
+                .contains("BETWEEN ? AND ?")
+                .doesNotContain("people.id");
+        assertThat(oracleQuery.params())
+                .extracting(value -> value.toJson())
+                .containsExactly("52", "57");
+    }
+
+    @Test
+    void shouldUseTypedJsonIdForIgnoreCaseBetweenQuery() {
+        var condition = CriteriaCondition.ignoreCase(
+                CriteriaCondition.between("_id", List.of("Alpha", "Zulu")));
+        var query = SelectQuery.builder().from("person")
+                .where(condition)
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.ids()).isEmpty();
+        assertThat(oracleQuery.query())
+                .contains("lower(")
+                .contains("people.content.\"_id\"")
+                .contains("BETWEEN ? AND ?")
+                .doesNotContain("people.id");
+        assertThat(oracleQuery.params())
+                .extracting(value -> value.asString().getValue())
+                .containsExactly("alpha", "zulu");
+    }
+
+    @Test
+    void shouldUseTypedJsonIdForOrdering() {
+        var query = select().from("person")
+                .orderBy("_id").desc()
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.query())
+                .contains("ORDER BY  people.content.\"_id\"  DESC")
+                .doesNotContain("people.id");
+        assertThat(oracleQuery.params()).isEmpty();
+        assertThat(oracleQuery.ids()).isEmpty();
+    }
+
+    @Test
+    void shouldKeepIdProjectionOnPrimaryKey() {
+        var query = select("_id").from("person").build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.query())
+                .contains("id, entity, people.id")
+                .doesNotContain("people.content.\"_id\"");
+    }
+
+    @Test
     void shouldWrapCompositeOrConditionsToPreserveEntityFilter() {
         var query = select().from("person")
                 .where("age").not().gt(42)


### PR DESCRIPTION
Fixes https://github.com/eclipse-jnosql/jnosql/issues/731

## Summary

  Oracle NoSQL stores an entity ID in two forms:

  - the entity-qualified string table primary key, such as `NaturalNumber:54`;
  - the original typed value in `content."_id"`, such as numeric `54`.

  This change keeps direct `_id` equality, `IN`, and projection operations on the table primary key while routing operations that require the original type through `content."_id"`:

  - `<`, `<=`, `>`, and `>=`
  - `BETWEEN`
  - `ORDER BY`

  The JSON `_id` identifier is quoted, and relational values retain their original Oracle NoSQL type. Regression tests cover relational predicates, ranges, ordering, and primary-key projection behavior.

  ## Verification

  `mvn -B -pl jnosql-oracle-nosql verify`

  - Tests run: 122
  - Failures: 0
  - Errors: 0
  - Skipped: 54
