### PR TITLE
fix: preserve Oracle NoSQL delete counts

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
@@ -69,6 +69,7 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
     static final String ENTITY = "entity";
     static final String ID = "_id";
     static final String ORACLE_ID = "id";
+    private static final String NUM_ROWS_DELETED = "numRowsDeleted";
     private final String table;
     private final NoSQLHandle serviceHandle;
 
@@ -131,15 +132,28 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
 
     @Override
     public void delete(DeleteQuery query) {
+        executeDelete(query);
+    }
+
+    @Override
+    public long deleteAndCount(DeleteQuery query) {
+        return executeDelete(query);
+    }
+
+    private long executeDelete(DeleteQuery query) {
         Objects.requireNonNull(query, "query is required");
 
         var selectBuilder = new DeleteBuilder(query, table);
         var oracleQuery = selectBuilder.get();
+        long deleted = 0L;
         if (oracleQuery.hasIds()) {
             for (String id : oracleQuery.ids()) {
                 var delRequest = new DeleteRequest().setKey(new MapValue().put(ORACLE_ID, generateId(id, query.name())))
                         .setTableName(table);
-                serviceHandle.delete(delRequest);
+                var result = serviceHandle.delete(delRequest);
+                if (result != null && result.getSuccess()) {
+                    deleted++;
+                }
             }
         }
         if (!oracleQuery.hasOnlyIds()) {
@@ -156,8 +170,14 @@ final class DefaultOracleNoSQLDocumentManager implements OracleNoSQLDocumentMana
                 QueryResult result = serviceHandle.query(queryRequest);
                 List<MapValue> results = result.getResults();
                 LOGGER.finest("The delete result: " +results);
+                deleted += results.stream()
+                        .map(row -> row.get(NUM_ROWS_DELETED))
+                        .filter(Objects::nonNull)
+                        .mapToLong(FieldValue::getLong)
+                        .sum();
             } while (!queryRequest.isDone());
         }
+        return deleted;
     }
 
 

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManager.java
@@ -16,6 +16,7 @@ package org.eclipse.jnosql.databases.oracle.communication;
 
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 
 import java.util.stream.Stream;
 
