### PR TITLE
fix: preserve Oracle NoSQL returned IDs

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
@@ -295,12 +295,19 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
                         entity.add(Element.of(entry.getKey(), FieldValueConverter.INSTANCE.of(entry.getValue())));
                     }
                 }
-                var id = result.get(ORACLE_ID).asString().getValue().split(":")[1];
-                entity.add(Element.of(ID, id));
+                addPrimaryKeyIdWhenMissing(entity, result.get(ORACLE_ID).asString().getValue());
                 entities.add(entity);
             }
         } while (!queryRequest.isDone());
         return entities;
+    }
+
+    static void addPrimaryKeyIdWhenMissing(CommunicationEntity entity, String primaryKey) {
+        if (entity.find(ID).isEmpty()) {
+            int separator = primaryKey.indexOf(':');
+            String id = separator < 0 ? primaryKey : primaryKey.substring(separator + 1);
+            entity.add(Element.of(ID, id));
+        }
     }
 
     private void put(CommunicationEntity entity, TimeToLive ttl) {

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerTest.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultOracleNoSQLDocumentManagerTest {
+
+    @Test
+    void shouldPreserveExistingTypedId() {
+        var entity = CommunicationEntity.of("CatalogItem");
+        entity.add("_id", 54L);
+
+        DefaultOracleNoSQLDocumentManager.addPrimaryKeyIdWhenMissing(entity, "CatalogItem:54");
+
+        assertThat(entity.find("_id").orElseThrow().get())
+                .isEqualTo(54L)
+                .isInstanceOf(Long.class);
+    }
+
+    @Test
+    void shouldRemoveOnlyFirstPrimaryKeyPrefix() {
+        var entity = CommunicationEntity.of("CatalogItem");
+
+        DefaultOracleNoSQLDocumentManager.addPrimaryKeyIdWhenMissing(entity, "CatalogItem:part:42");
+
+        assertThat(entity.find("_id").orElseThrow().get()).isEqualTo("part:42");
+    }
+
+    @Test
+    void shouldUseEntirePrimaryKeyWithoutPrefix() {
+        var entity = CommunicationEntity.of("CatalogItem");
+
+        DefaultOracleNoSQLDocumentManager.addPrimaryKeyIdWhenMissing(entity, "standalone");
+
+        assertThat(entity.find("_id").orElseThrow().get()).isEqualTo("standalone");
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse-jnosql/jnosql/issues/732

  ## Summary

  - Preserve an existing typed `_id` from the deserialized JSON content.
  - Reconstruct `_id` from the table primary key only when it is missing.
  - Remove only the first primary-key prefix so IDs containing additional colons remain intact.
  - Add regression tests for typed IDs and fallback reconstruction.

  This prevents numeric IDs such as `54` from becoming the string `"54"` and prevents `CatalogItem:part:42` from being truncated to `part`.

  Preserving the original type also keeps cursor continuation boundaries compatible with ordering and predicates against `content."_id"`.

  This applies the same focused correction to the `1.1.x` branch.

  ## Verification

  - Tests run: 117
  - Failures: 0
  - Errors: 0
  - Skipped: 50
