### PR TITLE
fix: Oracle NoSQL projections return SDK FieldValue wrappers instead of Java values

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -310,11 +311,13 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
                     var json = result.get(JSON_FIELD).toJson();
                     entity.addAll(Elements.of(jsonB.fromJson(json, Map.class)));
                 }
+                Map<String, Object> projectedFields = new LinkedHashMap<>();
                 for (Map.Entry<String, FieldValue> entry : result) {
-                    if (isNotOracleField(entry)) {
-                        entity.add(Element.of(entry.getKey(), FieldValueConverter.INSTANCE.of(entry.getValue())));
+                    if (isNotOracleField(entry) && !entry.getValue().isEMPTY()) {
+                        projectedFields.put(entry.getKey(), FieldValueConverter.INSTANCE.toObject(entry.getValue()));
                     }
                 }
+                entity.addAll(toElements(projectedFields));
                 addPrimaryKeyIdWhenMissing(entity, result.get(ORACLE_ID).asString().getValue());
                 entities.add(entity);
             }
@@ -328,6 +331,26 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
             String id = separator < 0 ? primaryKey : primaryKey.substring(separator + 1);
             entity.add(Element.of(ID, id));
         }
+    }
+
+    private static List<Element> toElements(Map<String, ?> values) {
+        return values.entrySet().stream()
+                .map(entry -> Element.of(entry.getKey(), toElementValue(entry.getValue())))
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object toElementValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            List<Element> elements = toElements((Map<String, ?>) map);
+            return elements.size() == 1 ? elements.get(0) : elements;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            return StreamSupport.stream(iterable.spliterator(), false)
+                    .map(DefaultOracleNoSQLDocumentManager::toElementValue)
+                    .toList();
+        }
+        return value;
     }
 
     private void put(CommunicationEntity entity, TimeToLive ttl) {

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
@@ -27,6 +27,9 @@ import oracle.nosql.driver.values.NumberValue;
 import oracle.nosql.driver.values.StringValue;
 
 import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -69,21 +72,38 @@ enum FieldValueConverter {
     }
 
     Object toObject(FieldValue value) {
-        if (value.isNull()) {
-            return null;
-        }
         return switch (value.getType()) {
-            case STRING -> value.asString();
-            case INTEGER -> value.asInteger();
-            case LONG -> value.asLong();
-            case DOUBLE -> value.asDouble();
-            case BOOLEAN -> value.asBoolean();
-            case NUMBER -> value.asNumber();
-            case BINARY -> value.asBinary();
-            case ARRAY -> value.asArray();
-            case MAP -> value.asMap();
-            default -> throw new UnsupportedOperationException("There is not support to: " + value.getType());
+            case STRING -> value.getString();
+            case INTEGER -> value.getInt();
+            case LONG -> value.getLong();
+            case DOUBLE -> value.getDouble();
+            case BOOLEAN -> value.getBoolean();
+            case NUMBER -> value.getNumber();
+            case BINARY -> value.getBinary();
+            case TIMESTAMP -> value.getTimestamp();
+            case NULL, JSON_NULL -> null;
+            case ARRAY -> toList(value.asArray());
+            case MAP -> toMap(value.asMap());
+            case EMPTY -> throw new UnsupportedOperationException("Oracle EMPTY represents a missing value");
         };
+    }
+
+    private List<Object> toList(ArrayValue value) {
+        List<Object> values = new ArrayList<>(value.size());
+        for (FieldValue element : value) {
+            values.add(toObject(element));
+        }
+        return values;
+    }
+
+    private Map<String, Object> toMap(MapValue value) {
+        Map<String, Object> values = new LinkedHashMap<>();
+        for (Map.Entry<String, FieldValue> entry : value) {
+            if (!entry.getValue().isEMPTY()) {
+                values.put(entry.getKey(), toObject(entry.getValue()));
+            }
+        }
+        return values;
     }
 
     private MapValue entries(Map<String, ?> value) {

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionFieldValueConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionFieldValueConverterTest.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import oracle.nosql.driver.values.ArrayValue;
+import oracle.nosql.driver.values.BinaryValue;
+import oracle.nosql.driver.values.BooleanValue;
+import oracle.nosql.driver.values.DoubleValue;
+import oracle.nosql.driver.values.EmptyValue;
+import oracle.nosql.driver.values.FieldValue;
+import oracle.nosql.driver.values.IntegerValue;
+import oracle.nosql.driver.values.JsonNullValue;
+import oracle.nosql.driver.values.LongValue;
+import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.values.NullValue;
+import oracle.nosql.driver.values.NumberValue;
+import oracle.nosql.driver.values.StringValue;
+import oracle.nosql.driver.values.TimestampValue;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OracleNoSQLProjectionFieldValueConverterTest {
+
+    private final FieldValueConverter converter = FieldValueConverter.INSTANCE;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRecursivelyConvertFieldValuesToJavaValues() {
+        byte[] binary = {1, 2, 3};
+        BigDecimal number = new BigDecimal("1234567890.0123456789");
+        Timestamp timestamp = Timestamp.valueOf("2026-08-02 12:34:56.123456789");
+        MapValue nestedMap = new MapValue()
+                .put("nestedString", new StringValue("nested"))
+                .put("nestedLong", new LongValue(99L));
+        ArrayValue array = new ArrayValue()
+                .add(new StringValue("first"))
+                .add(new IntegerValue(7))
+                .add(nestedMap);
+        MapValue source = new MapValue()
+                .put("string", new StringValue("value"))
+                .put("integer", new IntegerValue(42))
+                .put("long", new LongValue(43L))
+                .put("double", new DoubleValue(44.5D))
+                .put("boolean", BooleanValue.trueInstance())
+                .put("number", new NumberValue(number))
+                .put("binary", new BinaryValue(binary))
+                .put("timestamp", new TimestampValue(timestamp))
+                .put("null", NullValue.getInstance())
+                .put("jsonNull", JsonNullValue.getInstance())
+                .put("array", array)
+                .put("map", nestedMap);
+
+        Object converted = converter.toObject(source);
+
+        assertThat(converted).isInstanceOf(Map.class);
+        Map<String, Object> result = (Map<String, Object>) converted;
+        assertThat(result.get("string")).isExactlyInstanceOf(String.class).isEqualTo("value");
+        assertThat(result.get("integer")).isExactlyInstanceOf(Integer.class).isEqualTo(42);
+        assertThat(result.get("long")).isExactlyInstanceOf(Long.class).isEqualTo(43L);
+        assertThat(result.get("double")).isExactlyInstanceOf(Double.class).isEqualTo(44.5D);
+        assertThat(result.get("boolean")).isExactlyInstanceOf(Boolean.class).isEqualTo(true);
+        assertThat(result.get("number")).isExactlyInstanceOf(BigDecimal.class).isEqualTo(number);
+        assertThat(result.get("binary")).isExactlyInstanceOf(byte[].class);
+        assertThat((byte[]) result.get("binary")).containsExactly(binary);
+        assertThat(result.get("timestamp")).isExactlyInstanceOf(Timestamp.class).isEqualTo(timestamp);
+        assertThat(result).containsKeys("null", "jsonNull");
+        assertThat(result.get("null")).isNull();
+        assertThat(result.get("jsonNull")).isNull();
+
+        assertThat(result.get("array")).isInstanceOf(List.class);
+        List<Object> convertedArray = (List<Object>) result.get("array");
+        assertThat(convertedArray.get(0)).isExactlyInstanceOf(String.class).isEqualTo("first");
+        assertThat(convertedArray.get(1)).isExactlyInstanceOf(Integer.class).isEqualTo(7);
+        assertThat(convertedArray.get(2)).isInstanceOf(Map.class);
+        Map<String, Object> arrayMap = (Map<String, Object>) convertedArray.get(2);
+        assertThat(arrayMap.get("nestedString")).isExactlyInstanceOf(String.class).isEqualTo("nested");
+        assertThat(arrayMap.get("nestedLong")).isExactlyInstanceOf(Long.class).isEqualTo(99L);
+
+        assertThat(result.get("map")).isInstanceOf(Map.class);
+        Map<String, Object> convertedMap = (Map<String, Object>) result.get("map");
+        assertThat(convertedMap.get("nestedString")).isExactlyInstanceOf(String.class).isEqualTo("nested");
+        assertThat(convertedMap.get("nestedLong")).isExactlyInstanceOf(Long.class).isEqualTo(99L);
+        assertNoFieldValue(result);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldKeepEmptyDistinctFromNull() {
+        MapValue source = new MapValue()
+                .put("missing", EmptyValue.getInstance())
+                .put("null", NullValue.getInstance());
+
+        Map<String, Object> result = (Map<String, Object>) converter.toObject(source);
+
+        assertThat(result).doesNotContainKey("missing");
+        assertThat(result).containsKey("null");
+        assertThat(result.get("null")).isNull();
+        assertThatThrownBy(() -> converter.toObject(EmptyValue.getInstance()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("missing value");
+        assertThatThrownBy(() -> converter.toObject(new ArrayValue().add(EmptyValue.getInstance())))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("missing value");
+    }
+
+    private static void assertNoFieldValue(Object value) {
+        if (value == null) {
+            return;
+        }
+        assertThat(value).isNotInstanceOf(FieldValue.class);
+        if (value instanceof Map<?, ?> map) {
+            map.values().forEach(OracleNoSQLProjectionFieldValueConverterTest::assertNoFieldValue);
+        } else if (value instanceof Iterable<?> values) {
+            values.forEach(OracleNoSQLProjectionFieldValueConverterTest::assertNoFieldValue);
+        }
+    }
+}

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionResultTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionResultTest.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import jakarta.json.bind.Jsonb;
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.PrepareRequest;
+import oracle.nosql.driver.ops.PrepareResult;
+import oracle.nosql.driver.ops.PreparedStatement;
+import oracle.nosql.driver.ops.QueryRequest;
+import oracle.nosql.driver.ops.QueryResult;
+import oracle.nosql.driver.values.ArrayValue;
+import oracle.nosql.driver.values.EmptyValue;
+import oracle.nosql.driver.values.FieldValue;
+import oracle.nosql.driver.values.IntegerValue;
+import oracle.nosql.driver.values.JsonNullValue;
+import oracle.nosql.driver.values.MapValue;
+import oracle.nosql.driver.values.NullValue;
+import oracle.nosql.driver.values.NumberValue;
+import oracle.nosql.driver.values.StringValue;
+import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
+import org.eclipse.jnosql.communication.semistructured.Element;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OracleNoSQLProjectionResultTest {
+
+    @Test
+    void shouldExposeProjectedFieldsAsJavaValues() {
+        String sql = "select entity, id, name, age, amount, tags, profile, nullValue, jsonNull, missing from database";
+        NoSQLHandle serviceHandle = mock(NoSQLHandle.class);
+        Jsonb jsonB = mock(Jsonb.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        PrepareResult prepareResult = new PrepareResult().setPreparedStatement(preparedStatement);
+        QueryResult queryResult = mock(QueryResult.class);
+        MapValue profile = new MapValue()
+                .put("city", new StringValue("Lisbon"))
+                .put("coordinates", new ArrayValue().add(38.7D).add(-9.1D))
+                .put("sqlNull", NullValue.getInstance())
+                .put("jsonNull", JsonNullValue.getInstance())
+                .put("missing", EmptyValue.getInstance());
+        MapValue row = new MapValue()
+                .put(DefaultOracleNoSQLDocumentManager.ENTITY, "person")
+                .put(DefaultOracleNoSQLDocumentManager.ORACLE_ID, "person:42")
+                .put("name", new StringValue("Ada"))
+                .put("age", new IntegerValue(37))
+                .put("amount", new NumberValue(new BigDecimal("19.99")))
+                .put("tags", new ArrayValue().add("engineer").add("speaker"))
+                .put("profile", profile)
+                .put("nullValue", NullValue.getInstance())
+                .put("jsonNull", JsonNullValue.getInstance())
+                .put("missing", EmptyValue.getInstance());
+        when(serviceHandle.prepare(any(PrepareRequest.class))).thenReturn(prepareResult);
+        when(serviceHandle.query(any(QueryRequest.class))).thenReturn(queryResult);
+        when(queryResult.getResults()).thenReturn(List.of(row));
+        var manager = new DefaultOracleNoSQLDocumentManager("database", serviceHandle, jsonB);
+
+        CommunicationEntity entity = manager.sql(sql).findFirst().orElseThrow();
+
+        assertThat(entity.name()).isEqualTo("person");
+        assertThat(entity.elementNames()).containsExactlyInAnyOrder("_id", "name", "age", "amount", "tags", "profile",
+                "nullValue", "jsonNull");
+        assertThat(entity.find("_id").orElseThrow().get()).isExactlyInstanceOf(String.class).isEqualTo("42");
+        assertThat(entity.find("name").orElseThrow().get()).isExactlyInstanceOf(String.class).isEqualTo("Ada");
+        assertThat(entity.find("age").orElseThrow().get()).isExactlyInstanceOf(Integer.class).isEqualTo(37);
+        assertThat(entity.find("amount").orElseThrow().get())
+                .isExactlyInstanceOf(BigDecimal.class).isEqualTo(new BigDecimal("19.99"));
+        assertThat(entity.find("tags").orElseThrow().get())
+                .isInstanceOf(List.class).isEqualTo(List.of("engineer", "speaker"));
+        assertThat(entity.find("nullValue")).get().extracting(Element::get).isNull();
+        assertThat(entity.find("jsonNull")).get().extracting(Element::get).isNull();
+        assertThat(entity.find("missing")).isEmpty();
+
+        Object profileValue = entity.find("profile").orElseThrow().get();
+        assertThat(profileValue).isInstanceOf(List.class);
+        Map<String, Object> convertedProfile = new LinkedHashMap<>();
+        for (Object value : (List<?>) profileValue) {
+            Element element = (Element) value;
+            convertedProfile.put(element.name(), element.get());
+        }
+        assertThat(convertedProfile.get("city")).isExactlyInstanceOf(String.class).isEqualTo("Lisbon");
+        assertThat(convertedProfile.get("coordinates"))
+                .isInstanceOf(List.class).isEqualTo(List.of(38.7D, -9.1D));
+        assertThat(convertedProfile).containsKeys("sqlNull", "jsonNull").doesNotContainKey("missing");
+        assertThat(convertedProfile.get("sqlNull")).isNull();
+        assertThat(convertedProfile.get("jsonNull")).isNull();
+        assertNoFieldValue(entity.elements());
+        verify(serviceHandle).prepare(any(PrepareRequest.class));
+        verify(serviceHandle).query(any(QueryRequest.class));
+    }
+
+    private static void assertNoFieldValue(Object value) {
+        if (value == null) {
+            return;
+        }
+        assertThat(value).isNotInstanceOf(FieldValue.class);
+        if (value instanceof Element element) {
+            assertNoFieldValue(element.get());
+        } else if (value instanceof Map<?, ?> map) {
+            map.values().forEach(OracleNoSQLProjectionResultTest::assertNoFieldValue);
+        } else if (value instanceof Iterable<?> values) {
+            values.forEach(OracleNoSQLProjectionResultTest::assertNoFieldValue);
+        }
+    }
+}


### PR DESCRIPTION
  Fixes eclipse-jnosql/jnosql#736

  This applies the Oracle NoSQL projection-result conversion fix to the 1.1.x branch.

  It converts SDK `FieldValue` wrappers into Java values before returning projection results through JNoSQL. The conversion recursively handles scalar values, nested maps, and arrays. SQL `NULL` and JSON `null` are
  preserved as Java `null`, while missing `EMPTY` fields are omitted.

  Tests cover:

  - Scalar projection values
  - Nested maps and arrays
  - SQL and JSON null values
  - Missing `EMPTY` values
  - Conversion at the document-manager query boundary

  Validation:

  - Oracle NoSQL module: 117 tests, 0 failures, 0 errors
  - RAT and Checkstyle passed
  - NoSQL Data TCK improved from 74 to 77 passing tests
  - All three projection tests addressed by this issue now pass

