### PR TITLE
fix(oracle-nosql): Oracle NoSQL projections return SDK FieldValue wrappers instead of Java values

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -310,11 +311,13 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
                     var json = result.get(JSON_FIELD).toJson();
                     entity.addAll(Elements.of(jsonB.fromJson(json, Map.class)));
                 }
+                Map<String, Object> projectedFields = new LinkedHashMap<>();
                 for (Map.Entry<String, FieldValue> entry : result) {
-                    if (isNotOracleField(entry)) {
-                        entity.add(Element.of(entry.getKey(), FieldValueConverter.of(entry.getValue())));
+                    if (isNotOracleField(entry) && !entry.getValue().isEMPTY()) {
+                        projectedFields.put(entry.getKey(), FieldValueConverter.toObject(entry.getValue()));
                     }
                 }
+                entity.addAll(toElements(projectedFields));
                 addPrimaryKeyIdWhenMissing(entity, result.get(ORACLE_ID).asString().getValue());
                 entities.add(entity);
             }
@@ -328,6 +331,26 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
             String id = separator < 0 ? primaryKey : primaryKey.substring(separator + 1);
             entity.add(Element.of(ID, id));
         }
+    }
+
+    private static List<Element> toElements(Map<String, ?> values) {
+        return values.entrySet().stream()
+                .map(entry -> Element.of(entry.getKey(), toElementValue(entry.getValue())))
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object toElementValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            List<Element> elements = toElements((Map<String, ?>) map);
+            return elements.size() == 1 ? elements.get(0) : elements;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            return StreamSupport.stream(iterable.spliterator(), false)
+                    .map(DefaultOracleNoSQLDocumentManager::toElementValue)
+                    .toList();
+        }
+        return value;
     }
 
     private void put(CommunicationEntity entity, TimeToLive ttl) {

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
@@ -27,8 +27,11 @@ import oracle.nosql.driver.values.NumberValue;
 import oracle.nosql.driver.values.StringValue;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 class FieldValueConverter {
@@ -64,6 +67,43 @@ class FieldValueConverter {
         }
 
         throw new UnsupportedOperationException("Unsupported value type: " + value.getClass());
+    }
+
+    static Object toObject(FieldValue value) {
+        Objects.requireNonNull(value, "value is required");
+
+        return switch (value.getType()) {
+            case STRING -> value.getString();
+            case INTEGER -> value.getInt();
+            case LONG -> value.getLong();
+            case DOUBLE -> value.getDouble();
+            case BOOLEAN -> value.getBoolean();
+            case NUMBER -> value.getNumber();
+            case BINARY -> value.getBinary();
+            case TIMESTAMP -> value.getTimestamp();
+            case NULL, JSON_NULL -> null;
+            case ARRAY -> toList(value.asArray());
+            case MAP -> toMap(value.asMap());
+            case EMPTY -> throw new UnsupportedOperationException("EMPTY represents a missing field");
+        };
+    }
+
+    private static List<Object> toList(ArrayValue value) {
+        List<Object> result = new ArrayList<>(value.size());
+        for (FieldValue fieldValue : value) {
+            result.add(toObject(fieldValue));
+        }
+        return result;
+    }
+
+    private static Map<String, Object> toMap(MapValue value) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<String, FieldValue> entry : value) {
+            if (!entry.getValue().isEMPTY()) {
+                result.put(entry.getKey(), toObject(entry.getValue()));
+            }
+        }
+        return result;
     }
 
     private interface FieldValueMapper {

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionFieldValueConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionFieldValueConverterTest.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import oracle.nosql.driver.values.ArrayValue;
+import oracle.nosql.driver.values.BinaryValue;
+import oracle.nosql.driver.values.BooleanValue;
+import oracle.nosql.driver.values.DoubleValue;
+import oracle.nosql.driver.values.EmptyValue;
+import oracle.nosql.driver.values.FieldValue;
+import oracle.nosql.driver.values.IntegerValue;
+import oracle.nosql.driver.values.JsonNullValue;
+import oracle.nosql.driver.values.LongValue;
+import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.values.NullValue;
+import oracle.nosql.driver.values.NumberValue;
+import oracle.nosql.driver.values.StringValue;
+import oracle.nosql.driver.values.TimestampValue;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OracleNoSQLProjectionFieldValueConverterTest {
+
+    @Test
+    void shouldConvertScalarFieldValuesToJavaValues() {
+        BigDecimal number = new BigDecimal("1234567890.0123456789");
+        byte[] binary = {1, 2, 3};
+        Timestamp timestamp = Timestamp.valueOf("2026-08-02 19:30:45.123456789");
+
+        assertThat(FieldValueConverter.toObject(new StringValue("Ada")))
+                .isExactlyInstanceOf(String.class).isEqualTo("Ada");
+        assertThat(FieldValueConverter.toObject(new IntegerValue(42)))
+                .isExactlyInstanceOf(Integer.class).isEqualTo(42);
+        assertThat(FieldValueConverter.toObject(new LongValue(42L)))
+                .isExactlyInstanceOf(Long.class).isEqualTo(42L);
+        assertThat(FieldValueConverter.toObject(new DoubleValue(42.5)))
+                .isExactlyInstanceOf(Double.class).isEqualTo(42.5);
+        assertThat(FieldValueConverter.toObject(BooleanValue.trueInstance()))
+                .isExactlyInstanceOf(Boolean.class).isEqualTo(true);
+        assertThat(FieldValueConverter.toObject(new NumberValue(number)))
+                .isExactlyInstanceOf(BigDecimal.class).isEqualTo(number);
+        assertThat((byte[]) FieldValueConverter.toObject(new BinaryValue(binary)))
+                .containsExactly(binary);
+        assertThat(FieldValueConverter.toObject(new TimestampValue(timestamp)))
+                .isExactlyInstanceOf(Timestamp.class).isEqualTo(timestamp);
+        assertThat(FieldValueConverter.toObject(NullValue.getInstance())).isNull();
+        assertThat(FieldValueConverter.toObject(JsonNullValue.getInstance())).isNull();
+    }
+
+    @Test
+    void shouldRecursivelyConvertNestedFieldValues() {
+        MapValue nested = new MapValue(true, 4)
+                .put("enabled", BooleanValue.trueInstance())
+                .put("nullValue", NullValue.getInstance())
+                .put("jsonNullValue", JsonNullValue.getInstance())
+                .put("missing", EmptyValue.getInstance());
+        ArrayValue array = new ArrayValue()
+                .add(new StringValue("first"))
+                .add(new IntegerValue(2))
+                .add(JsonNullValue.getInstance())
+                .add(nested);
+        MapValue value = new MapValue(true, 3)
+                .put("name", new StringValue("projection"))
+                .put("items", array)
+                .put("details", nested);
+
+        Object converted = FieldValueConverter.toObject(value);
+
+        assertThat(converted).isInstanceOf(Map.class);
+        Map<?, ?> result = (Map<?, ?>) converted;
+        assertThat(result.get("name")).isExactlyInstanceOf(String.class).isEqualTo("projection");
+        assertThat(result.get("items")).isInstanceOf(List.class);
+        assertThat(result.get("items")).isEqualTo(Arrays.asList("first", 2, null, expectedNestedMap()));
+        assertThat(result.get("details")).isEqualTo(expectedNestedMap());
+        assertNoFieldValues(converted);
+    }
+
+    @Test
+    void shouldTreatEmptyAsMissingWithoutChangingArrayPositions() {
+        MapValue map = new MapValue(true, 2)
+                .put("present", new StringValue("value"))
+                .put("missing", EmptyValue.getInstance());
+
+        assertThat(FieldValueConverter.toObject(map)).isEqualTo(Map.of("present", "value"));
+        assertThatThrownBy(() -> FieldValueConverter.toObject(EmptyValue.getInstance()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("missing field");
+        assertThatThrownBy(() -> FieldValueConverter.toObject(
+                new ArrayValue().add(EmptyValue.getInstance())))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("missing field");
+    }
+
+    private static void assertNoFieldValues(Object value) {
+        if (value == null) {
+            return;
+        }
+        assertThat(value).isNotInstanceOf(FieldValue.class);
+        if (value instanceof Map<?, ?> map) {
+            map.forEach((key, item) -> assertNoFieldValues(item));
+        } else if (value instanceof Iterable<?> iterable) {
+            iterable.forEach(OracleNoSQLProjectionFieldValueConverterTest::assertNoFieldValues);
+        }
+    }
+
+    private static Map<String, Object> expectedNestedMap() {
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("enabled", true);
+        expected.put("nullValue", null);
+        expected.put("jsonNullValue", null);
+        return expected;
+    }
+}

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionResultTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionResultTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import jakarta.json.bind.Jsonb;
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.PrepareRequest;
+import oracle.nosql.driver.ops.PrepareResult;
+import oracle.nosql.driver.ops.PreparedStatement;
+import oracle.nosql.driver.ops.QueryRequest;
+import oracle.nosql.driver.ops.QueryResult;
+import oracle.nosql.driver.values.ArrayValue;
+import oracle.nosql.driver.values.EmptyValue;
+import oracle.nosql.driver.values.FieldValue;
+import oracle.nosql.driver.values.IntegerValue;
+import oracle.nosql.driver.values.JsonNullValue;
+import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.values.NullValue;
+import oracle.nosql.driver.values.StringValue;
+import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
+import org.eclipse.jnosql.communication.semistructured.Element;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OracleNoSQLProjectionResultTest {
+
+    @Test
+    void shouldExposeSqlProjectionValuesWithoutOracleWrappers() {
+        MapValue nested = new MapValue(true, 6)
+                .put("label", new StringValue("nested"))
+                .put("values", new ArrayValue()
+                        .add(new IntegerValue(1))
+                        .add(JsonNullValue.getInstance()))
+                .put("sqlNull", NullValue.getInstance())
+                .put("jsonNull", JsonNullValue.getInstance())
+                .put("missing", EmptyValue.getInstance());
+        MapValue row = new MapValue(true, 8)
+                .put(DefaultOracleNoSQLDocumentManager.ORACLE_ID, new StringValue("person:42"))
+                .put(DefaultOracleNoSQLDocumentManager.ENTITY, new StringValue("person"))
+                .put("name", new StringValue("Ada"))
+                .put("age", new IntegerValue(37))
+                .put("profile", nested)
+                .put("nullable", JsonNullValue.getInstance())
+                .put("missing", EmptyValue.getInstance());
+
+        NoSQLHandle handle = mock(NoSQLHandle.class);
+        Jsonb jsonb = mock(Jsonb.class);
+        PreparedStatement statement = mock(PreparedStatement.class);
+        PrepareResult prepareResult = new PrepareResult().setPreparedStatement(statement);
+        QueryResult queryResult = new QueryResult(new QueryRequest()).setResults(List.of(row));
+        when(handle.prepare(any(PrepareRequest.class))).thenReturn(prepareResult);
+        when(handle.query(any(QueryRequest.class))).thenReturn(queryResult);
+        var manager = new DefaultOracleNoSQLDocumentManager("database", handle, jsonb);
+
+        CommunicationEntity entity = manager.sql("select projections from database")
+                .findFirst().orElseThrow();
+
+        assertThat(entity.name()).isEqualTo("person");
+        assertThat(entity.find(DefaultOracleNoSQLDocumentManager.ID).orElseThrow().get())
+                .isExactlyInstanceOf(String.class).isEqualTo("42");
+        assertThat(entity.find("name").orElseThrow().get())
+                .isExactlyInstanceOf(String.class).isEqualTo("Ada");
+        assertThat(entity.find("age").orElseThrow().get())
+                .isExactlyInstanceOf(Integer.class).isEqualTo(37);
+        assertThat(entity.find("nullable")).isPresent();
+        assertThat(entity.find("nullable").orElseThrow().get()).isNull();
+        assertThat(entity.find("missing")).isEmpty();
+
+        Map<String, Object> profile = new LinkedHashMap<>();
+        for (Object value : (List<?>) entity.find("profile").orElseThrow().get()) {
+            Element element = (Element) value;
+            profile.put(element.name(), element.get());
+        }
+        assertThat(profile).containsKeys("sqlNull", "jsonNull").doesNotContainKey("missing");
+        assertThat(profile.get("sqlNull")).isNull();
+        assertThat(profile.get("jsonNull")).isNull();
+        assertNoFieldValues(entity.toMap());
+    }
+
+    private static void assertNoFieldValues(Object value) {
+        if (value == null) {
+            return;
+        }
+        assertThat(value).isNotInstanceOf(FieldValue.class);
+        if (value instanceof Map<?, ?> map) {
+            map.forEach((key, item) -> assertNoFieldValues(item));
+        } else if (value instanceof Iterable<?> iterable) {
+            iterable.forEach(OracleNoSQLProjectionResultTest::assertNoFieldValues);
+        } else if (value instanceof Element element) {
+            assertNoFieldValues(element.get());
+        }
+    }
+}


### PR DESCRIPTION
  Fixes eclipse-jnosql/jnosql#736

  This change converts Oracle NoSQL projection results from SDK `FieldValue` wrappers into Java values before returning them through JNoSQL.

  It recursively handles scalar values, nested maps, and arrays. SQL `NULL` and JSON `null` are preserved as Java `null`, while missing `EMPTY` fields are omitted.

  Tests cover:

  - Scalar projection values
  - Nested maps and arrays
  - SQL and JSON null values
  - Missing `EMPTY` values
  - Conversion at the document-manager query boundary

  Validation:

  - Oracle NoSQL module: 122 tests, 0 failures, 0 errors
  - RAT and Checkstyle passed
  - NoSQL Data TCK improved from 74 to 77 passing tests
  - All three projection tests addressed by this issue now pass

