### PR TITLE
fix(oracle-nosql): preserve JSON null predicate semantics

### DIFF
--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -226,7 +226,22 @@ abstract class AbstractQueryBuilder implements Supplier<OracleQuery> {
     }
 
     private void predicateNull(StringBuilder query, Element document, boolean negated) {
-        query.append(identifierOf(document.name())).append(negated ? "IS NOT NULL " : "IS NULL ");
+        String identifier = identifierOf(document.name()).trim();
+        if (DefaultOracleNoSQLDocumentManager.ID.equals(document.name())) {
+            query.append(identifier).append(negated ? " IS NOT NULL " : " IS NULL ");
+            return;
+        }
+
+        // A JSON path can be explicitly JSON null, missing, or SQL null through a null parent.
+        if (negated) {
+            query.append('(').append(identifier).append(" != null AND EXISTS ")
+                    .append(identifier).append(" AND ")
+                    .append(identifier).append(" IS NOT NULL) ");
+        } else {
+            query.append('(').append(identifier).append(" = null OR NOT EXISTS ")
+                    .append(identifier).append(" OR ")
+                    .append(identifier).append(" IS NULL) ");
+        }
     }
 
     private void predicateIgnoreCase(StringBuilder query,

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/NullPredicateQueryBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/NullPredicateQueryBuilderTest.java
@@ -30,14 +30,19 @@ class NullPredicateQueryBuilderTest {
 
     private static final String ENTITY = "asciiCharacter";
     private static final String FIELD = "hexadecimal";
+    private static final String ID = "_id";
     private static final String TABLE = "entities";
+    private static final String JSON_PATH = TABLE + ".content." + FIELD;
+    private static final String ID_PATH = TABLE + ".id";
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("queryCases")
     void shouldTranslateNullEqualityWithoutBindParameter(QueryCase queryCase) {
-        var generated = queryCase.build(CriteriaCondition.eq(nullElement()));
+        var generated = queryCase.build(CriteriaCondition.eq(nullElement(FIELD)));
 
-        assertThat(generated.query()).contains("content." + FIELD, " IS NULL")
+        assertThat(normalize(generated.query()))
+                .contains("(" + JSON_PATH + " = null OR NOT EXISTS " + JSON_PATH
+                        + " OR " + JSON_PATH + " IS NULL)")
                 .doesNotContain("?");
         assertThat(generated.params()).isEmpty();
     }
@@ -45,10 +50,32 @@ class NullPredicateQueryBuilderTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("queryCases")
     void shouldTranslateNegatedNullEqualityWithoutBindParameter(QueryCase queryCase) {
-        var generated = queryCase.build(CriteriaCondition.eq(nullElement()).negate());
+        var generated = queryCase.build(CriteriaCondition.eq(nullElement(FIELD)).negate());
 
-        assertThat(generated.query()).contains("content." + FIELD, " IS NOT NULL")
+        assertThat(normalize(generated.query()))
+                .contains("(" + JSON_PATH + " != null AND EXISTS " + JSON_PATH
+                        + " AND " + JSON_PATH + " IS NOT NULL)")
                 .doesNotContain("?");
+        assertThat(generated.params()).isEmpty();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("queryCases")
+    void shouldKeepIdNullEqualityAsNativeSqlNullPredicate(QueryCase queryCase) {
+        var generated = queryCase.build(CriteriaCondition.eq(nullElement(ID)));
+
+        assertThat(normalize(generated.query())).contains(ID_PATH + " IS NULL")
+                .doesNotContain("content." + ID, "= null", "EXISTS", "?");
+        assertThat(generated.params()).isEmpty();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("queryCases")
+    void shouldKeepNegatedIdNullEqualityAsNativeSqlNullPredicate(QueryCase queryCase) {
+        var generated = queryCase.build(CriteriaCondition.eq(nullElement(ID)).negate());
+
+        assertThat(normalize(generated.query())).contains(ID_PATH + " IS NOT NULL")
+                .doesNotContain("content." + ID, "!= null", "EXISTS", "?");
         assertThat(generated.params()).isEmpty();
     }
 
@@ -57,8 +84,8 @@ class NullPredicateQueryBuilderTest {
     void shouldKeepNullStringAsBindParameter(QueryCase queryCase) {
         var generated = queryCase.build(CriteriaCondition.eq(Element.of(FIELD, "null")));
 
-        assertThat(generated.query()).contains("content." + FIELD, " = ", "?")
-                .doesNotContain("IS NULL", "IS NOT NULL");
+        assertThat(normalize(generated.query())).contains(JSON_PATH + " = ?")
+                .doesNotContain("IS NULL", "IS NOT NULL", "EXISTS", "= null", "!= null");
         assertThat(generated.params()).singleElement()
                 .satisfies(parameter -> assertThat(parameter.asString().getValue()).isEqualTo("null"));
     }
@@ -93,8 +120,12 @@ class NullPredicateQueryBuilderTest {
         };
     }
 
-    private static Element nullElement() {
-        return Element.of(FIELD, Value.ofNull());
+    private static Element nullElement(String field) {
+        return Element.of(field, Value.ofNull());
+    }
+
+    private static String normalize(String query) {
+        return query.replaceAll("\\s+", " ").trim();
     }
 
     private record QueryCase(String name, Function<CriteriaCondition, OracleQuery> builder) {


### PR DESCRIPTION
Fixes eclipse-jnosql/jnosql#749

  ## Summary

  Backport the Oracle NoSQL JSON null-predicate correction to `1.1.x`.

  JNoSQL stores a Java `null` attribute as explicit JSON `null`, but the Oracle provider currently renders the corresponding predicate as `path IS NULL`. Oracle NoSQL distinguishes JSON null, a missing JSON path, and SQL NULL, so that predicate does not match the value
  written by JNoSQL.

  For JSON-backed fields, this change renders:

  ```sql
  -- IS NULL
  (path = null OR NOT EXISTS path OR path IS NULL)

  -- IS NOT NULL
  (path != null AND EXISTS path AND path IS NOT NULL)

  ## Compatibility

  This change preserves the existing behavior for:

  - _id, which remains a native IS NULL or IS NOT NULL predicate
  - The literal string "null", which remains a normal bind parameter
  - Select, count, and delete queries

  ## Tests

  Added 15 unit-test cases covering null and not-null predicates across select, count, and delete queries, native _id handling, and literal "null" binding.

  Validation:

  - Oracle provider suite: 156 tests, 0 failures, 0 errors
  - Focused null-predicate tests: 15/15 passed
  - Jakarta Data NoSQL TCK: 88/88 passed
  - Jakarta NoSQL TCK: 111/111 passed

  Backport of #414.