@@ -24,6 +25,13 @@ import java.util.stream.Stream;
  */
 public interface OracleNoSQLDocumentManager extends DatabaseManager {
 
+    /**
+     * Deletes documents matching the query and returns the number of affected documents.
+     *
+     * @param query the delete query
+     * @return the number of deleted documents
+     */
+    long deleteAndCount(DeleteQuery query);
 
     /**
      * Executes an Oracle query using the Oracle Query Language (SQL).

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerDeleteCountTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerDeleteCountTest.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.jnosql.databases.oracle.communication;
+
+import jakarta.json.bind.Jsonb;
+import oracle.nosql.driver.NoSQLHandle;
+import oracle.nosql.driver.ops.DeleteRequest;
+import oracle.nosql.driver.ops.DeleteResult;
+import oracle.nosql.driver.ops.PrepareRequest;
+import oracle.nosql.driver.ops.PrepareResult;
+import oracle.nosql.driver.ops.PreparedStatement;
+import oracle.nosql.driver.ops.QueryRequest;
+import oracle.nosql.driver.ops.QueryResult;
+import oracle.nosql.driver.values.FieldValue;
+import oracle.nosql.driver.values.MapValue;
+import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultOracleNoSQLDocumentManagerDeleteCountTest {
+
+    private static final String TABLE = "database";
+    private static final String ENTITY = "person";
+    private static final String NUM_ROWS_DELETED = "numRowsDeleted";
+
+    private NoSQLHandle handle;
+    private PreparedStatement preparedStatement;
+    private DefaultOracleNoSQLDocumentManager manager;
+
+    @BeforeEach
+    void setUp() {
+        handle = mock(NoSQLHandle.class);
+        preparedStatement = mock(PreparedStatement.class);
+        manager = new DefaultOracleNoSQLDocumentManager(TABLE, handle, mock(Jsonb.class));
+    }
+
+    @Test
+    void shouldExposeCountedDeleteOnProviderInterfaceForCdiProxies() throws NoSuchMethodException {
+        assertThat(OracleNoSQLDocumentManager.class.getDeclaredMethod("deleteAndCount", DeleteQuery.class))
+                .isNotNull();
+    }
+
+    @Test
+    void shouldCountOnlySuccessfulDirectIdDeletes() {
+        when(handle.delete(any(DeleteRequest.class)))
+                .thenReturn(new DeleteResult().setSuccess(true), new DeleteResult().setSuccess(false));
+
+        DeleteQuery query = delete().from(ENTITY)
+                .where("_id").in(List.of("one", "two"))
+                .build();
+
+        long deleted = manager.deleteAndCount(query);
+
+        ArgumentCaptor<DeleteRequest> requests = ArgumentCaptor.forClass(DeleteRequest.class);
+        verify(handle, times(2)).delete(requests.capture());
+        assertThat(requests.getAllValues())
+                .allSatisfy(request -> assertThat(request.getTableName()).isEqualTo(TABLE))
+                .extracting(request -> request.getKey().getString("id"))
+                .containsExactlyInAnyOrder("person:one", "person:two");
+        assertThat(deleted).isEqualTo(1L);
+        verify(handle, never()).prepare(any(PrepareRequest.class));
+    }
+
+    @Test
+    void shouldSumNativeSqlDeleteCountsAcrossBatches() {
+        prepareSqlDelete(List.of(
+                List.of(deleteCount(1L)),
+                List.of(deleteCount(2L))));
+
+        long deleted = manager.deleteAndCount(delete().from(ENTITY).build());
+
+        ArgumentCaptor<PrepareRequest> request = ArgumentCaptor.forClass(PrepareRequest.class);
+        verify(handle).prepare(request.capture());
+        assertThat(request.getValue().getStatement())
+                .isEqualTo("DELETE from database WHERE database.entity= 'person'");
+        assertThat(deleted).isEqualTo(3L);
+        verify(handle, times(2)).query(any(QueryRequest.class));
+        verify(handle, never()).delete(any(DeleteRequest.class));
+    }
+
+    @Test
+    void shouldBindConditionalSqlDeleteAndReturnNativeCount() {
+        prepareSqlDelete(List.of(List.of(new MapValue().put(NUM_ROWS_DELETED, 2))));
+
+        long deleted = manager.deleteAndCount(delete().from(ENTITY)
+                .where("type").eq("V")
+                .build());
+
+        ArgumentCaptor<FieldValue> parameter = ArgumentCaptor.forClass(FieldValue.class);
+        verify(preparedStatement).setVariable(eq(1), parameter.capture());
+        assertThat(parameter.getValue().asString().getValue()).isEqualTo("V");
+
+        ArgumentCaptor<PrepareRequest> request = ArgumentCaptor.forClass(PrepareRequest.class);
+        verify(handle).prepare(request.capture());
+        assertThat(request.getValue().getStatement())
+                .contains("DELETE from database WHERE database.entity= 'person' AND")
+                .contains("database.content.type")
+                .contains(" =  ?");
+        assertThat(deleted).isEqualTo(2L);
+    }
+
+    @Test
+    void shouldPreserveVoidDeleteExecution() {
+        prepareSqlDelete(List.of(List.of(deleteCount(3L))));
+
+        manager.delete(delete().from(ENTITY).build());
+
+        verify(handle).prepare(any(PrepareRequest.class));
+        verify(handle).query(any(QueryRequest.class));
+    }
+
+    private void prepareSqlDelete(List<List<MapValue>> resultBatches) {
+        when(handle.prepare(any(PrepareRequest.class)))
+                .thenReturn(new PrepareResult().setPreparedStatement(preparedStatement));
+
+        AtomicInteger nextBatch = new AtomicInteger();
+        when(handle.query(any(QueryRequest.class))).thenAnswer(invocation -> {
+            QueryRequest request = invocation.getArgument(0);
+            int batch = nextBatch.getAndIncrement();
+            request.setContKey(batch + 1 < resultBatches.size() ? new byte[]{1} : null);
+            return new QueryResult(request).setResults(resultBatches.get(batch));
+        });
+    }
+
+    private static MapValue deleteCount(long count) {
+        return new MapValue().put(NUM_ROWS_DELETED, count);
+    }
+}


### PR DESCRIPTION
(cherry picked from commit e6c1908ca5e4c8af814c9c43ce7ec7964b25b57b)

## Description

  Backports Oracle NoSQL support for the optional count-returning delete contract introduced by eclipse-jnosql/jnosql#739.

  The provider preserves the affected-row information already returned by Oracle:

  - Direct-ID deletes count each non-null successful `DeleteResult`.
  - SQL deletes sum the exact, case-sensitive `numRowsDeleted` field across all rows and continuation batches using `FieldValue.getLong()`.
  - Existing `void delete(DeleteQuery)` delegates to the shared execution path and discards the count.
  - `OracleNoSQLDocumentManager` explicitly declares `deleteAndCount(DeleteQuery)` for provider and CDI proxy visibility.

  Related issue: Fixes eclipse-jnosql/jnosql#740

  Depends on: eclipse-jnosql/jnosql#739

  ## Technical Rationale

  The count comes from the Oracle delete operation itself; the provider does not issue a separate, non-atomic pre-delete count. The backport is a direct cherry-pick of the main-line provider change.

  ## Validation

  - Focused Oracle delete-count tests on 1.1.x: 5 tests, 0 failures, 0 errors.
  - Main-line Oracle NoSQL module package with the same implementation: 123 tests, 0 failures, 0 errors, 54 skipped.
  - Checkstyle: 0 violations.
  - Combined core and Oracle provider candidate: Jakarta Data NoSQL TCK, 88 tests, 0 failures, 0 errors.
