### PR TITLE
Fix Oracle NoSQL typed ID routing

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -66,16 +66,16 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
                 }
                 return;
             case LESSER_THAN:
-                predicate(query, " < ", document, params);
+                predicateRelational(query, " < ", document, params);
                 return;
             case GREATER_THAN:
-                predicate(query, " > ", document, params);
+                predicateRelational(query, " > ", document, params);
                 return;
             case LESSER_EQUALS_THAN:
-                predicate(query, " <= ", document, params);
+                predicateRelational(query, " <= ", document, params);
                 return;
             case GREATER_EQUALS_THAN:
-                predicate(query, " >= ", document, params);
+                predicateRelational(query, " >= ", document, params);
                 return;
             case LIKE:
                 predicateLike(query, document);
@@ -154,7 +154,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     }
 
     protected void predicateBetween(StringBuilder query,List<FieldValue> params, Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
 
         List<Object> values = ValueUtil.convertToList(document.value());
 
@@ -176,7 +176,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     }
 
     private void predicateBetweenIgnoreCase(StringBuilder query, List<FieldValue> params, Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
 
         List<Object> values = ValueUtil.convertToList(document.value());
 
@@ -247,16 +247,27 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
         return value;
     }
 
+    private void predicateRelational(StringBuilder query,
+                                     String condition,
+                                     Element document,
+                                     List<FieldValue> params) {
+        String name = relationalIdentifierOf(document.name());
+        Object value = ValueUtil.convert(document.value());
+        FieldValue fieldValue = FieldValueConverter.INSTANCE.of(value);
+        query.append(name).append(condition).append(" ? ");
+        params.add(fieldValue);
+    }
+
     protected void predicateLike(StringBuilder query,
                                  Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         Object value = OracleNoSqlLikeConverter.INSTANCE.convert(document.get());
         query.append("regex_like(").append(name).append(", \"").append(value).append("\")");
     }
 
     protected void predicateStartsWith(StringBuilder query,
                                        Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         var value = document.get() == null ? "" : document.get(String.class);
         query.append("regex_like(").append(name).append(", \"").append(OracleNoSqlLikeConverter.INSTANCE.startsWith(value)).append(
                 "\")");
@@ -264,7 +275,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
 
     protected void predicateEndsWith(StringBuilder query,
                                      Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         var value = document.get() == null ? "" : document.get(String.class);
         query.append("regex_like(").append(name).append(", \"").append(OracleNoSqlLikeConverter.INSTANCE.endsWith(value)).append(
                 "\")");
@@ -272,7 +283,7 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
 
     protected void predicateContains(StringBuilder query,
                                      Element document) {
-        String name = identifierOf(document.name());
+        String name = relationalIdentifierOf(document.name());
         var value = document.get() == null ? "" : document.get(String.class);
         query.append("regex_like(").append(name).append(", \"").append(OracleNoSqlLikeConverter.INSTANCE.contains(value)).append(
                 "\")");
@@ -282,7 +293,16 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
         if (DefaultOracleNoSQLDocumentManager.ID.equals(name)) {
             return ' ' + table + "." + ID_FIELD + ' ';
         }
-        return ' ' + table + "." + JSON_FIELD + "." + name + ' ';
+        return relationalIdentifierOf(name);
+    }
+
+    protected String sortIdentifierOf(String name) {
+        return relationalIdentifierOf(name);
+    }
+
+    private String relationalIdentifierOf(String name) {
+        String field = DefaultOracleNoSQLDocumentManager.ID.equals(name) ? '"' + name + '"' : name;
+        return ' ' + table + "." + JSON_FIELD + "." + field + ' ';
     }
 
     private Object sqlValueOf(Element document) {

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
@@ -54,7 +54,7 @@ final class SelectBuilder extends AbstractQueryBuilder {
             query.append(" ORDER BY ");
 
             String order = this.documentQuery.sorts().stream()
-                    .map(s -> identifierOf(s.property()) + " " + (s.isAscending() ? Direction.ASC : Direction.DESC))
+                    .map(s -> sortIdentifierOf(s.property()) + " " + (s.isAscending() ? Direction.ASC : Direction.DESC))
                     .collect(Collectors.joining(", "));
             query.append(order);
         }

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
 
 class SelectBuilderTest {
@@ -149,5 +150,114 @@ class SelectBuilderTest {
 
     private static String normalize(String query) {
         return query.replaceAll("\\s+", " ").trim();
+    }
+
+    @Test
+    void shouldUseTypedJsonIdForRelationalPredicates() {
+        var queries = List.of(
+                select().from("naturalNumber").where("_id").lt(54L).build(),
+                select().from("naturalNumber").where("_id").lte(54L).build(),
+                select().from("naturalNumber").where("_id").gt(54L).build(),
+                select().from("naturalNumber").where("_id").gte(54L).build());
+
+        assertThat(queries).allSatisfy(query -> {
+            var oracleQuery = new SelectBuilder(query, "entities").get();
+
+            assertThat(oracleQuery.query())
+                    .contains("entities.content.\"_id\"")
+                    .doesNotContain("entities.id");
+            assertThat(oracleQuery.params()).singleElement()
+                    .satisfies(value -> assertThat(value.asLong().getValue()).isEqualTo(54L));
+        });
+    }
+
+    @Test
+    void shouldUseTypedJsonIdForBetweenInEverySqlBuilder() {
+        var selectQuery = select().from("naturalNumber")
+                .where("_id").between(49L, 54L)
+                .build();
+        var deleteQuery = delete().from("naturalNumber")
+                .where("_id").between(49L, 54L)
+                .build();
+
+        var oracleQueries = List.of(
+                new SelectBuilder(selectQuery, "entities").get(),
+                new SelectCountBuilder(selectQuery, "entities").get(),
+                new DeleteBuilder(deleteQuery, "entities").get());
+
+        assertThat(oracleQueries).allSatisfy(oracleQuery -> {
+            assertThat(oracleQuery.query())
+                    .contains("entities.content.\"_id\"")
+                    .contains("BETWEEN ? AND ?")
+                    .doesNotContain("entities.id");
+            assertThat(oracleQuery.params()).hasSize(2);
+            assertThat(oracleQuery.params().get(0).asLong().getValue()).isEqualTo(49L);
+            assertThat(oracleQuery.params().get(1).asLong().getValue()).isEqualTo(54L);
+        });
+    }
+
+    @Test
+    void shouldUseTypedJsonIdForIgnoreCaseBetweenQuery() {
+        var condition = CriteriaCondition.ignoreCase(
+                CriteriaCondition.between("_id", List.of("Alpha", "Zulu")));
+        var query = SelectQuery.builder().from("person")
+                .where(condition)
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "people").get();
+
+        assertThat(oracleQuery.ids()).isEmpty();
+        assertThat(oracleQuery.query())
+                .contains("lower(")
+                .contains("people.content.\"_id\"")
+                .contains("BETWEEN ? AND ?")
+                .doesNotContain("people.id");
+        assertThat(oracleQuery.params())
+                .extracting(value -> value.asString().getValue())
+                .containsExactly("alpha", "zulu");
+    }
+
+    @Test
+    void shouldUseTypedJsonIdForSorting() {
+        var query = select().from("naturalNumber")
+                .orderBy("_id").asc()
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "entities").get();
+
+        assertThat(oracleQuery.query())
+                .contains("ORDER BY")
+                .contains("entities.content.\"_id\"")
+                .contains("ASC")
+                .doesNotContain("ORDER BY  entities.id");
+    }
+
+    @Test
+    void shouldKeepPrimaryKeyIdForProjection() {
+        var query = select("_id").from("naturalNumber").build();
+
+        var oracleQuery = new SelectBuilder(query, "entities").get();
+
+        assertThat(oracleQuery.query())
+                .contains("select id, entity, entities.id")
+                .doesNotContain("entities.content.\"_id\"");
+    }
+
+    @Test
+    void shouldKeepPrefixedPrimaryKeyIdForDirectInPredicate() {
+        var query = select().from("naturalNumber")
+                .where("_id").in(List.of(54L, 55L))
+                .build();
+
+        var oracleQuery = new SelectCountBuilder(query, "entities").get();
+
+        assertThat(oracleQuery.query())
+                .contains("entities.id")
+                .contains("IN")
+                .doesNotContain("entities.content.\"_id\"");
+        assertThat(oracleQuery.params()).singleElement().satisfies(value -> {
+            assertThat(value.asArray().get(0).asString().getValue()).isEqualTo("naturalNumber:54");
+            assertThat(value.asArray().get(1).asString().getValue()).isEqualTo("naturalNumber:55");
+        });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jnosql/jnosql/issues/731

 ## Summary

  Backports the Oracle NoSQL typed `_id` routing fix to the `1.1.x` branch.

  Direct `_id` equality, `IN`, and projection operations continue using the entity-qualified string table primary key. Relational predicates, `BETWEEN`, and `_id` ordering now use the original typed value stored in
  `content."_id"`.

  Regression tests cover all relational operators, range handling across the SQL builders, ordering, projection, and preservation of the direct primary-key fast path.

  ## Verification

  `mvn -B -pl jnosql-oracle-nosql verify`

  - Tests run: 119
  - Failures: 0
  - Errors: 0
  - Skipped: 50
