### PR TITLE
fix: support Oracle NoSQL IGNORE_CASE conditions

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -23,6 +23,7 @@ import org.eclipse.jnosql.communication.semistructured.Element;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 
 import static org.eclipse.jnosql.databases.oracle.communication.TableCreationConfiguration.ID_FIELD;
@@ -113,8 +114,26 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
             case BETWEEN:
                 predicateBetween(query, params, document);
                 return;
+            case IGNORE_CASE:
+                predicateIgnoreCase(query, params, document.get(CriteriaCondition.class));
+                return;
             default:
                 throw new UnsupportedOperationException("There is not support condition for " + condition.condition());
+        }
+    }
+
+    private void predicateIgnoreCase(StringBuilder query, List<FieldValue> params, CriteriaCondition condition) {
+        var document = condition.element();
+        switch (condition.condition()) {
+            case EQUALS:
+                predicateIgnoreCase(query, " = ", document, params);
+                return;
+            case BETWEEN:
+                predicateBetweenIgnoreCase(query, params, document);
+                return;
+            default:
+                throw new UnsupportedOperationException("There is not support condition for IGNORE_CASE "
+                        + condition.condition());
         }
     }
 
@@ -154,6 +173,16 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
         FieldValue fieldValue = FieldValueConverter.INSTANCE.of(value);
         query.append(name).append(" IN ?[] ");
         params.add(fieldValue);
+    }
+
+    private void predicateBetweenIgnoreCase(StringBuilder query, List<FieldValue> params, Element document) {
+        String name = identifierOf(document.name());
+
+        List<Object> values = ValueUtil.convertToList(document.value());
+
+        query.append("lower(").append(name).append(") BETWEEN ? AND ? ");
+        params.add(FieldValueConverter.INSTANCE.of(lowerCaseString(values.get(ORIGIN))));
+        params.add(FieldValueConverter.INSTANCE.of(lowerCaseString(values.get(1))));
     }
 
     protected void appendCondition(StringBuilder query, List<FieldValue> params,
@@ -198,6 +227,24 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
 
     private void predicateNull(StringBuilder query, Element document, boolean negated) {
         query.append(identifierOf(document.name())).append(negated ? "IS NOT NULL " : "IS NULL ");
+    }
+
+    private void predicateIgnoreCase(StringBuilder query,
+                                     String condition,
+                                     Element document,
+                                     List<FieldValue> params) {
+        String name = identifierOf(document.name());
+        Object value = lowerCaseString(sqlValueOf(document));
+        FieldValue fieldValue = FieldValueConverter.INSTANCE.of(value);
+        query.append("lower(").append(name).append(")").append(condition).append(" ? ");
+        params.add(fieldValue);
+    }
+
+    private Object lowerCaseString(Object value) {
+        if (value instanceof String string) {
+            return string.toLowerCase(Locale.ROOT);
+        }
+        return value;
     }
 
     protected void predicateLike(StringBuilder query,

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
@@ -10,14 +10,69 @@
  */
 package org.eclipse.jnosql.databases.oracle.communication;
 
+import jakarta.data.Sort;
+import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
 
 class SelectBuilderTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "2B, 2b",
+            "2g, 2g",
+            "6A, 6a"
+    })
+    void shouldTranslateIgnoreCaseEquality(String value, String expectedBind) {
+        var condition = CriteriaCondition.ignoreCase(CriteriaCondition.eq("hexadecimal", value));
+        var query = SelectQuery.builder()
+                .from("AsciiCharacter")
+                .where(condition)
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "entity_data").get();
+
+        assertThat(normalize(oracleQuery.query()))
+                .contains("entity_data.entity= 'AsciiCharacter' AND")
+                .contains("lower( entity_data.content.hexadecimal ) = ?");
+        assertThat(oracleQuery.params()).hasSize(1);
+        assertThat(oracleQuery.params().get(0).asString().getValue()).isEqualTo(expectedBind);
+        assertThat(oracleQuery.ids()).isEmpty();
+    }
+
+    @Test
+    void shouldTranslateIgnoreCaseBetweenAndPreserveSurroundingQuery() {
+        var condition = CriteriaCondition.ignoreCase(
+                        CriteriaCondition.between("hexadecimal", List.of("4c", "5A")))
+                .and(CriteriaCondition.not(
+                        CriteriaCondition.in("hexadecimal", Set.of("5"))));
+        var query = SelectQuery.builder()
+                .from("AsciiCharacter")
+                .where(condition)
+                .sort(Sort.asc("hexadecimal"))
+                .build();
+
+        var oracleQuery = new SelectBuilder(query, "entity_data").get();
+
+        assertThat(normalize(oracleQuery.query())).isEqualTo(
+                "select * from entity_data WHERE entity_data.entity= 'AsciiCharacter' AND "
+                        + "(lower( entity_data.content.hexadecimal ) BETWEEN ? AND ? AND "
+                        + "NOT entity_data.content.hexadecimal IN ?[] ) "
+                        + "ORDER BY entity_data.content.hexadecimal ASC");
+        assertThat(oracleQuery.params()).hasSize(3);
+        assertThat(oracleQuery.params().get(0).asString().getValue()).isEqualTo("4c");
+        assertThat(oracleQuery.params().get(1).asString().getValue()).isEqualTo("5a");
+        assertThat(oracleQuery.params().get(2).asArray().get(0).asString().getValue()).isEqualTo("5");
+        assertThat(oracleQuery.ids()).isEmpty();
+    }
 
     @Test
     void shouldUseIdFastPathForEqualsQuery() {
@@ -90,5 +145,9 @@ class SelectBuilderTest {
             assertThat(value.isString()).isTrue();
             assertThat(value.asString().getValue()).isEqualTo("Q");
         });
+    }
+
+    private static String normalize(String query) {
+        return query.replaceAll("\\s+", " ").trim();
     }
 }


### PR DESCRIPTION
Fixes eclipse-jnosql/jnosql#733

  ## Summary

  - translate `IGNORE_CASE(EQUALS)` to `lower(field) = ?`
  - translate `IGNORE_CASE(BETWEEN)` to `lower(field) BETWEEN ? AND ?`
  - normalize String bind values using `Locale.ROOT`
  - preserve surrounding predicates, bind ordering, entity filtering, sorting, and existing `_id` fast paths
  - add regression coverage for the four Data TCK cases

  ## Verification

  - focused `SelectBuilderTest`: 8 passed
  - Oracle module: 118 tests run, 0 failures, 0 errors
  - unchanged issue reproducer: 4/4 passed against `1.1.16-SNAPSHOT`
  - Checkstyle, RAT, PMD, and packaging passed
