### PR TITLE
Test enhcament

### DIFF
--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentConfigurationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentConfigurationTest.java
@@ -17,10 +17,10 @@ package org.eclipse.jnosql.databases.arangodb.communication;
 
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ArangoDBDocumentConfigurationTest {
 
@@ -30,22 +30,22 @@ public class ArangoDBDocumentConfigurationTest {
         ArangoDBDocumentConfiguration configuration = new ArangoDBDocumentConfiguration();
         configuration.addHost("localhost", 8529);
         ArangoDBDocumentManagerFactory managerFactory = configuration.apply(Settings.builder().build());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldReturnFromConfiguration() {
         ArangoDBDocumentConfiguration configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof ArangoDBDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof ArangoDBDocumentConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         ArangoDBDocumentConfiguration configuration = DatabaseConfiguration
                 .getConfiguration(ArangoDBDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof ArangoDBDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof ArangoDBDocumentConfiguration).isTrue();
     }
 
 }

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerFactoryTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerFactoryTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class ArangoDBDocumentManagerFactoryTest {
@@ -36,7 +36,7 @@ public class ArangoDBDocumentManagerFactoryTest {
     @Test
     public void shouldCreateEntityManager() {
         var database = managerFactory.apply("database");
-        assertNotNull(database);
+        assertThat(database).isNotNull();
     }
 
 }

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
@@ -53,10 +53,6 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -87,7 +83,7 @@ public class ArangoDBDocumentManagerTest {
         var entity = getEntity();
 
         CommunicationEntity documentEntity = entityManager.insert(entity);
-        assertTrue(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals(KEY_NAME)));
+        assertThat(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals(KEY_NAME))).isTrue();
     }
 
     @Test
@@ -97,7 +93,7 @@ public class ArangoDBDocumentManagerTest {
         Element newField = Elements.of("newField", "10");
         entity.add(newField);
         CommunicationEntity updated = entityManager.update(entity);
-        assertEquals(newField, updated.find("newField").get());
+        assertThat(updated.find("newField").get()).isEqualTo(newField);
     }
 
     @Test
@@ -127,12 +123,12 @@ public class ArangoDBDocumentManagerTest {
         Element id = entity.find(KEY_NAME).get();
         SelectQuery query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         CommunicationEntity documentEntity = entities.getFirst();
-        assertEquals(entity.find(KEY_NAME).get().value().get(String.class), documentEntity.find(KEY_NAME).get()
-                .value().get(String.class));
-        assertEquals(entity.find("name").get(), documentEntity.find("name").get());
-        assertEquals(entity.find("city").get(), documentEntity.find("city").get());
+        assertThat(documentEntity.find(KEY_NAME).get()
+                .value().get(String.class)).isEqualTo(entity.find(KEY_NAME).get().value().get(String.class));
+        assertThat(documentEntity.find("name").get()).isEqualTo(entity.find("name").get());
+        assertThat(documentEntity.find("city").get()).isEqualTo(entity.find("city").get());
     }
 
 
@@ -180,12 +176,12 @@ public class ArangoDBDocumentManagerTest {
         SelectQuery query = select().from("AppointmentBook").where(key.name()).eq(key.get()).build();
 
         CommunicationEntity documentEntity = entityManager.singleResult(query).get();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").get().get();
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test
@@ -202,12 +198,12 @@ public class ArangoDBDocumentManagerTest {
         SelectQuery query = select().from("AppointmentBook").where(key.name()).eq(key.get()).build();
 
         CommunicationEntity documentEntity = entityManager.singleResult(query).get();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").get().get();
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test
@@ -218,7 +214,7 @@ public class ArangoDBDocumentManagerTest {
         String aql = "FOR a IN person FILTER a.name == @name RETURN a";
         List<CommunicationEntity> entities = entityManager.aql(aql,
                 singletonMap("name", "Poliana")).collect(Collectors.toList());
-        assertNotNull(entities);
+        assertThat(entities).isNotNull();
     }
 
 
@@ -227,7 +223,7 @@ public class ArangoDBDocumentManagerTest {
         CommunicationEntity entity = getEntity();
         entityManager.insert(entity);
 
-        assertTrue(entityManager.count(COLLECTION_NAME) > 0);
+        assertThat(entityManager.count(COLLECTION_NAME) > 0).isTrue();
     }
 
     @Test
@@ -253,7 +249,7 @@ public class ArangoDBDocumentManagerTest {
         arangoDB.db(DATABASE).collection(COLLECTION_NAME).insertDocument(new Human());
         SelectQuery select = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(select).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -266,7 +262,7 @@ public class ArangoDBDocumentManagerTest {
         arangoDB.db(DATABASE).collection(COLLECTION_NAME).insertDocument(map);
         SelectQuery select = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(select).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -276,7 +272,7 @@ public class ArangoDBDocumentManagerTest {
         List<String> entities = entityManager.aql(aql,
                 singletonMap("name", "Poliana"), String.class).toList();
 
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -284,7 +280,7 @@ public class ArangoDBDocumentManagerTest {
         entityManager.insert(getEntity());
         String aql = "FOR a IN person RETURN a.name";
         List<String> entities = entityManager.aql(aql, String.class).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBValueWriteDecoratorTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBValueWriteDecoratorTest.java
@@ -18,7 +18,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 
 @SuppressWarnings("rawtypes")
@@ -28,7 +29,7 @@ class ArangoDBValueWriteDecoratorTest {
 
     @Test
     void shouldTestUUIDType() {
-        assertTrue(valueWriter.test(UUID.class));
+        assertThat(valueWriter.test(UUID.class)).isTrue();
     }
 
 }

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
@@ -28,9 +28,9 @@ import java.util.Optional;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryAQLConverterTest {
 
@@ -42,8 +42,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  c.name == @name RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  c.name == @name RETURN c");
 
     }
 
@@ -57,8 +57,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  c.name == @name AND  c.age <= @age RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  c.name == @name AND  c.age <= @age RETURN c");
 
     }
 
@@ -72,8 +72,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  c.name == @name OR  c.age <= @age RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  c.name == @name OR  c.age <= @age RETURN c");
 
     }
 
@@ -86,8 +86,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  c.name == @name SORT  c.name ASC RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  c.name == @name SORT  c.name ASC RETURN c");
     }
 
     @Test
@@ -100,8 +100,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  c.name == @name SORT  c.name ASC , c.age DESC RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  c.name == @name SORT  c.name ASC , c.age DESC RETURN c");
     }
 
 
@@ -114,8 +114,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  c.name == @name LIMIT 5 RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  c.name == @name LIMIT 5 RETURN c");
 
     }
 
@@ -128,8 +128,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  c.name == @name LIMIT 1, 5 RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  c.name == @name LIMIT 1, 5 RETURN c");
     }
 
     @Test
@@ -140,8 +140,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("FOR c IN collection FILTER  NOT ( c.name == @name) RETURN c", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  NOT ( c.name == @name) RETURN c");
 
     }
 
@@ -156,11 +156,11 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.select(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals(3, values.size());
-        assertEquals("Assis", values.get("city"));
-        assertEquals("Otavio", values.get("name"));
-        assertEquals("Lucas", values.get("name_1"));
-        assertEquals("FOR c IN collection FILTER  NOT ( c.city == @city) AND  c.name == @name OR  NOT ( c.name == @name_1) RETURN c", aql);
+        assertThat(values.size()).isEqualTo(3);
+        assertThat(values.get("city")).isEqualTo("Assis");
+        assertThat(values.get("name")).isEqualTo("Otavio");
+        assertThat(values.get("name_1")).isEqualTo("Lucas");
+        assertThat(aql).isEqualTo("FOR c IN collection FILTER  NOT ( c.city == @city) AND  c.name == @name OR  NOT ( c.name == @name_1) RETURN c");
 
     }
 
@@ -172,8 +172,8 @@ public class QueryAQLConverterTest {
         AQLQueryResult convert = QueryAQLConverter.count(query);
         String aql = convert.query();
         Map<String, Object> values = convert.values();
-        assertEquals("value", values.get("name"));
-        assertEquals("RETURN LENGTH(FOR c IN collection FILTER  c.name == @name RETURN c)", aql);
+        assertThat(values.get("name")).isEqualTo("value");
+        assertThat(aql).isEqualTo("RETURN LENGTH(FOR c IN collection FILTER  c.name == @name RETURN c)");
 
     }
 

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBDocumentRepositoryProxyTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBDocumentRepositoryProxyTest.java
@@ -36,11 +36,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnableAutoWeld
@@ -80,7 +80,7 @@ public class ArangoDBDocumentRepositoryProxyTest {
         verify(template).aql(eq("FOR p IN Person FILTER p.name = @name RETURN p"), captor.capture());
 
         Map value = captor.getValue();
-        assertEquals("Ada", value.get("name"));
+        assertThat(value.get("name")).isEqualTo("Ada");
     }
 
     @Test

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBExtensionTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBExtensionTest.java
@@ -22,10 +22,11 @@ import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtensi
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Database.class})
@@ -40,6 +41,6 @@ public class ArangoDBExtensionTest {
 
     @Test
     public void shouldSave() {
-        Assertions.assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 }

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactoryTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactoryTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class CassandraColumnManagerFactoryTest {
@@ -48,15 +48,15 @@ public class CassandraColumnManagerFactoryTest {
     @Test
     public void shouldReturnErrorWhenSettingsIsNull() {
         CassandraConfiguration cassandraConfiguration = new CassandraConfiguration();
-        assertThrows(NullPointerException.class, () -> cassandraConfiguration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> cassandraConfiguration.apply(null));
 
-        assertThrows(NullPointerException.class, () -> cassandraConfiguration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> cassandraConfiguration.apply(null));
     }
 
     @Test
     public void shouldReturnEntityManager() {
         DatabaseManager columnEntityManager = subject.apply(Constants.KEY_SPACE);
-        assertNotNull(columnEntityManager);
+        assertThat(columnEntityManager).isNotNull();
     }
 
 }

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerTest.java
@@ -27,7 +27,6 @@ import org.eclipse.jnosql.communication.semistructured.Elements;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -57,11 +56,7 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class CassandraColumnManagerTest {
@@ -90,7 +85,7 @@ public class CassandraColumnManagerTest {
         entityManager.close();
         DefaultCassandraColumnManager manager = DefaultCassandraColumnManager.class.cast(entityManager);
         CqlSession session = manager.getSession();
-        assertTrue(session.isClosed());
+        assertThat(session.isClosed()).isTrue();
     }
 
     @Test
@@ -117,7 +112,7 @@ public class CassandraColumnManagerTest {
 
         List<CommunicationEntity> entities = entityManager.select(select().from(Constants.COLUMN_FAMILY).where("id").eq(10L).build())
                 .toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -128,27 +123,27 @@ public class CassandraColumnManagerTest {
 
         List<CommunicationEntity> entities = entityManager.select(select().from(Constants.COLUMN_FAMILY).build())
                 .toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
     void shouldReturnErrorWhenInsertWithColumnNull() {
 
-        assertThrows(NullPointerException.class, () -> entityManager.insert((CommunicationEntity) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.insert((CommunicationEntity) null));
     }
 
     @Test
     void shouldReturnErrorWhenInsertWithConsistencyLevelNull() {
 
-        assertThrows(NullPointerException.class, () -> entityManager.insert(getColumnFamily(), null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.insert(getColumnFamily(), null));
 
-        assertThrows(NullPointerException.class, () -> entityManager.insert(getEntities(), null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.insert(getEntities(), null));
     }
 
     @Test
     void shouldReturnErrorWhenInsertWithColumnsNull() {
 
-        assertThrows(NullPointerException.class, () -> entityManager.insert((Iterable<CommunicationEntity>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.insert((Iterable<CommunicationEntity>) null));
     }
 
 
@@ -162,13 +157,13 @@ public class CassandraColumnManagerTest {
     @Test
     void shouldReturnErrorWhenUpdateWithColumnsNull() {
 
-        assertThrows(NullPointerException.class, () -> entityManager.update((Iterable<CommunicationEntity>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.update((Iterable<CommunicationEntity>) null));
 
     }
 
     @Test
     void shouldReturnErrorWhenUpdateWithColumnNull() {
-        assertThrows(NullPointerException.class, () -> entityManager.update((CommunicationEntity) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.update((CommunicationEntity) null));
     }
 
     @Test
@@ -228,20 +223,20 @@ public class CassandraColumnManagerTest {
 
     @Test
     void shouldReturnErrorWhenSaveHasNullElement() {
-        assertThrows(NullPointerException.class, () -> entityManager.save((CommunicationEntity) null, Duration.ofSeconds(1L), ConsistencyLevel.ALL));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.save((CommunicationEntity) null, Duration.ofSeconds(1L), ConsistencyLevel.ALL));
 
-        assertThrows(NullPointerException.class, () -> entityManager.save(getColumnFamily(), null, ConsistencyLevel.ALL));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.save(getColumnFamily(), null, ConsistencyLevel.ALL));
 
-        assertThrows(NullPointerException.class, () -> entityManager.save(getColumnFamily(), Duration.ofSeconds(1L), null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.save(getColumnFamily(), Duration.ofSeconds(1L), null));
     }
 
     @Test
     void shouldReturnErrorWhenSaveIterableHasNullElement() {
-        assertThrows(NullPointerException.class, () -> entityManager.save((List<CommunicationEntity>) null, Duration.ofSeconds(1L), ConsistencyLevel.ALL));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.save((List<CommunicationEntity>) null, Duration.ofSeconds(1L), ConsistencyLevel.ALL));
 
-        assertThrows(NullPointerException.class, () -> entityManager.save(getEntities(), null, ConsistencyLevel.ALL));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.save(getEntities(), null, ConsistencyLevel.ALL));
 
-        assertThrows(NullPointerException.class, () -> entityManager.save(getEntities(), Duration.ofSeconds(1L), null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.save(getEntities(), Duration.ofSeconds(1L), null));
     }
 
     @Test
@@ -251,7 +246,7 @@ public class CassandraColumnManagerTest {
 
         var query = select().from(columnEntity.name()).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -263,7 +258,7 @@ public class CassandraColumnManagerTest {
 
         query = select().from(columnEntity.name()).where("id").eq(-10L).build();
         entity = entityManager.singleResult(query);
-        assertFalse(entity.isPresent());
+        assertThat(entity.isPresent()).isFalse();
 
     }
 
@@ -271,14 +266,14 @@ public class CassandraColumnManagerTest {
     void shouldReturnErrorWhenThereIsNotThanOneResultInSingleResult() {
         entityManager.insert(getEntities());
         var query = select().from(Constants.COLUMN_FAMILY).build();
-        assertThrows(NonUniqueResultException.class, () -> entityManager.singleResult(query));
+        assertThatExceptionOfType(NonUniqueResultException.class).isThrownBy(() -> entityManager.singleResult(query));
     }
 
     @Test
     void shouldReturnErrorWhenQueryIsNull() {
-        assertThrows(NullPointerException.class, () -> entityManager.select(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.select(null));
 
-        assertThrows(NullPointerException.class, () -> entityManager.singleResult(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.singleResult(null));
     }
 
 
@@ -289,7 +284,7 @@ public class CassandraColumnManagerTest {
 
         var query = select().from(Constants.COLUMN_FAMILY).where("id").eq(10L).build();
         List<CommunicationEntity> columnEntity = entityManager.select(query).toList();
-        assertFalse(columnEntity.isEmpty());
+        assertThat(columnEntity.isEmpty()).isFalse();
         List<Element> columns = columnEntity.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList()))
                 .contains("name", "version", "options", "id");
@@ -304,7 +299,7 @@ public class CassandraColumnManagerTest {
         entityManager.insert(getColumnFamily());
         var query = select().from(Constants.COLUMN_FAMILY).where("id").eq(10L).build();
         List<CommunicationEntity> columnEntity = entityManager.select(query, CONSISTENCY_LEVEL).toList();
-        assertFalse(columnEntity.isEmpty());
+        assertThat(columnEntity.isEmpty()).isFalse();
         List<Element> columns = columnEntity.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList())).contains("name", "version", "options", "id");
         assertThat(columns.stream().map(Element::value).map(Value::get).collect(toList()))
@@ -317,7 +312,7 @@ public class CassandraColumnManagerTest {
         entityManager.insert(getColumnFamily());
         List<CommunicationEntity> entities = entityManager.cql("select * from newKeySpace.newColumnFamily where id=10;")
                 .toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         List<Element> columns = entities.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList())).contains("name", "version", "options", "id");
         assertThat(columns.stream().map(Element::value).map(Value::get).collect(toList()))
@@ -329,7 +324,7 @@ public class CassandraColumnManagerTest {
         entityManager.insert(getColumnFamily());
         String query = "select * from newKeySpace.newColumnFamily where id = :id;";
         List<CommunicationEntity> entities = entityManager.cql(query, singletonMap("id", 10L)).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         List<Element> columns = entities.getFirst().elements();
         assertThat(columns.stream().map(Element::name).collect(toList()))
                 .contains("name", "version", "options", "id");
@@ -359,17 +354,17 @@ public class CassandraColumnManagerTest {
         entityManager.delete(deleteQuery);
         List<CommunicationEntity> entities = entityManager.cql("select * from newKeySpace.newColumnFamily where id=10;")
                 .toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
     void shouldReturnErrorWhenDeleteQueryIsNull() {
-        assertThrows(NullPointerException.class, () -> entityManager.delete(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.delete(null));
     }
 
     @Test
     void shouldReturnErrorWhenDeleteConsistencyLevelIsNull() {
-        assertThrows(NullPointerException.class, () -> entityManager.delete(delete().from(Constants.COLUMN_FAMILY).build(), null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.delete(delete().from(Constants.COLUMN_FAMILY).build(), null));
     }
 
     @Test
@@ -380,7 +375,7 @@ public class CassandraColumnManagerTest {
         entityManager.delete(deleteQuery, CONSISTENCY_LEVEL);
         List<CommunicationEntity> entities = entityManager.cql("select * from newKeySpace.newColumnFamily where id=10;")
                 .toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -389,7 +384,7 @@ public class CassandraColumnManagerTest {
         var query = select().from(Constants.COLUMN_FAMILY).where("id").in(Arrays.asList(1L, 2L, 3L))
                 .limit(2).build();
         List<CommunicationEntity> columnFamilyEntities = entityManager.select(query).toList();
-        assertEquals(Integer.valueOf(2), Integer.valueOf(columnFamilyEntities.size()));
+        assertThat(Integer.valueOf(columnFamilyEntities.size())).isEqualTo(Integer.valueOf(2));
     }
 
     private List<CommunicationEntity> getEntities() {
@@ -424,8 +419,8 @@ public class CassandraColumnManagerTest {
         var column = columnEntity.find("name").get();
         udt = UDT.class.cast(column);
         List<Element> udtColumns = (List<Element>) udt.get();
-        assertEquals("name", udt.name());
-        assertEquals("fullname", udt.userType());
+        assertThat(udt.name()).isEqualTo("name");
+        assertThat(udt.userType()).isEqualTo("fullname");
         assertThat(udtColumns).contains(Element.of("firstname", "Ada"),
                 Element.of("lastname", "Lovelace"));
     }
@@ -449,8 +444,8 @@ public class CassandraColumnManagerTest {
         Element column = columnEntity.find("name").get();
         udt = UDT.class.cast(column);
         List<Element> udtColumns = (List<Element>) udt.get();
-        assertEquals("name", udt.name());
-        assertEquals("fullname", udt.userType());
+        assertThat(udt.name()).isEqualTo("name");
+        assertThat(udt.userType()).isEqualTo("fullname");
         assertThat(udtColumns).contains(Element.of("firstname", "Ioda"));
     }
 
@@ -470,7 +465,7 @@ public class CassandraColumnManagerTest {
                 .build();
 
         var entity1 = entityManager.singleResult(query).get();
-        assertNotNull(entity1);
+        assertThat(entity1).isNotNull();
 
     }
 
@@ -488,8 +483,8 @@ public class CassandraColumnManagerTest {
         var query = select().from("contacts").where("user").eq("otaviojava").build();
         var columnEntity = entityManager.singleResult(query).get();
         List<List<Element>> names = (List<List<Element>>) columnEntity.find("names").get().get();
-        assertEquals(3, names.size());
-        assertTrue(names.stream().allMatch(n -> n.size() == 2));
+        assertThat(names.size()).isEqualTo(3);
+        assertThat(names.stream().allMatch(n -> n.size() == 2)).isTrue();
     }
 
     @Test
@@ -497,7 +492,7 @@ public class CassandraColumnManagerTest {
         var entity = createEntityWithIterable();
         entityManager.insert(entity);
         long contacts = entityManager.count("contacts");
-        assertTrue(contacts > 0);
+        assertThat(contacts > 0).isTrue();
     }
 
     @Test
@@ -537,11 +532,11 @@ public class CassandraColumnManagerTest {
         var query = select().from(Constants.COLUMN_FAMILY).build();
         CassandraQuery cassandraQuery = CassandraQuery.of(query);
 
-        assertFalse(cassandraQuery.getPagingState().isPresent());
+        assertThat(cassandraQuery.getPagingState().isPresent()).isFalse();
 
         List<CommunicationEntity> entities = entityManager.select(cassandraQuery).toList();
-        assertEquals(10, entities.size());
-        assertTrue(cassandraQuery.getPagingState().isPresent());
+        assertThat(entities.size()).isEqualTo(10);
+        assertThat(cassandraQuery.getPagingState().isPresent()).isTrue();
     }
 
     @Test
@@ -554,7 +549,7 @@ public class CassandraColumnManagerTest {
 
         var query = select().from(Constants.COLUMN_FAMILY).limit(4).skip(2).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertEquals(4, entities.size());
+        assertThat(entities.size()).isEqualTo(4);
     }
 
     @Test
@@ -563,11 +558,11 @@ public class CassandraColumnManagerTest {
         entityManager.insert(entity);
         SelectQuery query = select().from("agenda").build();
         var result = entityManager.singleResult(query).get();
-        Assertions.assertEquals(Element.of("user", "otaviojava"), result.find("user").get());
-        Assertions.assertEquals(2, result.size());
+        assertThat(result.find("user").get()).isEqualTo(Element.of("user", "otaviojava"));
+        assertThat(result.size()).isEqualTo(2);
         List<List<Element>> names = (List<List<Element>>) result.find("names").get().get();
-        assertEquals(3, names.size());
-        assertTrue(names.stream().allMatch(n -> n.size() == 2));
+        assertThat(names.size()).isEqualTo(3);
+        assertThat(names.stream().allMatch(n -> n.size() == 2)).isTrue();
     }
 
     @Test

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfigurationTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfigurationTest.java
@@ -18,13 +18,12 @@ package org.eclipse.jnosql.databases.cassandra.communication;
 
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class CassandraConfigurationTest {
@@ -34,7 +33,7 @@ public class CassandraConfigurationTest {
         Settings settings = ColumnDatabase.INSTANCE.getSettings();
         CassandraConfiguration cassandraConfiguration = new CassandraConfiguration();
         var entityManagerFactory = cassandraConfiguration.apply(settings);
-        assertNotNull(entityManagerFactory);
+        assertThat(entityManagerFactory).isNotNull();
     }
 
     @Test
@@ -42,21 +41,21 @@ public class CassandraConfigurationTest {
         Settings settings = ColumnDatabase.INSTANCE.getSettings();
         CassandraConfiguration cassandraConfiguration = new CassandraConfiguration();
         var entityManagerFactory = cassandraConfiguration.apply(settings);
-        assertNotNull(entityManagerFactory);
+        assertThat(entityManagerFactory).isNotNull();
     }
 
     @Test
     public void shouldCreateConfiguration() {
         var configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue( configuration instanceof DatabaseConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof DatabaseConfiguration).isTrue();
     }
 
     @Test
     public void shouldCreateConfigurationQuery() {
         CassandraConfiguration configuration = DatabaseConfiguration.getConfiguration(CassandraConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue( configuration instanceof CassandraConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof CassandraConfiguration).isTrue();
     }
 
 }

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultUDTTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultUDTTest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DefaultUDTTest {
 
@@ -35,8 +34,8 @@ public class DefaultUDTTest {
         UDT udt = UDT.builder("fullname").withName("name")
                 .addUDT(columns).build();
 
-        assertEquals("fullname", udt.userType());
-        assertEquals("name", udt.name());
+        assertThat(udt.userType()).isEqualTo("fullname");
+        assertThat(udt.name()).isEqualTo("name");
     }
 
     @Test

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverterTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverterTest.java
@@ -58,9 +58,6 @@ import java.util.stream.Stream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, ColumnTemplate.class, EntityConverter.class,
@@ -103,8 +100,8 @@ public class CassandraColumnEntityConverterTest {
                 .withPhones(asList("234", "2342")).build();
 
         CommunicationEntity entity = converter.toCommunication(artist);
-        assertEquals("Artist", entity.name());
-        assertEquals(5, entity.size());
+        assertThat(entity.name()).isEqualTo("Artist");
+        assertThat(entity.size()).isEqualTo(5);
     }
 
     @Test
@@ -112,8 +109,8 @@ public class CassandraColumnEntityConverterTest {
 
 
         var entity = converter.toCommunication(actor);
-        assertEquals("Actor", entity.name());
-        assertEquals(7, entity.size());
+        assertThat(entity.name()).isEqualTo("Actor");
+        assertThat(entity.size()).isEqualTo(7);
 
 
         assertThat(entity.elements()).contains(columns);
@@ -125,12 +122,12 @@ public class CassandraColumnEntityConverterTest {
         Stream.of(columns).forEach(entity::add);
 
         Actor actor = converter.toEntity(Actor.class, entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
+        assertThat(actor).isNotNull();
+        assertThat(actor.getAge()).isEqualTo(10);
+        assertThat(actor.getId()).isEqualTo(12L);
+        assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+        assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+        assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
     }
 
     @Test
@@ -139,12 +136,12 @@ public class CassandraColumnEntityConverterTest {
         Stream.of(columns).forEach(entity::add);
 
         Actor actor = converter.toEntity(entity);
-        assertNotNull(actor);
-        assertEquals(10, actor.getAge());
-        assertEquals(12L, actor.getId());
-        assertEquals(asList("234", "2342"), actor.getPhones());
-        assertEquals(Collections.singletonMap("JavaZone", "Jedi"), actor.getMovieCharacter());
-        assertEquals(Collections.singletonMap("JavaZone", 10), actor.getMovieRating());
+        assertThat(actor).isNotNull();
+        assertThat(actor.getAge()).isEqualTo(10);
+        assertThat(actor.getId()).isEqualTo(12L);
+        assertThat(actor.getPhones()).isEqualTo(asList("234", "2342"));
+        assertThat(actor.getMovieCharacter()).isEqualTo(Collections.singletonMap("JavaZone", "Jedi"));
+        assertThat(actor.getMovieRating()).isEqualTo(Collections.singletonMap("JavaZone", 10));
     }
 
 
@@ -158,23 +155,23 @@ public class CassandraColumnEntityConverterTest {
                 .withPhones(asList("234", "2342")).withMovie(movie).build();
 
         var entity = converter.toCommunication(director);
-        assertEquals(6, entity.size());
+        assertThat(entity.size()).isEqualTo(6);
 
-        assertEquals(getValue(entity.find("name")), director.getName());
-        assertEquals(getValue(entity.find("age")), director.getAge());
-        assertEquals(getValue(entity.find("_id")), director.getId());
-        assertEquals(getValue(entity.find("phones")), director.getPhones());
+        assertThat(director.getName()).isEqualTo(getValue(entity.find("name")));
+        assertThat(director.getAge()).isEqualTo(getValue(entity.find("age")));
+        assertThat(director.getId()).isEqualTo(getValue(entity.find("_id")));
+        assertThat(director.getPhones()).isEqualTo(getValue(entity.find("phones")));
 
 
         Element subColumn = entity.find("movie").get();
         List<Element> columns = subColumn.get(new TypeReference<>() {
         });
 
-        assertEquals(3, columns.size());
-        assertEquals("movie", subColumn.name());
-        assertEquals(movie.getTitle(), columns.stream().filter(c -> "title".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getYear(), columns.stream().filter(c -> "year".equals(c.name())).findFirst().get().get());
-        assertEquals(movie.getActors(), columns.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get());
+        assertThat(columns.size()).isEqualTo(3);
+        assertThat(subColumn.name()).isEqualTo("movie");
+        assertThat(columns.stream().filter(c -> "title".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getTitle());
+        assertThat(columns.stream().filter(c -> "year".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getYear());
+        assertThat(columns.stream().filter(c -> "actors".equals(c.name())).findFirst().get().get()).isEqualTo(movie.getActors());
 
 
     }
@@ -190,10 +187,10 @@ public class CassandraColumnEntityConverterTest {
         var entity = converter.toCommunication(director);
         Director director1 = converter.toEntity(entity);
 
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
+        assertThat(director1.getMovie()).isEqualTo(movie);
+        assertThat(director1.getName()).isEqualTo(director.getName());
+        assertThat(director1.getAge()).isEqualTo(director.getAge());
+        assertThat(director1.getId()).isEqualTo(director.getId());
     }
 
     @Test
@@ -213,10 +210,10 @@ public class CassandraColumnEntityConverterTest {
 
         Director director1 = converter.toEntity(entity);
 
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
+        assertThat(director1.getMovie()).isEqualTo(movie);
+        assertThat(director1.getName()).isEqualTo(director.getName());
+        assertThat(director1.getAge()).isEqualTo(director.getAge());
+        assertThat(director1.getId()).isEqualTo(director.getId());
     }
 
 
@@ -238,10 +235,10 @@ public class CassandraColumnEntityConverterTest {
         entity.add(Element.of("movie", map));
         Director director1 = converter.toEntity(entity);
 
-        assertEquals(movie, director1.getMovie());
-        assertEquals(director.getName(), director1.getName());
-        assertEquals(director.getAge(), director1.getAge());
-        assertEquals(director.getId(), director1.getId());
+        assertThat(director1.getMovie()).isEqualTo(movie);
+        assertThat(director1.getName()).isEqualTo(director.getName());
+        assertThat(director1.getAge()).isEqualTo(director.getAge());
+        assertThat(director1.getId()).isEqualTo(director.getId());
     }
 
 
@@ -255,9 +252,9 @@ public class CassandraColumnEntityConverterTest {
         worker.setSalary(new Money("BRL", BigDecimal.TEN));
         worker.setJob(job);
         var entity = converter.toCommunication(worker);
-        assertEquals("Worker", entity.name());
-        assertEquals("Bob", entity.find("name").get().get());
-        assertEquals("BRL 10", entity.find("money").get().get());
+        assertThat(entity.name()).isEqualTo("Worker");
+        assertThat(entity.find("name").get().get()).isEqualTo("Bob");
+        assertThat(entity.find("money").get().get()).isEqualTo("BRL 10");
     }
 
     @Test
@@ -271,9 +268,9 @@ public class CassandraColumnEntityConverterTest {
         worker.setJob(job);
         var entity = converter.toCommunication(worker);
         Worker worker1 = converter.toEntity(entity);
-        assertEquals(worker.getSalary(), worker1.getSalary());
-        assertEquals(job.getCity(), worker1.getJob().getCity());
-        assertEquals(job.getDescription(), worker1.getJob().getDescription());
+        assertThat(worker1.getSalary()).isEqualTo(worker.getSalary());
+        assertThat(worker1.getJob().getCity()).isEqualTo(job.getCity());
+        assertThat(worker1.getJob().getDescription()).isEqualTo(job.getDescription());
     }
 
 
@@ -289,12 +286,12 @@ public class CassandraColumnEntityConverterTest {
         contact.setHome(address);
 
         var entity = converter.toCommunication(contact);
-        assertEquals("ContactCassandra", entity.name());
+        assertThat(entity.name()).isEqualTo("ContactCassandra");
         Element column = entity.find("home").get();
         UDT udt = UDT.class.cast(column);
 
-        assertEquals("address", udt.userType());
-        assertEquals("home", udt.name());
+        assertThat(udt.userType()).isEqualTo("address");
+        assertThat(udt.name()).isEqualTo("home");
         assertThat((List<Element>) udt.get())
                 .contains(Element.of("city", "California"), Element.of("street", "Street"));
 
@@ -313,12 +310,12 @@ public class CassandraColumnEntityConverterTest {
         entity.add(udt);
 
         ContactCassandra contact = converter.toEntity(entity);
-        assertNotNull(contact);
+        assertThat(contact).isNotNull();
         Address home = contact.getHome();
-        assertEquals("Poliana", contact.getName());
-        assertEquals(Integer.valueOf(20), contact.getAge());
-        assertEquals("Salvador", home.getCity());
-        assertEquals("Jose Anasoh", home.getStreet());
+        assertThat(contact.getName()).isEqualTo("Poliana");
+        assertThat(contact.getAge()).isEqualTo(Integer.valueOf(20));
+        assertThat(home.getCity()).isEqualTo("Salvador");
+        assertThat(home.getStreet()).isEqualTo("Jose Anasoh");
 
     }
 
@@ -332,9 +329,9 @@ public class CassandraColumnEntityConverterTest {
         history.setNumber(new java.util.Date().getTime());
 
         var entity = converter.toCommunication(history);
-        assertEquals("History2", entity.name());
+        assertThat(entity.name()).isEqualTo("History2");
         History2 historyConverted = converter.toEntity(entity);
-        assertNotNull(historyConverted);
+        assertThat(historyConverted).isNotNull();
 
     }
 
@@ -346,14 +343,14 @@ public class CassandraColumnEntityConverterTest {
                 new org.eclipse.jnosql.databases.cassandra.mapping.model.Contact("Ada", "ada@lovelace.com")));
 
         var entity = converter.toCommunication(appointmentBook);
-        assertEquals("AppointmentBook", entity.name());
-        assertEquals("otaviojava", entity.find("user").get().get());
+        assertThat(entity.name()).isEqualTo("AppointmentBook");
+        assertThat(entity.find("user").get().get()).isEqualTo("otaviojava");
         UDT column = (UDT) entity.find("contacts").get();
 
         List<List<Element>> contacts = (List<List<Element>>) column.get();
-        assertEquals(2, contacts.size());
-        assertTrue(contacts.stream().allMatch(c -> c.size() == 2));
-        assertEquals("Contact", column.userType());
+        assertThat(contacts.size()).isEqualTo(2);
+        assertThat(contacts.stream().allMatch(c -> c.size() == 2)).isTrue();
+        assertThat(column.userType()).isEqualTo("Contact");
 
     }
 
@@ -370,7 +367,7 @@ public class CassandraColumnEntityConverterTest {
         entity.add(UDT.builder("Contact").withName("contacts").addUDTs(columns).build());
         AppointmentBook appointmentBook = converter.toEntity(entity);
         List<org.eclipse.jnosql.databases.cassandra.mapping.model.Contact> contacts = appointmentBook.getContacts();
-        assertEquals("otaviojava", appointmentBook.getUser());
+        assertThat(appointmentBook.getUser()).isEqualTo("otaviojava");
 
         assertThat(contacts).contains(new org.eclipse.jnosql.databases.cassandra.mapping.model.Contact("Poliana", "poliana"),
                 new org.eclipse.jnosql.databases.cassandra.mapping.model.Contact("Ada", "ada@lovelace.com"));

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraExtensionTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraExtensionTest.java
@@ -24,8 +24,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, ColumnTemplate.class, EntityConverter.class,
@@ -42,6 +43,6 @@ public class CassandraExtensionTest {
 
     @Test
     public void shouldSaveCassandra() {
-        Assertions.assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 }

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryProxyTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryProxyTest.java
@@ -36,11 +36,11 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, ColumnTemplate.class, EntityConverter.class,
@@ -105,7 +105,7 @@ public class CassandraRepositoryProxyTest {
         humanRepository.findByName2("Ada");
         verify(template).cql(Mockito.eq("select * from Person where name = :name"), captor.capture());
         Map map = captor.getValue();
-        assertEquals("Ada", map.get("name"));
+        assertThat(map.get("name")).isEqualTo("Ada");
     }
 
     @Test

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/DefaultCassandraTemplateTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/DefaultCassandraTemplateTest.java
@@ -50,7 +50,6 @@ import java.util.stream.Stream;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -103,10 +102,10 @@ public class DefaultCassandraTemplateTest {
         ContactCassandra contact = new ContactCassandra();
         contact.setName("Name");
         contact.setAge(20);
-        assertEquals(contact, template.save(contact, level));
+        assertThat(template.save(contact, level)).isEqualTo(contact);
 
         Mockito.verify(manager).save(captor.capture(), Mockito.eq(level));
-        assertEquals(entity, captor.getValue());
+        assertThat(captor.getValue()).isEqualTo(entity);
 
     }
 
@@ -127,7 +126,7 @@ public class DefaultCassandraTemplateTest {
         contact.setAge(20);
         assertThat(template.save(Collections.singletonList(contact), level)).contains(contact);
         Mockito.verify(manager).save(captor.capture(), Mockito.eq(level));
-        assertEquals(entity, captor.getValue());
+        assertThat(captor.getValue()).isEqualTo(entity);
 
     }
 
@@ -147,10 +146,10 @@ public class DefaultCassandraTemplateTest {
         ContactCassandra contact = new ContactCassandra();
         contact.setName("Name");
         contact.setAge(20);
-        assertEquals(contact, template.save(contact, duration, level));
+        assertThat(template.save(contact, duration, level)).isEqualTo(contact);
 
         Mockito.verify(manager).save(captor.capture(), Mockito.eq(duration), Mockito.eq(level));
-        assertEquals(entity, captor.getValue());
+        assertThat(captor.getValue()).isEqualTo(entity);
     }
 
     @Test
@@ -171,7 +170,7 @@ public class DefaultCassandraTemplateTest {
         contact.setAge(20);
         assertThat(template.save(Collections.singletonList(contact), duration, level)).contains(contact);
         Mockito.verify(manager).save(captor.capture(), Mockito.eq(duration), Mockito.eq(level));
-        assertEquals(entity, captor.getValue());
+        assertThat(captor.getValue()).isEqualTo(entity);
     }
 
     @Test

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/TimestampConverterTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/TimestampConverterTest.java
@@ -24,7 +24,8 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class TimestampConverterTest {
 
@@ -50,9 +51,9 @@ public class TimestampConverterTest {
         java.time.LocalDate localDate = converter.convertToDatabaseColumn(number).toInstant()
                 .atZone(defaultZoneId).toLocalDate();
 
-        assertEquals(calendar.get(Calendar.DAY_OF_MONTH), localDate.getDayOfMonth());
-        assertEquals(calendar.get(Calendar.YEAR), localDate.getYear());
-        assertEquals(calendar.get(Calendar.MONTH) + 1, localDate.getMonthValue());
+        assertThat(localDate.getDayOfMonth()).isEqualTo(calendar.get(Calendar.DAY_OF_MONTH));
+        assertThat(localDate.getYear()).isEqualTo(calendar.get(Calendar.YEAR));
+        assertThat(localDate.getMonthValue()).isEqualTo(calendar.get(Calendar.MONTH) + 1);
     }
 
     @Test
@@ -66,9 +67,9 @@ public class TimestampConverterTest {
         calendar.setTime(date);
         java.time.LocalDate localDate = converter.convertToDatabaseColumn(date).toInstant()
                 .atZone(defaultZoneId).toLocalDate();
-        assertEquals(calendar.get(Calendar.DAY_OF_MONTH), localDate.getDayOfMonth());
-        assertEquals(calendar.get(Calendar.YEAR), localDate.getYear());
-        assertEquals(calendar.get(Calendar.MONTH) + 1, localDate.getMonthValue());
+        assertThat(localDate.getDayOfMonth()).isEqualTo(calendar.get(Calendar.DAY_OF_MONTH));
+        assertThat(localDate.getYear()).isEqualTo(calendar.get(Calendar.YEAR));
+        assertThat(localDate.getMonthValue()).isEqualTo(calendar.get(Calendar.MONTH) + 1);
     }
 
     @Test
@@ -77,9 +78,9 @@ public class TimestampConverterTest {
         Calendar calendar = Calendar.getInstance();
         java.time.LocalDate localDate = converter.convertToDatabaseColumn(calendar).toInstant()
                 .atZone(defaultZoneId).toLocalDate();
-        assertEquals(calendar.get(Calendar.DAY_OF_MONTH), localDate.getDayOfMonth());
-        assertEquals(calendar.get(Calendar.YEAR), localDate.getYear());
-        assertEquals(calendar.get(Calendar.MONTH) + 1, localDate.getMonthValue());
+        assertThat(localDate.getDayOfMonth()).isEqualTo(calendar.get(Calendar.DAY_OF_MONTH));
+        assertThat(localDate.getYear()).isEqualTo(calendar.get(Calendar.YEAR));
+        assertThat(localDate.getMonthValue()).isEqualTo(calendar.get(Calendar.MONTH) + 1);
     }
 
     @Test
@@ -88,9 +89,9 @@ public class TimestampConverterTest {
         java.time.LocalDate date = java.time.LocalDate.now();
         java.time.LocalDate localDate = converter.convertToDatabaseColumn(date).toInstant()
                 .atZone(defaultZoneId).toLocalDate();
-        assertEquals(date.getDayOfMonth(), localDate.getDayOfMonth());
-        assertEquals(date.getYear(), localDate.getYear());
-        assertEquals(date.getMonthValue(), localDate.getMonthValue());
+        assertThat(localDate.getDayOfMonth()).isEqualTo(date.getDayOfMonth());
+        assertThat(localDate.getYear()).isEqualTo(date.getYear());
+        assertThat(localDate.getMonthValue()).isEqualTo(date.getMonthValue());
     }
 
 
@@ -100,9 +101,9 @@ public class TimestampConverterTest {
         LocalDateTime date = LocalDateTime.now();
         java.time.LocalDate localDate = converter.convertToDatabaseColumn(date).toInstant()
                 .atZone(defaultZoneId).toLocalDate();
-        assertEquals(date.getDayOfMonth(), localDate.getDayOfMonth());
-        assertEquals(date.getYear(), localDate.getYear());
-        assertEquals(date.getMonthValue(), localDate.getMonthValue());
+        assertThat(localDate.getDayOfMonth()).isEqualTo(date.getDayOfMonth());
+        assertThat(localDate.getYear()).isEqualTo(date.getYear());
+        assertThat(localDate.getMonthValue()).isEqualTo(date.getMonthValue());
     }
 
     @Test
@@ -111,8 +112,8 @@ public class TimestampConverterTest {
         ZonedDateTime date = ZonedDateTime.now();
         java.time.LocalDate localDate = converter.convertToDatabaseColumn(date).toInstant()
                 .atZone(defaultZoneId).toLocalDate();
-        assertEquals(date.getDayOfMonth(), localDate.getDayOfMonth());
-        assertEquals(date.getYear(), localDate.getYear());
-        assertEquals(date.getMonthValue(), localDate.getMonthValue());
+        assertThat(localDate.getDayOfMonth()).isEqualTo(date.getDayOfMonth());
+        assertThat(localDate.getYear()).isEqualTo(date.getYear());
+        assertThat(localDate.getMonthValue()).isEqualTo(date.getMonthValue());
     }
 }

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManagerTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManagerTest.java
@@ -35,10 +35,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class CouchbaseBucketManagerTest {
 
@@ -76,8 +73,8 @@ public class CouchbaseBucketManagerTest {
     public void shouldPutValue() {
         manager.put(KEY_OTAVIO, userOtavio);
         Optional<Value> otavio = manager.get(KEY_OTAVIO);
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
@@ -88,12 +85,12 @@ public class CouchbaseBucketManagerTest {
 
         manager.put(entities);
         Optional<Value> otavio = manager.get(KEY_OTAVIO);
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = manager.get(KEY_SORO);
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
 
@@ -101,8 +98,8 @@ public class CouchbaseBucketManagerTest {
     public void shouldPutPrimitivesValues() {
         manager.put("integer", 1);
         Optional<Value> integer = manager.get("integer");
-        assertTrue(integer.isPresent());
-        assertEquals(Integer.valueOf(1), integer.get().get(Integer.class));
+        assertThat(integer.isPresent()).isTrue();
+        assertThat(integer.get().get(Integer.class)).isEqualTo(Integer.valueOf(1));
     }
 
     @Test
@@ -111,10 +108,10 @@ public class CouchbaseBucketManagerTest {
         manager.put(KeyValueEntity.of(KEY_OTAVIO, userOtavio), Duration.ofSeconds(1L));
 
         Optional<Value> otavio = manager.get(KEY_OTAVIO);
-        assertTrue(otavio.isPresent());
+        assertThat(otavio.isPresent()).isTrue();
         Thread.sleep(2_000);
         otavio = manager.get(KEY_OTAVIO);
-        assertFalse(otavio.isPresent());
+        assertThat(otavio.isPresent()).isFalse();
     }
 
     @Test
@@ -122,10 +119,10 @@ public class CouchbaseBucketManagerTest {
 
         manager.put(singleton(KeyValueEntity.of(KEY_OTAVIO, userOtavio)), Duration.ofSeconds(1L));
         Optional<Value> otavio = manager.get(KEY_OTAVIO);
-        assertTrue(otavio.isPresent());
+        assertThat(otavio.isPresent()).isTrue();
         Thread.sleep(2_000);
         otavio = manager.get(KEY_OTAVIO);
-        assertFalse(otavio.isPresent());
+        assertThat(otavio.isPresent()).isFalse();
     }
 
 
@@ -134,8 +131,8 @@ public class CouchbaseBucketManagerTest {
     public void shouldPutKeyValue() {
         manager.put(entityOtavio);
         Optional<Value> otavio = manager.get(KEY_OTAVIO);
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
@@ -144,12 +141,12 @@ public class CouchbaseBucketManagerTest {
 
         manager.put(asList(soroEntity, entityOtavio));
         Optional<Value> otavio = manager.get(KEY_OTAVIO);
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = manager.get(KEY_SORO);
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
     @Test
@@ -157,7 +154,7 @@ public class CouchbaseBucketManagerTest {
         User user = new User(KEY_OTAVIO);
         KeyValueEntity keyValue = KeyValueEntity.of(KEY_OTAVIO, Value.of(user));
         manager.put(keyValue);
-        assertNotNull(manager.get(KEY_OTAVIO));
+        assertThat(manager.get(KEY_OTAVIO)).isNotNull();
 
 
     }
@@ -165,9 +162,9 @@ public class CouchbaseBucketManagerTest {
     @Test
     public void shouldRemoveKey() {
         manager.put(entityOtavio);
-        assertTrue(manager.get(KEY_OTAVIO).isPresent());
+        assertThat(manager.get(KEY_OTAVIO).isPresent()).isTrue();
         manager.delete(KEY_OTAVIO);
-        assertFalse(manager.get(KEY_OTAVIO).isPresent());
+        assertThat(manager.get(KEY_OTAVIO).isPresent()).isFalse();
     }
 
     @Test
@@ -180,7 +177,7 @@ public class CouchbaseBucketManagerTest {
                 .map(value -> value.get(User.class)).collect(Collectors.toList()))
                 .contains(userOtavio, userSoro);
         manager.delete(keys);
-        assertEquals(0L, StreamSupport.stream(manager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(manager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 
 

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentConfigurationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentConfigurationTest.java
@@ -15,10 +15,10 @@
 package org.eclipse.jnosql.databases.couchbase.communication;
 
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 
 public class CouchbaseDocumentConfigurationTest {
@@ -28,22 +28,22 @@ public class CouchbaseDocumentConfigurationTest {
     public void shouldCreateDocumentManagerFactoryByFile() {
         CouchbaseDocumentConfiguration configuration = new CouchbaseDocumentConfiguration();
         CouchbaseDocumentManagerFactory managerFactory = configuration.apply(CouchbaseUtil.getSettings());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldGetConfiguration() {
         DatabaseConfiguration configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof CouchbaseDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof CouchbaseDocumentConfiguration).isTrue();
     }
 
     @Test
     public void shouldGetConfigurationFromQuery() {
         CouchbaseDocumentConfiguration configuration = DatabaseConfiguration
                 .getConfiguration(CouchbaseDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof CouchbaseDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof CouchbaseDocumentConfiguration).isTrue();
     }
 
 }

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerFactoryTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerFactoryTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class CouchbaseDocumentManagerFactoryTest {
@@ -30,7 +30,7 @@ public class CouchbaseDocumentManagerFactoryTest {
         Settings settings=Database.INSTANCE.getSettings();
         CouchbaseDocumentConfiguration configuration =  new CouchbaseDocumentConfiguration();
         CouchbaseDocumentManagerFactory factory = configuration.apply(settings);
-        assertNotNull(factory.apply(CouchbaseUtil.BUCKET_NAME));
+        assertThat(factory.apply(CouchbaseUtil.BUCKET_NAME)).isNotNull();
     }
 
 }

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
@@ -52,9 +52,6 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -103,7 +100,7 @@ public class CouchbaseDocumentManagerTest {
     void shouldInsert() {
         CommunicationEntity entity = getEntity();
         CommunicationEntity documentEntity = entityManager.insert(entity);
-        assertEquals(entity, documentEntity);
+        assertThat(documentEntity).isEqualTo(entity);
     }
 
     @Test
@@ -111,7 +108,7 @@ public class CouchbaseDocumentManagerTest {
         CommunicationEntity entity = getEntity();
         entity.add("_key", "anyvalue");
         CommunicationEntity documentEntity = entityManager.insert(entity);
-        assertEquals(entity, documentEntity);
+        assertThat(documentEntity).isEqualTo(entity);
     }
 
     @Test
@@ -121,7 +118,7 @@ public class CouchbaseDocumentManagerTest {
         Element newField = Elements.of("newField", "10");
         entity.add(newField);
         CommunicationEntity updated = entityManager.update(entity);
-        assertEquals(newField, updated.find("newField").get());
+        assertThat(updated.find("newField").get()).isEqualTo(newField);
     }
 
     @Test
@@ -186,7 +183,7 @@ public class CouchbaseDocumentManagerTest {
                 .where(name.name()).eq(name.get()).build();
         entityManager.delete(deleteQuery);
         Thread.sleep(1_000L);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -235,7 +232,7 @@ public class CouchbaseDocumentManagerTest {
         Optional<Element> foods = entityFound.find("foods");
         Set<String> setFoods = foods.get().get(new TypeReference<>() {
         });
-        assertEquals(set, setFoods);
+        assertThat(setFoods).isEqualTo(set);
     }
 
     @Test
@@ -252,12 +249,12 @@ public class CouchbaseDocumentManagerTest {
         var query = select().from(COLLECTION_APP_NAME).where(key.name()).eq(key.get()).build();
 
         CommunicationEntity documentEntity = entityManager.singleResult(query).get();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").get().get();
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseKeyValueConfigurationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseKeyValueConfigurationTest.java
@@ -16,11 +16,11 @@ package org.eclipse.jnosql.databases.couchbase.communication;
 
 import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class CouchbaseKeyValueConfigurationTest {
 
@@ -35,21 +35,21 @@ public class CouchbaseKeyValueConfigurationTest {
     @Test
     public void shouldCreateKeyValueFactoryFromFile() {
         BucketManagerFactory managerFactory = configuration.apply(CouchbaseUtil.getSettings());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldReturnFromConfiguration() {
         KeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof KeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof KeyValueConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         CouchbaseKeyValueConfiguration configuration = KeyValueConfiguration
                 .getConfiguration(CouchbaseKeyValueConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof CouchbaseKeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof CouchbaseKeyValueConfiguration).isTrue();
     }
 }

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseBucketManagerFactoryTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseBucketManagerFactoryTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.jnosql.databases.couchbase.communication;
 
 import org.eclipse.jnosql.communication.keyvalue.BucketManager;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -24,8 +23,8 @@ import java.util.List;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class DefaultCouchbaseBucketManagerFactoryTest {
@@ -41,33 +40,33 @@ public class DefaultCouchbaseBucketManagerFactoryTest {
     @Test
     public void shouldReturnManager() {
         BucketManager database = factory.apply(CouchbaseUtil.BUCKET_NAME);
-        assertNotNull(database);
+        assertThat(database).isNotNull();
     }
 
     @Test
     public void shouldReturnError() {
-        assertThrows(NullPointerException.class, () -> factory.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> factory.apply(null));
     }
 
 
     @Test
     public void shouldReturnList() {
         List<String> names = factory.getList("jnosql", String.class);
-        Assertions.assertNotNull(names);
+        assertThat(names).isNotNull();
     }
 
     @Test
     public void shouldReturnSet() {
-        Assertions.assertNotNull(factory.getSet("jnosql", String.class));
+        assertThat(factory.getSet("jnosql", String.class)).isNotNull();
     }
 
     @Test
     public void shouldReturnQueue() {
-        Assertions.assertNotNull(factory.getQueue("jnosql", String.class));
+        assertThat(factory.getQueue("jnosql", String.class)).isNotNull();
     }
 
     @Test
     public void shouldReturnMap() {
-        Assertions.assertNotNull(factory.getMap("jnosql", String.class, String.class) );
+        assertThat(factory.getMap("jnosql", String.class, String.class)).isNotNull();
     }
 }

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DocumentQueryTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DocumentQueryTest.java
@@ -38,8 +38,6 @@ import static org.awaitility.Awaitility.await;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class DocumentQueryTest {
@@ -102,7 +100,7 @@ public class DocumentQueryTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertEquals(2, entities.size());
+        assertThat(entities.size()).isEqualTo(2);
 
     }
 
@@ -113,7 +111,7 @@ public class DocumentQueryTest {
                 .skip(1L)
                 .build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertEquals(2, entities.size());
+        assertThat(entities.size()).isEqualTo(2);
 
     }
 
@@ -121,7 +119,7 @@ public class DocumentQueryTest {
     public void shouldShouldDefineLimitAndStart() {
 
         List<CommunicationEntity> entities = entityManager.select(select().from(COLLECTION_NAME).build()).collect(Collectors.toList());
-        assertEquals(4, entities.size());
+        assertThat(entities.size()).isEqualTo(4);
 
         SelectQuery query = select().from(COLLECTION_NAME)
                 .where("name").eq("name")
@@ -130,7 +128,7 @@ public class DocumentQueryTest {
                 .build();
 
         entities = entityManager.select(query).toList();
-        assertEquals(2, entities.size());
+        assertThat(entities.size()).isEqualTo(2);
 
     }
 
@@ -139,7 +137,7 @@ public class DocumentQueryTest {
     public void shouldSelectAll() {
         SelectQuery query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).hasSize(4);
     }
 
@@ -152,7 +150,7 @@ public class DocumentQueryTest {
                 .eq("name")
                 .build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -169,7 +167,7 @@ public class DocumentQueryTest {
                 .map(d -> d.get(String.class))
                 .collect(Collectors.toList());
 
-        assertFalse(result.isEmpty());
+        assertThat(result.isEmpty()).isFalse();
         assertThat(result).contains("name", "name", "name", "name3");
     }
 
@@ -187,7 +185,7 @@ public class DocumentQueryTest {
                 .map(d -> d.get(String.class))
                 .collect(Collectors.toList());
 
-        assertFalse(result.isEmpty());
+        assertThat(result.isEmpty()).isFalse();
         assertThat(result).contains("name3", "name", "name", "name");
     }
 
@@ -199,7 +197,7 @@ public class DocumentQueryTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
 
     }
 

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseDocumentRepositoryProxyTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseDocumentRepositoryProxyTest.java
@@ -35,11 +35,11 @@ import org.mockito.Mockito;
 import java.time.Duration;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnableAutoWeld
@@ -83,7 +83,7 @@ public class CouchbaseDocumentRepositoryProxyTest {
 
         JsonObject value = captor.getValue();
 
-        assertEquals("Ada", value.getString("name"));
+        assertThat(value.getString("name")).isEqualTo("Ada");
     }
 
     @Test

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseExtensionTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseExtensionTest.java
@@ -25,8 +25,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, AbstractKeyValueTemplate.class,
@@ -41,6 +42,6 @@ public class CouchbaseExtensionTest {
 
     @Test
     public void shouldSaveOrientDB() {
-        Assertions.assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 }

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategyFactoryTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategyFactoryTest.java
@@ -29,11 +29,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CouchDBAuthenticationStrategyFactoryTest {
 
     @Nested
-    @DisplayName("Factory strategy resolution")
-    class FactoryResolution {
+    @DisplayName("When resolving authentication strategies")
+    class WhenTheResolution {
 
         @Test
-        @DisplayName("should return Basic strategy when username and password are provided")
+        @DisplayName("Should return Basic strategy when username and password are provided")
         void shouldReturnBasicStrategy() {
             CouchDBAuthenticationStrategy strategy =
                     CouchDBAuthenticationStrategyFactory.of("admin", "secret", null);
@@ -43,7 +43,7 @@ class CouchDBAuthenticationStrategyFactoryTest {
         }
 
         @Test
-        @DisplayName("should return Bearer strategy when token is provided and username/password are null")
+        @DisplayName("Should return Bearer strategy when token is provided and username/password are null")
         void shouldReturnBearerStrategy() {
             CouchDBAuthenticationStrategy strategy =
                     CouchDBAuthenticationStrategyFactory.of(null, null, "jwt-token");
@@ -53,7 +53,7 @@ class CouchDBAuthenticationStrategyFactoryTest {
         }
 
         @Test
-        @DisplayName("should return None strategy when no authentication data is provided")
+        @DisplayName("Should return None strategy when no authentication data is provided")
         void shouldReturnNoneStrategy() {
             CouchDBAuthenticationStrategy strategy =
                     CouchDBAuthenticationStrategyFactory.of(null, null, null);
@@ -64,8 +64,8 @@ class CouchDBAuthenticationStrategyFactoryTest {
     }
 
     @Nested
-    @DisplayName("Authentication strategy behavior")
-    class StrategyBehavior {
+    @DisplayName("When applying authentication strategies")
+    class WhenTheApplication {
 
         @Test
         @DisplayName("Basic strategy should apply Authorization header using Basic scheme")

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentConfigurationTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentConfigurationTest.java
@@ -18,13 +18,12 @@ package org.eclipse.jnosql.databases.couchdb.communication;
 
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class CouchDBDocumentConfigurationTest {
@@ -33,29 +32,29 @@ class CouchDBDocumentConfigurationTest {
     public void shouldCreateDocumentManagerFactoryByMap() {
         CouchDBDocumentConfiguration configuration = new CouchDBDocumentConfiguration();
         var managerFactory = configuration.apply(Settings.settings());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldCreateDocumentManagerFactoryByFile() {
         CouchDBDocumentConfiguration configuration = new CouchDBDocumentConfiguration();
         var managerFactory = configuration.apply(Settings.settings());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldReturnFromConfiguration() {
         CouchDBDocumentConfiguration configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof CouchDBDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof CouchDBDocumentConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         CouchDBDocumentConfiguration configuration = DatabaseConfiguration
                 .getConfiguration(CouchDBDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof CouchDBDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof CouchDBDocumentConfiguration).isTrue();
     }
 
 }

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
@@ -23,7 +23,6 @@ import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.databases.couchdb.communication.configuration.DocumentDatabase;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -44,12 +43,7 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class DefaultCouchDBDocumentManagerTest {
@@ -73,7 +67,7 @@ class DefaultCouchDBDocumentManagerTest {
     void shouldInsert() {
         var entity = getEntity();
         var documentEntity = entityManager.insert(entity);
-        assertEquals(entity, documentEntity);
+        assertThat(documentEntity).isEqualTo(entity);
     }
 
     @Test
@@ -81,7 +75,7 @@ class DefaultCouchDBDocumentManagerTest {
         var entity = getEntity();
         entity.remove(CouchDBConstant.ID);
         var documentEntity = entityManager.insert(entity);
-        assertTrue(documentEntity.find(CouchDBConstant.ID).isPresent());
+        assertThat(documentEntity.find(CouchDBConstant.ID).isPresent()).isTrue();
     }
 
     @Test
@@ -92,20 +86,20 @@ class DefaultCouchDBDocumentManagerTest {
         var newField = Elements.of("newField", "10");
         entity.add(newField);
         var updated = entityManager.update(entity);
-        assertEquals(newField, updated.find("newField").get());
+        assertThat(updated.find("newField").get()).isEqualTo(newField);
     }
 
     @Test
     void shouldReturnErrorOnUpdate() {
-        assertThrows(NullPointerException.class, () -> entityManager.update((CommunicationEntity) null));
-        assertThrows(CouchDBHttpClientException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.update((CommunicationEntity) null));
+        assertThatExceptionOfType(CouchDBHttpClientException.class).isThrownBy(() -> {
             var entity = getEntity();
             entity.remove(CouchDBConstant.ID);
             entityManager.update(entity);
 
         });
 
-        assertThrows(CouchDBHttpClientException.class, () -> {
+        assertThatExceptionOfType(CouchDBHttpClientException.class).isThrownBy(() -> {
             var entity = getEntity();
             entity.add(CouchDBConstant.ID, "not_found");
             entityManager.update(entity);
@@ -122,14 +116,14 @@ class DefaultCouchDBDocumentManagerTest {
         Object id = entity.find(CouchDBConstant.ID).map(Element::get).get();
         var query = select().from(COLLECTION_NAME).where(CouchDBConstant.ID).eq(id).build();
         var documentFound = entityManager.singleResult(query).get();
-        assertEquals(entity, documentFound);
+        assertThat(documentFound).isEqualTo(entity);
     }
 
     @Test
     void shouldSelectEmptyResult() {
         var query = select().from(COLLECTION_NAME).where("no_field").eq("not_found").build();
         var entities = entityManager.select(query).toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -143,7 +137,7 @@ class DefaultCouchDBDocumentManagerTest {
         var deleteQuery = delete().from(COLLECTION_NAME)
                 .where(name.name()).eq(name.get()).build();
         entityManager.delete(deleteQuery);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -152,7 +146,7 @@ class DefaultCouchDBDocumentManagerTest {
         entity.remove(CouchDBConstant.ID);
         entityManager.insert(entity);
         long count = entityManager.count();
-        assertTrue(count > 0);
+        assertThat(count > 0).isTrue();
     }
 
     @Test
@@ -167,19 +161,19 @@ class DefaultCouchDBDocumentManagerTest {
         CouchDBDocumentQuery query = CouchDBDocumentQuery.of(select().from(COLLECTION_NAME)
                 .where("index").in(asList(0, 1, 2, 3, 4)).limit(2).build());
 
-        assertFalse(query.getBookmark().isPresent());
+        assertThat(query.getBookmark().isPresent()).isFalse();
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entities.size());
-        assertTrue(query.getBookmark().isPresent());
+        assertThat(entities.size()).isEqualTo(2);
+        assertThat(query.getBookmark().isPresent()).isTrue();
         String bookmark = query.getBookmark().get();
 
         entities = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entities.size());
-        assertTrue(query.getBookmark().isPresent());
-        assertNotEquals(bookmark, query.getBookmark().get());
+        assertThat(entities.size()).isEqualTo(2);
+        assertThat(query.getBookmark().isPresent()).isTrue();
+        assertThat(query.getBookmark().get()).isNotEqualTo(bookmark);
 
         entities = entityManager.select(query).collect(Collectors.toList());
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -193,7 +187,7 @@ class DefaultCouchDBDocumentManagerTest {
         CouchDBDocumentQuery query = CouchDBDocumentQuery.of(select().from(COLLECTION_NAME)
                 .where("name").in(Arrays.asList("Poliana", "Poliana")).build());
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertEquals(4, entities.size());
+        assertThat(entities.size()).isEqualTo(4);
     }
 
     @Test
@@ -210,10 +204,10 @@ class DefaultCouchDBDocumentManagerTest {
         var query = select().from("AppointmentBook").where(key.name()).eq(key.get()).build();
 
         var documentEntity = entityManager.singleResult(query).get();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").get().get();
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test
@@ -263,10 +257,10 @@ class DefaultCouchDBDocumentManagerTest {
         final SelectQuery query = select().from(COLLECTION_NAME)
                 .where("_id").eq(id).and("scope").eq("xxx").build();
         final Optional<CommunicationEntity> optional = entityManager.select(query).findFirst();
-        Assertions.assertTrue(optional.isPresent());
+        assertThat(optional.isPresent()).isTrue();
         var documentEntity = optional.get();
         var properties = documentEntity.find("properties").get();
-        Assertions.assertNotNull(properties);
+        assertThat(properties).isNotNull();
     }
 
     @Test

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/MangoQueryConverterTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/MangoQueryConverterTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import java.util.Arrays;
 
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 class MangoQueryConverterTest {
@@ -34,7 +34,7 @@ class MangoQueryConverterTest {
     public void shouldReturnSelectFromAll(JsonObject expected) {
         var query = select().from("person").build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -42,7 +42,7 @@ class MangoQueryConverterTest {
     public void shouldReturnSelectFieldsFromAll(JsonObject expected) {
         var query = select("_id", "_rev").from("person").build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -50,7 +50,7 @@ class MangoQueryConverterTest {
     public void shouldReturnSelectFieldsLimitSkip(JsonObject expected) {
         var query = select("_id", "_rev").from("person").limit(10).skip(2).build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -59,7 +59,7 @@ class MangoQueryConverterTest {
         var query = select().from("person").orderBy("year").asc()
                 .orderBy("name").desc().build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -67,7 +67,7 @@ class MangoQueryConverterTest {
     public void shouldSelectFromGtAge(JsonObject expected) {
         var query = select().from("person").where("age").gt(10).build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -75,7 +75,7 @@ class MangoQueryConverterTest {
     public void shouldSelectFromGteAge(JsonObject expected) {
         var query = select().from("person").where("age").gte(10).build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -83,7 +83,7 @@ class MangoQueryConverterTest {
     public void shouldSelectFromLtAge(JsonObject expected) {
         var query = select().from("person").where("age").lt(10).build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -91,7 +91,7 @@ class MangoQueryConverterTest {
     public void shouldSelectFromLteAge(JsonObject expected) {
         var query = select().from("person").where("age").lte(10).build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -99,7 +99,7 @@ class MangoQueryConverterTest {
     public void shouldSelectFromInAge(JsonObject expected) {
         var query = select().from("person").where("age").in(Arrays.asList(10, 12)).build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -107,7 +107,7 @@ class MangoQueryConverterTest {
     public void shouldSelectFromNotAge(JsonObject expected) {
         var query = select().from("person").where("age").not().lt(10).build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -117,7 +117,7 @@ class MangoQueryConverterTest {
                 .where("name").eq("Poliana")
                 .and("name").eq("Ada").build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -127,7 +127,7 @@ class MangoQueryConverterTest {
                 .where("name").eq("Poliana")
                 .or("name").eq("Ada").build();
         JsonObject jsonObject = converter.apply(query);
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -135,7 +135,7 @@ class MangoQueryConverterTest {
     public void shouldReturnSelectFromAllBookmark(JsonObject expected) {
         var query = select().from("person").build();
         JsonObject jsonObject = converter.apply(CouchDBDocumentQuery.of(query));
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -143,7 +143,7 @@ class MangoQueryConverterTest {
     public void shouldReturnSelectFromAllBookmark2(JsonObject expected) {
         var query = select().from("person").build();
         JsonObject jsonObject = converter.apply(CouchDBDocumentQuery.of(query, "bookmark"));
-        assertEquals(expected, jsonObject);
+        assertThat(jsonObject).isEqualTo(expected);
     }
 
 

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/AttachmentTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/AttachmentTest.java
@@ -24,8 +24,8 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 /**
  * Contains tests to handle attachment representations.
@@ -77,17 +77,17 @@ public class AttachmentTest {
     }
     
     private void checkAttachment(EntityAttachment att, String name, String contentType, long lastModified) throws IOException {
-        assertEquals(name, att.name());
-        assertEquals(contentType, att.getContentType());
-        assertEquals(testData.length, att.getLength());
-        assertEquals(lastModified, att.getLastModified());
+        assertThat(att.name()).isEqualTo(name);
+        assertThat(att.getContentType()).isEqualTo(contentType);
+        assertThat(att.getLength()).isEqualTo(testData.length);
+        assertThat(att.getLastModified()).isEqualTo(lastModified);
         
         ByteArrayOutputStream data = new ByteArrayOutputStream();
         try(InputStream is = att.getData()) {
             copyStream(is, data, 128);
         }
         
-        assertArrayEquals(testData, data.toByteArray());
+        assertThat(data.toByteArray()).isEqualTo(testData);
     }
     
      public static long copyStream(InputStream is, OutputStream os, int bufferSize) throws IOException {

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/CompositeValueWriterTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/CompositeValueWriterTest.java
@@ -53,23 +53,23 @@ class CompositeValueWriterTest {
     }
 
     @Nested
-    @DisplayName("When evaluating supported types via test()")
-    class TestMethodScenarios {
+    @DisplayName("When validating supported value types")
+    class WhenTheValidation {
 
         @Test
         @DisplayName("Should return true when at least one registered custom writer supports the type")
         void shouldReturnTrueWhenCustomWriterSupportsTheType() {
-            // Arrange
+            // Given
             CompositeValueWriter<Object, Object> composite = new CompositeValueWriter<>(
                     new StringToIntegerWriter(),
                     new DummyUUIDWriter()
             );
 
-            // Act
+            // When
             boolean supportsString = composite.test(String.class);
             boolean supportsUUID = composite.test(UUID.class);
 
-            // Assert
+            // Then
             assertThat(supportsString).isTrue();
             assertThat(supportsUUID).isTrue();
         }
@@ -77,39 +77,37 @@ class CompositeValueWriterTest {
         @Test
         @DisplayName("Should fall back to the system default configuration when no custom writer matches")
         void shouldFallbackToDefaultWhenNoCustomWriterMatches() {
-            // Arrange
+            // Given
             CompositeValueWriter<Object, Object> composite = new CompositeValueWriter<>(
                     new StringToIntegerWriter()
             );
 
-            // Act
-            // Using a type unlikely to be supported natively by default SPI, or checking fallback execution path
+            // When
             boolean result = composite.test(Void.class);
 
-            // Assert
-            // Falls back to ValueWriterDecorator.getInstance().test(Void.class) which is typically false
+            // Then
             assertThat(result).isFalse();
         }
     }
 
     @Nested
-    @DisplayName("When converting data via write()")
-    class WriteMethodScenarios {
+    @DisplayName("When converting values")
+    class WhenTheConversion {
 
         @Test
         @DisplayName("Should delegate to the appropriate custom writer when a matching type is provided")
         void shouldDelegateToMatchingCustomWriter() {
-            // Arrange
+            // Given
             CompositeValueWriter<Object, Object> composite = new CompositeValueWriter<>(
                     new StringToIntegerWriter(),
                     new DummyUUIDWriter()
             );
             UUID targetUuid = UUID.randomUUID();
 
-            // Act
+            // When
             Object result = composite.write(targetUuid);
 
-            // Assert
+            // Then
             assertThat(result)
                     .isInstanceOf(String.class)
                     .isEqualTo("CUSTOM-" + targetUuid);
@@ -118,7 +116,7 @@ class CompositeValueWriterTest {
         @Test
         @DisplayName("Should respect registration order and use the first matching writer if multiple support the type")
         void shouldRespectOrderWhenMultipleWritersMatch() {
-            // Arrange
+            // Given
             ValueWriter<String, String> firstMatchingWriter = new ValueWriter<>() {
                 @Override public boolean test(Class<?> type) { return String.class.equals(type); }
                 @Override public String write(String type) { return "FIRST"; }
@@ -134,24 +132,23 @@ class CompositeValueWriterTest {
                     secondMatchingWriter
             );
 
-            // Act
+            // When
             String result = composite.write("input");
 
-            // Assert
+            // Then
             assertThat(result).isEqualTo("FIRST");
         }
 
         @Test
         @DisplayName("Should fall back to default writer behavior when payload type has no custom match")
         void shouldFallbackToDefaultWriterWhenNoCustomMatchFound() {
-            // Arrange
+            // Given
             CompositeValueWriter<Object, Object> composite = new CompositeValueWriter<>(new DummyUUIDWriter());
 
-            // Act & Assert
-            // Passing a plain String, which bypasses DummyUUIDWriter and hits the framework default pipeline
+            // When
             Object result = composite.write(Month.APRIL);
 
-            // Default framework behavior for a String value writer usually returns the string itself
+            // Then
             assertThat(result).isEqualTo("APRIL");
         }
     }

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/DefaultJsonBSupplierTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/DefaultJsonBSupplierTest.java
@@ -17,21 +17,21 @@ package org.eclipse.jnosql.communication.driver;
 import jakarta.json.bind.Jsonb;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class DefaultJsonBSupplierTest {
 
     @Test
     public void shouldReturnDefaultInstance() {
-        assertNotNull(JsonbSupplier.getInstance());
+        assertThat(JsonbSupplier.getInstance()).isNotNull();
     }
 
     @Test
     public void shouldProvideJSON() {
         JsonbSupplier supplier = JsonbSupplier.getInstance();
-        assertNotNull(supplier);
-        assertNotNull(supplier.get());
+        assertThat(supplier).isNotNull();
+        assertThat(supplier.get()).isNotNull();
     }
 
     @Test
@@ -39,7 +39,7 @@ public class DefaultJsonBSupplierTest {
         Jsonb jsonb = JsonbSupplier.getInstance().get();
         User user = new User("Ada", 32);
         String json = jsonb.toJson(user);
-        assertNotNull(json);
-        assertEquals(user, jsonb.fromJson(json, User.class));
+        assertThat(json).isNotNull();
+        assertThat(jsonb.fromJson(json, User.class)).isEqualTo(user);
     }
 }

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/UUIDValueWriterTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/UUIDValueWriterTest.java
@@ -26,16 +26,16 @@ class UUIDValueWriterTest {
     private final UUIDValueWriter writer = new UUIDValueWriter();
 
     @Nested
-    @DisplayName("When evaluating supported types via test()")
-    class WhenRecognizingSupportedTypes {
+    @DisplayName("When validating supported UUID types")
+    class WhenTheValidation {
 
         @Test
         @DisplayName("Should return true when the class type is exactly UUID")
         void shouldReturnTrueWhenClassIsUUID() {
-            // Act
+            // When
             boolean result = writer.test(UUID.class);
 
-            // Assert
+            // Then
             assertThat(result)
                     .isTrue();
         }
@@ -43,11 +43,11 @@ class UUIDValueWriterTest {
         @Test
         @DisplayName("Should return false when the class type is not UUID")
         void shouldReturnFalseWhenClassIsNotUUID() {
-            // Act
+            // When
             boolean resultWithString = writer.test(String.class);
             boolean resultWithInteger = writer.test(Integer.class);
 
-            // Assert
+            // Then
             assertThat(resultWithString).isFalse();
 
             assertThat(resultWithInteger).isFalse();
@@ -56,39 +56,39 @@ class UUIDValueWriterTest {
         @Test
         @DisplayName("Should return false when the class type is null")
         void shouldReturnFalseWhenClassIsNull() {
-            // Act
+            // When
             boolean result = writer.test(null);
 
-            // Assert
+            // Then
             assertThat(result).isFalse();
         }
     }
 
     @Nested
-    @DisplayName("When converting UUID data via write()")
-    class WriteMethodScenarios {
+    @DisplayName("When converting UUID values")
+    class WhenTheConversion {
 
         @Test
         @DisplayName("Should return a valid canonical String representation when UUID is provided")
         void shouldReturnStringRepresentationWhenUUIDIsNotNull() {
-            // Arrange
+            // Given
             UUID sampleUuid = UUID.randomUUID();
             String expectedString = sampleUuid.toString();
 
-            // Act
+            // When
             String actualString = writer.write(sampleUuid);
 
-            // Assert
+            // Then
             assertThat(actualString).isNotNull().isEqualTo(expectedString);
         }
 
         @Test
         @DisplayName("Should return null when the provided UUID parameter is null")
         void shouldReturnNullWhenUUIDIsNull() {
-            // Act
+            // When
             String actualString = writer.write(null);
 
-            // Assert
+            // Then
             assertThat(actualString).isNull();
         }
     }

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/ValueJSONTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/ValueJSONTest.java
@@ -25,22 +25,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class ValueJSONTest {
 
     @Test
     public void shouldReturnErrorWhenElementIsNull() {
-        assertThrows(NullPointerException.class, () -> ValueJSON.of(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> ValueJSON.of(null));
     }
 
     @Test
     public void shouldConvertType() {
         AtomicInteger number = new AtomicInteger(5_000);
         Value value = ValueJSON.of(number);
-        assertEquals(Integer.valueOf(5_000), value.get(Integer.class));
-        assertEquals("5000", value.get(String.class));
+        assertThat(value.get(Integer.class)).isEqualTo(Integer.valueOf(5_000));
+        assertThat(value.get(String.class)).isEqualTo("5000");
     }
 
     @Test

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerFactoryTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerFactoryTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class DefaultDynamoDBDatabaseManagerFactoryTest {
@@ -41,7 +41,7 @@ class DefaultDynamoDBDatabaseManagerFactoryTest {
     }
     @AfterEach
     void tearDown() {
-        assertDoesNotThrow(databaseManagerFactory::close, "DocumentManagerFactory.close() should be not throw exceptions");
+        assertThatCode(databaseManagerFactory::close).as("DocumentManagerFactory.close() should be not throw exceptions").doesNotThrowAnyException();
     }
     @Test
     void shouldCreateDocumentManager() {

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDocumentConfigurationTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDocumentConfigurationTest.java
@@ -16,13 +16,13 @@ package org.eclipse.jnosql.databases.dynamodb.communication;
 
 
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class DynamoDBDocumentConfigurationTest {
@@ -30,15 +30,15 @@ class DynamoDBDocumentConfigurationTest {
     @Test
     void shouldReturnFromServiceLoaderConfiguration() {
         var configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertInstanceOf(DatabaseConfiguration.class, configuration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration).isInstanceOf(DatabaseConfiguration.class);
     }
 
     @Test
     void shouldReturnFromServiceLoaderConfigurationQuery() {
         var configuration = DatabaseConfiguration
                 .getConfiguration(DynamoDBDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
+        assertThat(configuration).isNotNull();
     }
 
     @Test

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueConfigurationTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueConfigurationTest.java
@@ -15,13 +15,13 @@
 package org.eclipse.jnosql.databases.dynamodb.communication;
 
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class DynamoDBKeyValueConfigurationTest {
@@ -37,15 +37,15 @@ public class DynamoDBKeyValueConfigurationTest {
 	@Test
 	public void shouldReturnFromConfiguration() {
 		DynamoDBKeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
-		Assertions.assertNotNull(configuration);
-		Assertions.assertTrue(configuration instanceof DynamoDBKeyValueConfiguration);
+		assertThat(configuration).isNotNull();
+		assertThat(configuration instanceof DynamoDBKeyValueConfiguration).isTrue();
 	}
 
 	@Test
 	public void shouldReturnFromConfigurationQuery() {
 		DynamoDBKeyValueConfiguration configuration = KeyValueConfiguration
 				.getConfiguration(DynamoDBKeyValueConfiguration.class);
-		Assertions.assertNotNull(configuration);
-		Assertions.assertTrue(configuration instanceof DynamoDBKeyValueConfiguration);
+		assertThat(configuration).isNotNull();
+		assertThat(configuration instanceof DynamoDBKeyValueConfiguration).isTrue();
 	}
 }

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueEntityManagerTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueEntityManagerTest.java
@@ -32,10 +32,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class DynamoDBKeyValueEntityManagerTest {
@@ -63,16 +59,16 @@ class DynamoDBKeyValueEntityManagerTest {
     void shouldPutValue() {
         keyValueEntityManager.put("otavio", userOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     void shouldPutKeyValue() {
         keyValueEntityManager.put(keyValueOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
@@ -80,12 +76,12 @@ class DynamoDBKeyValueEntityManagerTest {
 
         keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
     @Test
@@ -93,15 +89,15 @@ class DynamoDBKeyValueEntityManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
     }
 
     @Test
     void shouldRemoveKey() {
         keyValueEntityManager.put(keyValueOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -113,7 +109,7 @@ class DynamoDBKeyValueEntityManagerTest {
                 .collect(Collectors.toList())).contains(userOtavio, userSoro);
         keyValueEntityManager.delete(keys);
         Iterable<Value> users = values;
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 
     @AfterAll

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBExtensionTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBExtensionTest.java
@@ -23,10 +23,11 @@ import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtensi
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class})
@@ -42,6 +43,6 @@ public class DynamoDBExtensionTest {
 
     @Test
     public void shouldSave() {
-        Assertions.assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 }

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfigurationTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfigurationTest.java
@@ -15,8 +15,9 @@
 package org.eclipse.jnosql.databases.elasticsearch.communication;
 
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ElasticsearchDocumentConfigurationTest {
 
@@ -25,16 +26,16 @@ public class ElasticsearchDocumentConfigurationTest {
     @Test
     public void shouldReturnFromConfiguration() {
         ElasticsearchDocumentConfiguration configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof ElasticsearchDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof ElasticsearchDocumentConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         ElasticsearchDocumentConfiguration configuration = DatabaseConfiguration
                 .getConfiguration(ElasticsearchDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof ElasticsearchDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof ElasticsearchDocumentConfiguration).isTrue();
     }
 
 }

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerFactoryTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerFactoryTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class ElasticsearchDocumentManagerFactoryTest {
@@ -28,7 +28,7 @@ public class ElasticsearchDocumentManagerFactoryTest {
     @Test
     public void shouldCreateEntityManager() {
         ElasticsearchDocumentManagerFactory factory = DocumentDatabase.INSTANCE.get();
-        assertNotNull(factory.apply("database"));
+        assertThat(factory.apply("database")).isNotNull();
     }
 
 }

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerTest.java
@@ -48,11 +48,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class ElasticsearchDocumentManagerTest {
@@ -104,15 +100,14 @@ public class ElasticsearchDocumentManagerTest {
     @Test
     public void shouldClose() {
         entityManager.close();
-        assertThrows(RuntimeException.class,
-                () -> entityManager.insert(DocumentEntityGerator.getEntity()));
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> entityManager.insert(DocumentEntityGerator.getEntity()));
     }
 
     @Test
     public void shouldInsert() {
         var entity = DocumentEntityGerator.getEntity();
         var documentEntity = entityManager.insert(entity);
-        assertEquals(entity, documentEntity);
+        assertThat(documentEntity).isEqualTo(entity);
 
         var id = documentEntity.find(EntityConverter.ID_FIELD).get();
         var query = SelectQuery.select()
@@ -126,7 +121,7 @@ public class ElasticsearchDocumentManagerTest {
 
     @Test
     public void shouldInsertTTL() {
-        assertThrows(UnsupportedOperationException.class, () -> entityManager.insert(DocumentEntityGerator.getEntity(), Duration.ofSeconds(1L)));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> entityManager.insert(DocumentEntityGerator.getEntity(), Duration.ofSeconds(1L)));
     }
 
     @Test
@@ -162,7 +157,7 @@ public class ElasticsearchDocumentManagerTest {
         var newField = Elements.of("newField", "10");
         entity.add(newField);
         var updated = entityManager.update(entity);
-        assertEquals(newField, updated.find("newField").get());
+        assertThat(updated.find("newField").get()).isEqualTo(newField);
 
         // it's required in order to avoid an eventual inconsistency
         await().until(numberOfEntitiesFrom(query), equalTo(1L));
@@ -236,7 +231,7 @@ public class ElasticsearchDocumentManagerTest {
         await().until(numberOfEntitiesFrom(query), equalTo(1L));
 
         var entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         var names = entities.stream().map(e -> e.find("name").get())
                 .distinct().collect(Collectors.toList());
         assertThat(names).contains(name);
@@ -388,14 +383,14 @@ public class ElasticsearchDocumentManagerTest {
         await().until(numberOfEntitiesFrom(query), equalTo(1L));
 
         var documentEntity = entityManager.singleResult(query).orElse(null);
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = documentEntity.find("contacts")
                 .orElseThrow()
                 .get(List.class);
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DefaultElasticsearchTemplateTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DefaultElasticsearchTemplateTest.java
@@ -43,8 +43,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 
@@ -102,33 +100,33 @@ public class DefaultElasticsearchTemplateTest {
 
     @Test
     public void shouldGetConverter() {
-        assertNotNull(template.converter());
-        assertEquals(converter, template.converter());
+        assertThat(template.converter()).isNotNull();
+        assertThat(template.converter()).isEqualTo(converter);
     }
 
     @Test
     public void shouldGetManager() {
-        assertNotNull(template.manager());
-        assertEquals(manager, template.manager());
+        assertThat(template.manager()).isNotNull();
+        assertThat(template.manager()).isEqualTo(manager);
     }
 
 
     @Test
     public void shouldGetPersistManager() {
-        assertNotNull(template.eventManager());
-        assertEquals(persistManager, template.eventManager());
+        assertThat(template.eventManager()).isNotNull();
+        assertThat(template.eventManager()).isEqualTo(persistManager);
     }
 
 
     @Test
     public void shouldGetClassMappings() {
-        assertNotNull(template.entities());
-        assertEquals(entities, template.entities());
+        assertThat(template.entities()).isNotNull();
+        assertThat(template.entities()).isEqualTo(entities);
     }
 
     @Test
     public void shouldGetConverters() {
-        assertNotNull(template.converters());
-        assertEquals(converters, template.converters());
+        assertThat(template.converters()).isNotNull();
+        assertThat(template.converters()).isEqualTo(converters);
     }
 }

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManagerFactoryTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManagerFactoryTest.java
@@ -23,8 +23,9 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class DefaultHazelcastBucketManagerFactoryTest {
 
@@ -40,92 +41,92 @@ public class DefaultHazelcastBucketManagerFactoryTest {
     @Test
     public void shouldReturnList() {
         List<String> list = managerFactory.getList("list_sample", String.class);
-        assertNotNull(list);
+        assertThat(list).isNotNull();
     }
 
     @Test
     public void shouldReturnSet() {
         Set<String> set = managerFactory.getSet("set_sample", String.class);
-        assertNotNull(set);
+        assertThat(set).isNotNull();
     }
 
     @Test
     public void shouldReturnQueue() {
         Queue<String> queue = managerFactory.getQueue("queue_sample", String.class);
-        assertNotNull(queue);
+        assertThat(queue).isNotNull();
     }
 
     @Test
     public void shouldReturnMap() {
         Map<String, String> map = managerFactory.getMap("map_sample", String.class, String.class);
-        assertNotNull(map);
+        assertThat(map).isNotNull();
     }
 
 
     @Test
     public void shouldReturnErrorWhenNullParameterList() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getList(null, String.class));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getList(null, String.class));
     }
 
     @Test
     public void shouldReturnErrorWhenNullParameterSet() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getSet(null, String.class));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getSet(null, String.class));
     }
 
     @Test
     public void shouldReturnErrorWhenNullParameterQueue() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getQueue(null, String.class));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getQueue(null, String.class));
     }
 
     @Test
     public void shouldReturnErrorWhenNullParameterMap() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getMap(null, String.class, String.class));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getMap(null, String.class, String.class));
     }
 
     //
     @Test
     public void shouldReturnListHazelcast() {
         List<String> list = managerFactory.getList("list_sample");
-        assertNotNull(list);
+        assertThat(list).isNotNull();
     }
 
     @Test
     public void shouldReturnSetHazelcast() {
         Set<String> set = managerFactory.getSet("set_sample");
-        assertNotNull(set);
+        assertThat(set).isNotNull();
     }
 
     @Test
     public void shouldReturnQueueHazelcast() {
         Queue<String> queue = managerFactory.getQueue("queue_sample");
-        assertNotNull(queue);
+        assertThat(queue).isNotNull();
     }
 
     @Test
     public void shouldReturnMapHazelcast() {
         Map<String, String> map = managerFactory.getMap("map_sample");
-        assertNotNull(map);
+        assertThat(map).isNotNull();
     }
 
 
     @Test
     public void shouldReturnErrorWhenNullParameterListHazelcast() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getList(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getList(null));
     }
 
     @Test
     public void shouldReturnErrorWhenNullParameterSetHazelcast() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getSet(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getSet(null));
     }
 
     @Test
     public void shouldReturnErrorWhenNullParameterQueueHazelcast() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getQueue(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getQueue(null));
     }
 
     @Test
     public void shouldReturnErrorWhenNullParameterMapHazelcast() {
-        assertThrows(NullPointerException.class, () -> managerFactory.getMap(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> managerFactory.getMap(null));
     }
 
 }

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerQueryTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerQueryTest.java
@@ -30,8 +30,8 @@ import static com.hazelcast.query.Predicates.and;
 import static com.hazelcast.query.Predicates.equal;
 import static com.hazelcast.query.Predicates.greaterEqual;
 import static java.util.Collections.singletonMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class HazelcastBucketManagerQueryTest {
 
@@ -54,52 +54,52 @@ public class HazelcastBucketManagerQueryTest {
 
     @Test
     public void shouldReturnWhenPredicateQueryIsNull() {
-        assertThrows(NullPointerException.class, () -> bucketManager.sql((Predicate<?, ? extends Object>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> bucketManager.sql((Predicate<?, ? extends Object>) null));
     }
 
     @Test
     public void shouldReturnActive() {
         Collection<Value> result = bucketManager.sql("active");
-        assertEquals(2, result.size());
+        assertThat(result.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldReturnActiveAndGreaterThan2000() {
         Collection<Value> result = bucketManager.sql("NOT active AND year > 1990");
-        assertEquals(2, result.size());
+        assertThat(result.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldReturnEqualsMatrix() {
         Collection<Value> result = bucketManager.sql("name = Matrix");
-        assertEquals(1, result.size());
+        assertThat(result.size()).isEqualTo(1);
     }
 
 
     @Test
     public void shouldReturnActivePredicate() {
         Collection<Value> result = bucketManager.sql(equal("active", true));
-        assertEquals(2, result.size());
+        assertThat(result.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldReturnActiveAndGreaterThan2000Predicate() {
         Predicate predicate = and(equal("active", false), greaterEqual("year", 1990));
         Collection<Value> result = bucketManager.sql(predicate);
-        assertEquals(2, result.size());
+        assertThat(result.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldReturnEqualsMatrixPredicate() {
         Predicate predicate = equal("name", "Matrix");
         Collection<Value> result = bucketManager.sql(predicate);
-        assertEquals(1, result.size());
+        assertThat(result.size()).isEqualTo(1);
     }
 
     @Test
     public void shouldReturnEqualsNameParam() {
         Collection<Value> result = bucketManager.sql("name = :name", singletonMap("name", "Matrix"));
-        assertEquals(1, result.size());
+        assertThat(result.size()).isEqualTo(1);
     }
 
     @Test
@@ -109,13 +109,13 @@ public class HazelcastBucketManagerQueryTest {
         params.put("year", 1900);
         Collection<Value> result = bucketManager.sql("name = :name AND year > :year", params);
 
-        assertEquals(1, result.size());
+        assertThat(result.size()).isEqualTo(1);
     }
 
     @Test
     public void shouldReturnLikeNameParam() {
         Collection<Value> result = bucketManager.sql("name like :name", singletonMap("name", "Mat%"));
-        assertEquals(1, result.size());
+        assertThat(result.size()).isEqualTo(1);
     }
 
 }

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerTest.java
@@ -32,10 +32,6 @@ import java.util.stream.StreamSupport;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HazelcastBucketManagerTest {
 
@@ -59,16 +55,16 @@ public class HazelcastBucketManagerTest {
     public void shouldPutValue() {
         keyValueEntityManager.put("otavio", userOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     public void shouldPutKeyValue() {
         keyValueEntityManager.put(keyValueOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
@@ -77,12 +73,12 @@ public class HazelcastBucketManagerTest {
 
         keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
     @Test
@@ -90,7 +86,7 @@ public class HazelcastBucketManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
 
 
     }
@@ -99,9 +95,9 @@ public class HazelcastBucketManagerTest {
     public void shouldRemoveKey() {
 
         keyValueEntityManager.put(keyValueOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -116,7 +112,7 @@ public class HazelcastBucketManagerTest {
                 .contains(userOtavio, userSoro);
         keyValueEntityManager.delete(keys);
         Iterable<Value> users = values;
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 
 

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueConfigurationTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueConfigurationTest.java
@@ -18,14 +18,14 @@ package org.eclipse.jnosql.databases.hazelcast.communication;
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class KeyValueConfigurationTest {
 
@@ -40,27 +40,27 @@ public class KeyValueConfigurationTest {
     public void shouldCreateKeyValueFactory() {
         Map<String, String> map = new HashMap<>();
         BucketManagerFactory managerFactory = configuration.get(map);
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldCreateKeyValueFactoryFromFile() {
         BucketManagerFactory managerFactory = configuration.apply(Settings.builder().build());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldReturnFromConfiguration() {
         KeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof KeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof KeyValueConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         HazelcastKeyValueConfiguration configuration = KeyValueConfiguration
                 .getConfiguration(HazelcastKeyValueConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof HazelcastKeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof HazelcastKeyValueConfiguration).isTrue();
     }
 }

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueEntityManagerFactoryTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueEntityManagerFactoryTest.java
@@ -27,7 +27,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class KeyValueEntityManagerFactoryTest {
 
@@ -43,31 +44,31 @@ public class KeyValueEntityManagerFactoryTest {
     @Test
     public void shouldCreateKeyValueEntityManager(){
         BucketManager keyValueEntityManager = managerFactory.apply(BUCKET_NAME);
-        assertNotNull(keyValueEntityManager);
+        assertThat(keyValueEntityManager).isNotNull();
     }
 
     @Test
     public void shouldCreateMap(){
         Map<String, String> map = managerFactory.getMap(BUCKET_NAME, String.class, String.class);
-        assertNotNull(map);
+        assertThat(map).isNotNull();
     }
 
     @Test
     public void shouldCreateSet(){
         Set<String> set = managerFactory.getSet(BUCKET_NAME, String.class);
-        assertNotNull(set);
+        assertThat(set).isNotNull();
     }
 
     @Test
     public void shouldCreateList(){
         List<String> list = managerFactory.getList(BUCKET_NAME, String.class);
-        assertNotNull(list);
+        assertThat(list).isNotNull();
     }
 
     @Test
     public void shouldCreateQueue(){
         Queue<String> queue = managerFactory.getQueue(BUCKET_NAME, String.class);
-        assertNotNull(queue);
+        assertThat(queue).isNotNull();
     }
 
 }

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/ListTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/ListTest.java
@@ -26,10 +26,8 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ListTest {
 
@@ -52,17 +50,17 @@ public class ListTest {
 
     @Test
     public void shouldReturnsList() {
-        assertNotNull(fruits);
+        assertThat(fruits).isNotNull();
     }
 
     @Test
     public void shouldAddList() {
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
         fruits.add(banana);
-        assertFalse(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isFalse();
         ProductCart banana = fruits.getFirst();
-        assertNotNull(banana);
-        assertEquals(banana.name(), "banana");
+        assertThat(banana).isNotNull();
+        assertThat("banana").isEqualTo(banana.name());
     }
 
     @Test
@@ -70,14 +68,14 @@ public class ListTest {
 
         fruits.add(banana);
         fruits.addFirst(orange);
-        assertEquals(2, fruits.size());
+        assertThat(fruits.size()).isEqualTo(2);
 
-        assertEquals(fruits.get(0).name(), "orange");
-        assertEquals(fruits.get(1).name(), "banana");
+        assertThat("orange").isEqualTo(fruits.get(0).name());
+        assertThat("banana").isEqualTo(fruits.get(1).name());
 
         fruits.set(0, waterMelon);
-        assertEquals(fruits.get(0).name(), "waterMelon");
-        assertEquals(fruits.get(1).name(), "banana");
+        assertThat("waterMelon").isEqualTo(fruits.get(0).name());
+        assertThat("banana").isEqualTo(fruits.get(1).name());
 
     }
 
@@ -93,12 +91,12 @@ public class ListTest {
         fruits.add(banana);
         fruits.add(new ProductCart("watermellon", BigDecimal.ONE));
         fruits.add(banana);
-        assertEquals(1, fruits.indexOf(banana));
-        assertEquals(3, fruits.lastIndexOf(banana));
+        assertThat(fruits.indexOf(banana)).isEqualTo(1);
+        assertThat(fruits.lastIndexOf(banana)).isEqualTo(3);
 
-        assertTrue(fruits.contains(banana));
-        assertEquals(-1, fruits.indexOf(melon));
-        assertEquals(-1, fruits.lastIndexOf(melon));
+        assertThat(fruits.contains(banana)).isTrue();
+        assertThat(fruits.indexOf(melon)).isEqualTo(-1);
+        assertThat(fruits.lastIndexOf(melon)).isEqualTo(-1);
     }
 
     @Test
@@ -107,10 +105,10 @@ public class ListTest {
         fruits.add(orange);
         fruits.add(banana);
         fruits.add(waterMelon);
-        assertTrue(fruits.contains(banana));
-        assertFalse(fruits.contains(melon));
-        assertTrue(fruits.containsAll(Arrays.asList(banana, orange)));
-        assertFalse(fruits.containsAll(Arrays.asList(banana, melon)));
+        assertThat(fruits.contains(banana)).isTrue();
+        assertThat(fruits.contains(melon)).isFalse();
+        assertThat(fruits.containsAll(Arrays.asList(banana, orange))).isTrue();
+        assertThat(fruits.containsAll(Arrays.asList(banana, melon))).isFalse();
 
     }
 
@@ -123,14 +121,14 @@ public class ListTest {
         for (ProductCart fruiCart: fruits) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         fruits.removeFirst();
         fruits.removeFirst();
         count = 0;
         for (ProductCart fruiCart: fruits) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
     @AfterEach
     public  void end() {

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
@@ -27,11 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class MapTest {
 
@@ -49,13 +46,13 @@ public class MapTest {
     @Test
     public void shouldPutAndGetMap() {
         Map<String, Species> vertebrates = entityManagerFactory.getMap("vertebrates", String.class, Species.class);
-        assertTrue(vertebrates.isEmpty());
+        assertThat(vertebrates.isEmpty()).isTrue();
 
         vertebrates.put("mammals", mammals);
         Species species = vertebrates.get("mammals");
-        assertNotNull(species);
-        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
-        assertEquals(1, vertebrates.size());
+        assertThat(species).isNotNull();
+        assertThat(mammals.getAnimals().getFirst()).isEqualTo(species.getAnimals().getFirst());
+        assertThat(vertebrates.size()).isEqualTo(1);
     }
 
     @Test
@@ -63,11 +60,11 @@ public class MapTest {
 
         Map<String, Species> vertebrates = entityManagerFactory.getMap("vertebrates", String.class, Species.class);
         vertebrates.put("mammals", mammals);
-        assertTrue(vertebrates.containsKey("mammals"));
-        assertFalse(vertebrates.containsKey("redfish"));
+        assertThat(vertebrates.containsKey("mammals")).isTrue();
+        assertThat(vertebrates.containsKey("redfish")).isFalse();
 
-        assertTrue(vertebrates.containsValue(mammals));
-        assertFalse(vertebrates.containsValue(fishes));
+        assertThat(vertebrates.containsValue(mammals)).isTrue();
+        assertThat(vertebrates.containsValue(fishes)).isFalse();
     }
 
     @Test
@@ -82,12 +79,12 @@ public class MapTest {
         Set<String> keys = vertebrates.keySet();
         Collection<Species> collectionSpecies = vertebrates.values();
 
-        assertEquals(3, keys.size());
-        assertEquals(3, collectionSpecies.size());
-        assertNotNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.get("mammals"));
-        assertEquals(2, vertebrates.size());
+        assertThat(keys.size()).isEqualTo(3);
+        assertThat(collectionSpecies.size()).isEqualTo(3);
+        assertThat(vertebrates.remove("mammals")).isNotNull();
+        assertThat(vertebrates.remove("mammals")).isNull();
+        assertThat(vertebrates.get("mammals")).isNull();
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @AfterEach

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/QueueTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/QueueTest.java
@@ -26,10 +26,8 @@ import org.junit.jupiter.api.Test;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class QueueTest {
 
@@ -46,36 +44,36 @@ public class QueueTest {
 
     @Test
     public void shouldPushInTheLine() {
-        assertTrue(lineBank.add(new LineBank("Otavio", 25)));
-        assertEquals(1, lineBank.size());
+        assertThat(lineBank.add(new LineBank("Otavio", 25))).isTrue();
+        assertThat(lineBank.size()).isEqualTo(1);
         LineBank otavio = lineBank.poll();
-        assertEquals(otavio.getPerson().name(), "Otavio");
-        assertNull(lineBank.poll());
-        assertTrue(lineBank.isEmpty());
+        assertThat("Otavio").isEqualTo(otavio.getPerson().name());
+        assertThat(lineBank.poll()).isNull();
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldPeekInTheLine() {
         lineBank.add(new LineBank("Otavio", 25));
         LineBank otavio = lineBank.peek();
-        assertNotNull(otavio);
-        assertNotNull(lineBank.peek());
+        assertThat(otavio).isNotNull();
+        assertThat(lineBank.peek()).isNotNull();
         LineBank otavio2 = lineBank.remove();
-        assertEquals(otavio.getPerson().name(), otavio2.getPerson().name());
+        assertThat(otavio2.getPerson().name()).isEqualTo(otavio.getPerson().name());
         boolean happendException = false;
         try {
             lineBank.remove();
         }catch(NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @Test
     public void shouldElementInTheLine() {
         lineBank.add(new LineBank("Otavio", 25));
-        assertNotNull(lineBank.element());
-        assertNotNull(lineBank.element());
+        assertThat(lineBank.element()).isNotNull();
+        assertThat(lineBank.element()).isNotNull();
         lineBank.remove(new LineBank("Otavio", 25));
         boolean happendException = false;
         try {
@@ -83,7 +81,7 @@ public class QueueTest {
         }catch(NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
     @SuppressWarnings("unused")
     @Test
@@ -94,14 +92,14 @@ public class QueueTest {
         for (LineBank line: lineBank) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         lineBank.remove();
         lineBank.remove();
         count = 0;
         for (LineBank line: lineBank) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
     @AfterEach
     public void dispose() {

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/SetTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/SetTest.java
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class SetTest {
 
@@ -44,12 +44,12 @@ public class SetTest {
 
     @Test
     public void shouldAddUsers() {
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
         users.add(userOtavioJava);
-        assertEquals(1, users.size());
+        assertThat(users.size()).isEqualTo(1);
 
         users.remove(userOtavioJava);
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
     }
 
 
@@ -66,14 +66,14 @@ public class SetTest {
         for (User user: users) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         users.remove(userOtavioJava);
         users.remove(felipe);
         count = 0;
         for (User user: users) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @AfterEach

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/DefaultHazelcastTemplateTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/DefaultHazelcastTemplateTest.java
@@ -29,8 +29,7 @@ import java.util.Collection;
 
 import static com.hazelcast.query.Predicates.equal;
 import static java.util.Collections.singletonMap;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, AbstractKeyValueTemplate.class, HazelcastTemplate.class})
@@ -46,22 +45,22 @@ public class DefaultHazelcastTemplateTest {
     @Test
     public void shouldRunQuery() {
         Collection<Human> people = template.sql("active");
-        assertNotNull(people);
-        assertTrue(people.stream().allMatch(Human.class::isInstance));
+        assertThat(people).isNotNull();
+        assertThat(people.stream().allMatch(Human.class::isInstance)).isTrue();
     }
 
     @Test
     public void shouldRunQuery2() {
         Collection<Human> people = template.sql("age = :age", singletonMap("age", 10));
-        assertNotNull(people);
-        assertTrue(people.stream().allMatch(Human.class::isInstance));
+        assertThat(people).isNotNull();
+        assertThat(people.stream().allMatch(Human.class::isInstance)).isTrue();
     }
 
     @Test
     public void shouldRunQuery3() {
         Collection<Human> people = template.sql(equal("name",  "Poliana"));
-        assertNotNull(people);
-        assertTrue(people.stream().allMatch(Human.class::isInstance));
+        assertThat(people).isNotNull();
+        assertThat(people.stream().allMatch(Human.class::isInstance)).isTrue();
     }
 
 }

--- a/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnConfigurationTest.java
+++ b/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnConfigurationTest.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class HBaseColumnConfigurationTest {
@@ -31,17 +31,17 @@ public class HBaseColumnConfigurationTest {
     @Test
     public void shouldCreatesColumnManagerFactory() {
         var configuration = new HBaseColumnConfiguration();
-        assertNotNull(configuration.apply(Settings.builder().build()));
+        assertThat(configuration.apply(Settings.builder().build())).isNotNull();
     }
 
     @Test
     public void shouldCreatesColumnManagerFactoryFromConfiguration() {
         var configuration = new HBaseColumnConfiguration();
-        assertNotNull(configuration.apply(Settings.builder().build()));
+        assertThat(configuration.apply(Settings.builder().build())).isNotNull();
     }
 
     @Test
     public void shouldReturnErrorCreatesColumnManagerFactory() {
-        assertThrows(NullPointerException.class, () -> new HBaseColumnConfiguration(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> new HBaseColumnConfiguration(null));
     }
 }

--- a/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManagerFactoryTest.java
+++ b/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManagerFactoryTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -32,7 +32,7 @@ public class HBaseColumnManagerFactoryTest {
     @Test
     public void shouldCreateColumnManager() {
         var managerFactory = configuration.apply(Settings.builder().build());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
 }

--- a/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseFamilyManagerTest.java
+++ b/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseFamilyManagerTest.java
@@ -33,11 +33,7 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class HBaseFamilyManagerTest {
@@ -71,7 +67,7 @@ public class HBaseFamilyManagerTest {
         entity.add(Element.of("id", "otaviojava"));
         entity.add(Element.of("age", 26));
         entity.add(Element.of("country", "Brazil"));
-        assertThrows(HBaseException.class, () -> manager.insert(entity));
+        assertThatExceptionOfType(HBaseException.class).isThrownBy(() -> manager.insert(entity));
     }
 
     @Test
@@ -80,10 +76,10 @@ public class HBaseFamilyManagerTest {
 
         var query = select().from(FAMILY).where(ID_FIELD).eq("otaviojava").build();
         List<CommunicationEntity> columnFamilyEntities = manager.select(query).collect(Collectors.toList());
-        assertNotNull(columnFamilyEntities);
-        assertFalse(columnFamilyEntities.isEmpty());
+        assertThat(columnFamilyEntities).isNotNull();
+        assertThat(columnFamilyEntities.isEmpty()).isFalse();
         var entity = columnFamilyEntities.getFirst();
-        assertEquals(FAMILY, entity.name());
+        assertThat(entity.name()).isEqualTo(FAMILY);
         assertThat(entity.elements()).contains(Element.of(ID_FIELD, "otaviojava"),
                 Element.of("age", "26"), Element.of("country", "Brazil"));
     }
@@ -97,7 +93,7 @@ public class HBaseFamilyManagerTest {
                 .or(ID_FIELD).eq("poliana").build();
 
         List<CommunicationEntity> entities = manager.select(query).toList();
-        assertEquals(Integer.valueOf(2), Integer.valueOf(entities.size()));
+        assertThat(Integer.valueOf(entities.size())).isEqualTo(Integer.valueOf(2));
 
     }
 
@@ -108,7 +104,7 @@ public class HBaseFamilyManagerTest {
         var deleteQuery = delete().from(FAMILY).where(ID_FIELD).eq("otaviojava").build();
         manager.delete(deleteQuery);
         List<CommunicationEntity> entities = manager.select(query).toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -124,7 +120,7 @@ public class HBaseFamilyManagerTest {
 
         manager.delete(deleteQuery);
         List<CommunicationEntity> entities = manager.select(query).toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     private CommunicationEntity createEntity() {

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueConfigurationTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueConfigurationTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class KeyValueConfigurationTest {
 
@@ -36,7 +37,7 @@ public class KeyValueConfigurationTest {
     public void shouldCreateKeyValueFactory() {
         Map<String, String> map = new HashMap<>();
         BucketManagerFactory managerFactory = configuration.get(map);
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
 }

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerFactoryTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerFactoryTest.java
@@ -23,8 +23,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 
 public class KeyValueEntityManagerFactoryTest {
@@ -44,28 +45,28 @@ public class KeyValueEntityManagerFactoryTest {
     @Test
     public void shouldCreateKeyValueEntityManager(){
         BucketManager keyValueEntityManager = managerFactory.apply(BUCKET_NAME);
-        assertNotNull(keyValueEntityManager);
+        assertThat(keyValueEntityManager).isNotNull();
     }
 
     @Test
     public void shouldCreateMap(){
         Map<String, String> map = managerFactory.getMap(BUCKET_NAME, String.class, String.class);
-        assertNotNull(map);
+        assertThat(map).isNotNull();
     }
 
     @Test
     public void shouldCreateSet(){
-        assertThrows(UnsupportedOperationException.class, () -> managerFactory.getSet(BUCKET_NAME, String.class));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> managerFactory.getSet(BUCKET_NAME, String.class));
     }
 
     @Test
     public void shouldCreateList(){
-        assertThrows(UnsupportedOperationException.class, () -> managerFactory.getList(BUCKET_NAME, String.class));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> managerFactory.getList(BUCKET_NAME, String.class));
     }
 
     @Test
     public void shouldCreateQueue(){
-        assertThrows(UnsupportedOperationException.class, () -> managerFactory.getQueue(BUCKET_NAME, String.class));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> managerFactory.getQueue(BUCKET_NAME, String.class));
     }
 
 }

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerTest.java
@@ -31,10 +31,6 @@ import java.util.stream.StreamSupport;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KeyValueEntityManagerTest {
 
@@ -59,16 +55,16 @@ public class KeyValueEntityManagerTest {
     public void shouldPutValue() {
         keyValueEntityManager.put("otavio", userOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     public void shouldPutKeyValue() {
         keyValueEntityManager.put(keyValueOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
@@ -77,12 +73,12 @@ public class KeyValueEntityManagerTest {
 
         keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
     @Test
@@ -90,7 +86,7 @@ public class KeyValueEntityManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
 
 
     }
@@ -99,9 +95,9 @@ public class KeyValueEntityManagerTest {
     public void shouldRemoveKey() {
 
         keyValueEntityManager.put(keyValueOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -117,6 +113,6 @@ public class KeyValueEntityManagerTest {
                 .contains(userOtavio, userSoro);
         keyValueEntityManager.delete(keys);
         Iterable<Value> users = values;
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 }

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/MapTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/MapTest.java
@@ -27,11 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class MapTest {
 
@@ -49,13 +46,13 @@ public class MapTest {
     @Test
     public void shouldPutAndGetMap() {
         Map<String, Species> vertebrates = entityManagerFactory.getMap("vertebrates", String.class, Species.class);
-        assertTrue(vertebrates.isEmpty());
+        assertThat(vertebrates.isEmpty()).isTrue();
 
         vertebrates.put("mammals", mammals);
         Species species = vertebrates.get("mammals");
-        assertNotNull(species);
-        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
-        assertEquals(1, vertebrates.size());
+        assertThat(species).isNotNull();
+        assertThat(mammals.getAnimals().getFirst()).isEqualTo(species.getAnimals().getFirst());
+        assertThat(vertebrates.size()).isEqualTo(1);
     }
 
     @Test
@@ -63,11 +60,11 @@ public class MapTest {
 
         Map<String, Species> vertebrates = entityManagerFactory.getMap("vertebrates", String.class, Species.class);
         vertebrates.put("mammals", mammals);
-        assertTrue(vertebrates.containsKey("mammals"));
-        assertFalse(vertebrates.containsKey("redfish"));
+        assertThat(vertebrates.containsKey("mammals")).isTrue();
+        assertThat(vertebrates.containsKey("redfish")).isFalse();
 
-        assertTrue(vertebrates.containsValue(mammals));
-        assertFalse(vertebrates.containsValue(fishes));
+        assertThat(vertebrates.containsValue(mammals)).isTrue();
+        assertThat(vertebrates.containsValue(fishes)).isFalse();
     }
 
     @Test
@@ -82,12 +79,12 @@ public class MapTest {
         Set<String> keys = vertebrates.keySet();
         Collection<Species> collectionSpecies = vertebrates.values();
 
-        assertEquals(3, keys.size());
-        assertEquals(3, collectionSpecies.size());
-        assertNotNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.get("mammals"));
-        assertEquals(2, vertebrates.size());
+        assertThat(keys.size()).isEqualTo(3);
+        assertThat(collectionSpecies.size()).isEqualTo(3);
+        assertThat(vertebrates.remove("mammals")).isNotNull();
+        assertThat(vertebrates.remove("mammals")).isNull();
+        assertThat(vertebrates.get("mammals")).isNull();
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @AfterEach

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/KeyValueConfigurationTest.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/KeyValueConfigurationTest.java
@@ -17,14 +17,14 @@ package org.eclipse.jnosql.databases.memcached.communication;
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class KeyValueConfigurationTest {
 
@@ -40,22 +40,22 @@ public class KeyValueConfigurationTest {
         Map<String, Object> map = new HashMap<>();
         map.put(MemcachedConfigurations.HOST.get()+".1","localhost:11211");
         BucketManagerFactory managerFactory = configuration.apply(Settings.of(map));
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldReturnFromConfiguration() {
         KeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof KeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof KeyValueConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         MemcachedKeyValueConfiguration configuration = KeyValueConfiguration
                 .getConfiguration(MemcachedKeyValueConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof MemcachedKeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof MemcachedKeyValueConfiguration).isTrue();
     }
 
 }

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerFactoryTest.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerFactoryTest.java
@@ -18,7 +18,8 @@ import org.eclipse.jnosql.communication.Settings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class MemcachedBucketManagerFactoryTest {
 
@@ -35,22 +36,22 @@ public class MemcachedBucketManagerFactoryTest {
 
     @Test
     public void shouldReturnErrorList() {
-        assertThrows(UnsupportedOperationException.class, () -> managerFactory.getList(null, String.class));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> managerFactory.getList(null, String.class));
     }
 
     @Test
     public void shouldReturnErrorSet() {
-        assertThrows(UnsupportedOperationException.class, () -> managerFactory.getSet(null, String.class));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> managerFactory.getSet(null, String.class));
     }
 
     @Test
     public void shouldReturnErrorQueue() {
-        assertThrows(UnsupportedOperationException.class, () -> managerFactory.getQueue(null, String.class));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> managerFactory.getQueue(null, String.class));
     }
 
     @Test
     public void shouldReturnErrorMap() {
-        assertThrows(UnsupportedOperationException.class, () -> managerFactory.getMap(null, String.class, String.class));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> managerFactory.getMap(null, String.class, String.class));
     }
 
 }

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerTest.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerTest.java
@@ -35,10 +35,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class MemcachedBucketManagerTest {
@@ -64,26 +60,26 @@ public class MemcachedBucketManagerTest {
     public void shouldPutValue() {
         keyValueEntityManager.put("otavio", otavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(this.otavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(this.otavio);
     }
 
     @Test
     public void shouldPutKeyValue() {
         keyValueEntityManager.put(entityOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(this.otavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(this.otavio);
     }
 
     @Test
     public void shouldPutValueDuration() throws InterruptedException {
         keyValueEntityManager.put(entityOtavio, Duration.ofSeconds(1L));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
+        assertThat(otavio.isPresent()).isTrue();
         TimeUnit.SECONDS.sleep(3L);
         otavio = keyValueEntityManager.get("otavio");
-        assertFalse(otavio.isPresent());
+        assertThat(otavio.isPresent()).isFalse();
     }
 
 
@@ -92,12 +88,12 @@ public class MemcachedBucketManagerTest {
 
         keyValueEntityManager.put(asList(entitySoro, entityOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(this.otavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(this.otavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(this.soro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(this.soro);
     }
 
     @Test
@@ -105,7 +101,7 @@ public class MemcachedBucketManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
 
 
     }
@@ -114,9 +110,9 @@ public class MemcachedBucketManagerTest {
     public void shouldRemoveKey() {
 
         keyValueEntityManager.put(entityOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -130,7 +126,7 @@ public class MemcachedBucketManagerTest {
                 .contains(otavio, soro);
         keyValueEntityManager.delete(keys);
         Iterable<Value> users = values;
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 
 

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/BinaryValueReaderTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/BinaryValueReaderTest.java
@@ -21,9 +21,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 class BinaryValueReaderTest {
 
@@ -36,14 +35,14 @@ class BinaryValueReaderTest {
 
     @Test
     void shouldValidateCompatibility() {
-        assertTrue(valueReader.test(Binary.class));
-        assertFalse(valueReader.test(AtomicBoolean.class));
+        assertThat(valueReader.test(Binary.class)).isTrue();
+        assertThat(valueReader.test(AtomicBoolean.class)).isFalse();
     }
 
     @Test
     void shouldConvert() {
         byte[] bytes = new byte[] {10, 10, 10};
-        assertEquals(new Binary(bytes), valueReader.read(Binary.class, bytes));
-        assertEquals(new Binary("hello".getBytes()), valueReader.read(Binary.class, "hello"));
+        assertThat(valueReader.read(Binary.class, bytes)).isEqualTo(new Binary(bytes));
+        assertThat(valueReader.read(Binary.class, "hello")).isEqualTo(new Binary("hello".getBytes()));
     }
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoAuthenticationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoAuthenticationTest.java
@@ -27,10 +27,8 @@ import static org.eclipse.jnosql.databases.mongodb.communication.MongoDBDocument
 import static org.eclipse.jnosql.databases.mongodb.communication.MongoDBDocumentConfigurations.AUTHENTICATION_SOURCE;
 import static org.eclipse.jnosql.databases.mongodb.communication.MongoDBDocumentConfigurations.PASSWORD;
 import static org.eclipse.jnosql.databases.mongodb.communication.MongoDBDocumentConfigurations.USER;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class MongoAuthenticationTest {
 
@@ -39,7 +37,7 @@ class MongoAuthenticationTest {
         Settings settings = Settings.builder().put(USER, "value")
                 .build();
 
-        assertThrows(CommunicationException.class, () -> MongoAuthentication.of(settings));
+        assertThatExceptionOfType(CommunicationException.class).isThrownBy(() -> MongoAuthentication.of(settings));
 
     }
     @Test
@@ -51,10 +49,10 @@ class MongoAuthenticationTest {
                 .build();
 
         MongoCredential credential = MongoAuthentication.of(settings).get();
-        assertEquals("database", credential.getSource());
-        assertArrayEquals("password".toCharArray(), credential.getPassword());
-        assertEquals("user", credential.getUserName());
-        assertNull(credential.getMechanism());
+        assertThat(credential.getSource()).isEqualTo("database");
+        assertThat(credential.getPassword()).isEqualTo("password".toCharArray());
+        assertThat(credential.getUserName()).isEqualTo("user");
+        assertThat(credential.getMechanism()).isNull();
 
     }
 
@@ -68,9 +66,9 @@ class MongoAuthenticationTest {
                 .build();
 
         MongoCredential credential = MongoAuthentication.of(settings).get();
-        assertEquals("$external", credential.getSource());
-        assertEquals("user", credential.getUserName());
-        assertEquals(GSSAPI.getMechanismName(), credential.getMechanism());
+        assertThat(credential.getSource()).isEqualTo("$external");
+        assertThat(credential.getUserName()).isEqualTo("user");
+        assertThat(credential.getMechanism()).isEqualTo(GSSAPI.getMechanismName());
 
     }
 
@@ -84,9 +82,9 @@ class MongoAuthenticationTest {
                 .build();
 
         MongoCredential credential = MongoAuthentication.of(settings).get();
-        assertEquals("$external", credential.getSource());
-        assertEquals("user", credential.getUserName());
-        assertEquals(AuthenticationMechanism.MONGODB_X509.getMechanismName(), credential.getMechanism());
+        assertThat(credential.getSource()).isEqualTo("$external");
+        assertThat(credential.getUserName()).isEqualTo("user");
+        assertThat(credential.getMechanism()).isEqualTo(AuthenticationMechanism.MONGODB_X509.getMechanismName());
     }
 
     @Test
@@ -99,10 +97,10 @@ class MongoAuthenticationTest {
                 .build();
 
         MongoCredential credential = MongoAuthentication.of(settings).get();
-        assertEquals("database", credential.getSource());
-        assertArrayEquals("password".toCharArray(), credential.getPassword());
-        assertEquals("user", credential.getUserName());
-        assertEquals(SCRAM_SHA_1.getMechanismName(), credential.getMechanism());
+        assertThat(credential.getSource()).isEqualTo("database");
+        assertThat(credential.getPassword()).isEqualTo("password".toCharArray());
+        assertThat(credential.getUserName()).isEqualTo("user");
+        assertThat(credential.getMechanism()).isEqualTo(SCRAM_SHA_1.getMechanismName());
     }
 
     @Test
@@ -115,10 +113,10 @@ class MongoAuthenticationTest {
                 .build();
 
         MongoCredential credential = MongoAuthentication.of(settings).get();
-        assertEquals("database", credential.getSource());
-        assertArrayEquals("password".toCharArray(), credential.getPassword());
-        assertEquals("user", credential.getUserName());
-        assertEquals(SCRAM_SHA_256.getMechanismName(), credential.getMechanism());
+        assertThat(credential.getSource()).isEqualTo("database");
+        assertThat(credential.getPassword()).isEqualTo("password".toCharArray());
+        assertThat(credential.getUserName()).isEqualTo("user");
+        assertThat(credential.getMechanism()).isEqualTo(SCRAM_SHA_256.getMechanismName());
     }
 
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfigurationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfigurationTest.java
@@ -16,14 +16,14 @@
 package org.eclipse.jnosql.databases.mongodb.communication;
 
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 class MongoDBDocumentConfigurationTest {
 
@@ -33,35 +33,35 @@ class MongoDBDocumentConfigurationTest {
         map.put("mongodb-server-host-1", "172.17.0.2:27017");
         MongoDBDocumentConfiguration configuration = new MongoDBDocumentConfiguration();
         var managerFactory = configuration.get(map);
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
 
     @Test
     void shouldReturnErrorWhenSettingsIsNull() {
         var configuration = new MongoDBDocumentConfiguration();
-        assertThrows(NullPointerException.class, () -> configuration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.apply(null));
     }
 
     @Test
     void shouldReturnErrorWhenMapSettingsIsNull() {
         MongoDBDocumentConfiguration configuration = new MongoDBDocumentConfiguration();
-        assertThrows(NullPointerException.class, () -> configuration.get((Map) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.get((Map) null));
     }
 
     @Test
     void shouldReturnFromConfiguration() {
         var configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof DatabaseConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof DatabaseConfiguration).isTrue();
     }
 
     @Test
     void shouldReturnFromConfigurationQuery() {
         MongoDBDocumentConfiguration configuration = DatabaseConfiguration
                 .getConfiguration(MongoDBDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof MongoDBDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof MongoDBDocumentConfiguration).isTrue();
     }
 
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerFactoryTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerFactoryTest.java
@@ -22,8 +22,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 class MongoDBDocumentManagerFactoryTest {
 
@@ -37,22 +38,22 @@ class MongoDBDocumentManagerFactoryTest {
     @Test
     void shouldCreateEntityManager() {
         MongoDBDocumentManagerFactory mongoDBFactory = configuration.apply(Settings.builder().build());
-        assertNotNull(mongoDBFactory.apply("database"));
+        assertThat(mongoDBFactory.apply("database")).isNotNull();
     }
 
     @Test
     void shouldReturnNPEWhenSettingsIsNull() {
-        assertThrows(NullPointerException.class, () -> configuration.apply((Settings) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.apply((Settings) null));
     }
 
     @Test
     void shouldReturnNPEWhenMapSettingsIsNull() {
-        assertThrows(NullPointerException.class, () -> configuration.get((Map<String, String>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.get((Map<String, String>) null));
     }
 
     @Test
     void shouldReturnNPEWhenMongoClientIsNull() {
-        assertThrows(NullPointerException.class, () -> configuration.get((MongoClient) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.get((MongoClient) null));
     }
 
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
@@ -27,7 +27,6 @@ import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.communication.semistructured.UpdateQuery;
 import org.eclipse.jnosql.databases.mongodb.communication.type.Money;
 import org.eclipse.jnosql.mapping.semistructured.MappingQuery;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,13 +57,8 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class MongoDBDocumentManagerTest {
@@ -86,7 +80,7 @@ class MongoDBDocumentManagerTest {
     void shouldInsert() {
         var entity = getEntity();
         var documentEntity = entityManager.insert(entity);
-        assertTrue(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id")));
+        assertThat(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id"))).isTrue();
     }
 
     @Test
@@ -102,7 +96,7 @@ class MongoDBDocumentManagerTest {
     void shouldThrowExceptionWhenInsertWithTTL() {
         var entity = getEntity();
         var ttl = Duration.ofSeconds(10);
-        assertThrows(UnsupportedOperationException.class, () -> entityManager.insert(entity, ttl));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> entityManager.insert(entity, ttl));
     }
 
     @Test
@@ -178,7 +172,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         entityManager.delete(deleteQuery);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -191,7 +185,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         var entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -206,7 +200,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -221,7 +215,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -238,7 +232,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
@@ -255,7 +249,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
@@ -273,7 +267,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).contains(entities.getFirst());
     }
 
@@ -290,7 +284,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).contains(entities.get(0), entities.get(2));
     }
 
@@ -307,7 +301,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).contains(entities.get(0), entities.get(2));
     }
 
@@ -323,7 +317,7 @@ class MongoDBDocumentManagerTest {
                 .and("type").eq("V")
                 .build();
 
-        assertEquals(entities, entityManager.select(query).collect(Collectors.toList()));
+        assertThat(entityManager.select(query).collect(Collectors.toList())).isEqualTo(entities);
     }
 
     @Test
@@ -380,7 +374,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
@@ -390,7 +384,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertTrue(entitiesFound.isEmpty());
+        assertThat(entitiesFound.isEmpty()).isTrue();
 
     }
 
@@ -408,7 +402,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
@@ -418,7 +412,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
 
     }
 
@@ -437,7 +431,7 @@ class MongoDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         List<Integer> ages = entitiesFound.stream()
                 .map(e -> e.find("age").get().get(Integer.class))
                 .collect(Collectors.toList());
@@ -454,7 +448,7 @@ class MongoDBDocumentManagerTest {
         ages = entitiesFound.stream()
                 .map(e -> e.find("age").get().get(Integer.class))
                 .collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(ages).contains(25, 23);
 
     }
@@ -464,7 +458,7 @@ class MongoDBDocumentManagerTest {
         entityManager.insert(getEntity());
         SelectQuery query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -472,11 +466,11 @@ class MongoDBDocumentManagerTest {
         entityManager.insert(getEntity());
         SelectQuery query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         DeleteQuery deleteQuery = delete().from(COLLECTION_NAME).build();
         entityManager.delete(deleteQuery);
         entities = entityManager.select(query).toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -484,12 +478,12 @@ class MongoDBDocumentManagerTest {
         entityManager.insert(getEntity());
         SelectQuery query = select("name").from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         final CommunicationEntity entity = entities.getFirst();
-        assertEquals(2, entity.size());
-        assertTrue(entity.find("name").isPresent());
-        assertTrue(entity.find("_id").isPresent());
-        assertFalse(entity.find("city").isPresent());
+        assertThat(entity.size()).isEqualTo(2);
+        assertThat(entity.find("name").isPresent()).isTrue();
+        assertThat(entity.find("_id").isPresent()).isTrue();
+        assertThat(entity.find("city").isPresent()).isFalse();
     }
 
 
@@ -554,11 +548,11 @@ class MongoDBDocumentManagerTest {
         List<CommunicationEntity> entities = entityManager.select(select().from("download")
                 .where("_id").eq(id).build()).toList();
 
-        assertEquals(1, entities.size());
+        assertThat(entities.size()).isEqualTo(1);
         CommunicationEntity documentEntity = entities.getFirst();
-        assertEquals(id, documentEntity.find("_id").get().get());
+        assertThat(documentEntity.find("_id").get().get()).isEqualTo(id);
 
-        assertArrayEquals(contents, (byte[]) documentEntity.find("contents").get().get());
+        assertThat((byte[]) documentEntity.find("contents").get().get()).isEqualTo(contents);
 
     }
 
@@ -578,11 +572,11 @@ class MongoDBDocumentManagerTest {
         List<CommunicationEntity> entities = entityManager.select(select().from("download")
                 .where("_id").eq(id).build()).toList();
 
-        assertEquals(1, entities.size());
+        assertThat(entities.size()).isEqualTo(1);
         CommunicationEntity documentEntity = entities.getFirst();
-        assertEquals(id, documentEntity.find("_id").get().get());
-        assertEquals(date, documentEntity.find("date").get().get(Date.class));
-        assertEquals(now, documentEntity.find("date").get().get(LocalDate.class));
+        assertThat(documentEntity.find("_id").get().get()).isEqualTo(id);
+        assertThat(documentEntity.find("date").get().get(Date.class)).isEqualTo(date);
+        assertThat(documentEntity.find("date").get().get(LocalDate.class)).isEqualTo(now);
 
 
     }
@@ -590,7 +584,7 @@ class MongoDBDocumentManagerTest {
     @Test
     void shouldConvertFromListDocumentList() {
         CommunicationEntity entity = createDocumentList();
-        assertDoesNotThrow(() -> entityManager.insert(entity));
+        assertThatCode(() -> entityManager.insert(entity)).doesNotThrowAnyException();
     }
 
     @SuppressWarnings("unchecked")
@@ -603,18 +597,18 @@ class MongoDBDocumentManagerTest {
                 .eq(key.get()).build();
 
         var documentEntity = entityManager.singleResult(query).get();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").get().get();
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test
     void shouldCount() {
         entityManager.insert(getEntity());
-        assertTrue(entityManager.count(COLLECTION_NAME) > 0);
+        assertThat(entityManager.count(COLLECTION_NAME) > 0).isTrue();
     }
 
     @Test
@@ -645,7 +639,7 @@ class MongoDBDocumentManagerTest {
                 .where(id.name()).eq(id.get()).build();
 
         CommunicationEntity result = entityManager.singleResult(query).get();
-        assertEquals(money, result.find("money").get().get(Money.class));
+        assertThat(result.find("money").get().get(Money.class)).isEqualTo(money);
 
     }
 
@@ -660,12 +654,12 @@ class MongoDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where("_id").eq(id).and("scope").eq("xxx").build();
         final Optional<CommunicationEntity> optional = entityManager.select(query).findFirst();
-        Assertions.assertTrue(optional.isPresent());
+        assertThat(optional.isPresent()).isTrue();
         CommunicationEntity documentEntity = optional.get();
         Element properties = documentEntity.find("properties").get();
         Map<String, Object> map = properties.get(new TypeReference<>() {
         });
-        Assertions.assertNotNull(map);
+        assertThat(map).isNotNull();
     }
 
     @Test

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBQueryTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBQueryTest.java
@@ -19,7 +19,6 @@ import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
@@ -65,7 +65,7 @@ class MongoDBQueryTest {
 
         Stream<CommunicationEntity> stream = entityManager.select(query);
         long count = stream.count();
-        Assertions.assertEquals(1L, count);
+        assertThat(count).isEqualTo(1L);
         entityManager.delete(delete().from(COLLECTION_NAME).build());
 
     }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBSpecificFeaturesTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBSpecificFeaturesTest.java
@@ -22,7 +22,6 @@ import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,7 @@ import static com.mongodb.client.model.Filters.eq;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class MongoDBSpecificFeaturesTest {
@@ -63,12 +62,9 @@ class MongoDBSpecificFeaturesTest {
     void shouldReturnErrorOnSelectWhenThereIsNullParameter() {
         Bson filter = eq("name", "Poliana");
 
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.select(null, null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.select(COLLECTION_NAME, null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.select(null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.select(null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.select(COLLECTION_NAME, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.select(null, filter));
     }
 
     @Test
@@ -77,7 +73,7 @@ class MongoDBSpecificFeaturesTest {
 
         List<CommunicationEntity> entities = entityManager.select(COLLECTION_NAME,
                 eq("name", "Poliana")).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -85,12 +81,9 @@ class MongoDBSpecificFeaturesTest {
     void shouldReturnErrorOnDeleteWhenThereIsNullParameter() {
         Bson filter = eq("name", "Poliana");
 
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.delete(null, null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.delete(COLLECTION_NAME, null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.delete(null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.delete(null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.delete(COLLECTION_NAME, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.delete(null, filter));
     }
 
     @Test
@@ -100,10 +93,10 @@ class MongoDBSpecificFeaturesTest {
         long result = entityManager.delete(COLLECTION_NAME,
                 eq("name", "Poliana"));
 
-        Assertions.assertEquals(1L, result);
+        assertThat(result).isEqualTo(1L);
         List<CommunicationEntity> entities = entityManager.select(COLLECTION_NAME,
                 eq("name", "Poliana")).toList();
-        Assertions.assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -112,12 +105,9 @@ class MongoDBSpecificFeaturesTest {
         List<Bson> pipeline = Collections.singletonList(bson);
         var pipelineArray = new Bson[]{bson};
 
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.aggregate(null, (List<Bson>) null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.aggregate(COLLECTION_NAME, (List<Bson>) null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.aggregate(null, (Bson[]) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.aggregate(null, (List<Bson>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.aggregate(COLLECTION_NAME, (List<Bson>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.aggregate(null, (Bson[]) null));
     }
 
     @Test
@@ -128,14 +118,14 @@ class MongoDBSpecificFeaturesTest {
         };
         entityManager.insert(getEntity());
         Stream<Map<String, BsonValue>> aggregate = entityManager.aggregate(COLLECTION_NAME, predicates);
-        Assertions.assertNotNull(aggregate);
+        assertThat(aggregate).isNotNull();
         Map<String, BsonValue> result = aggregate.findFirst()
                 .orElseThrow(() -> new IllegalStateException("There is an issue with the aggregate test result"));
 
-        Assertions.assertNotNull(result);
-        Assertions.assertFalse(result.isEmpty());
+        assertThat(result).isNotNull();
+        assertThat(result.isEmpty()).isFalse();
         BsonValue count = result.get("count");
-        Assertions.assertEquals(1L, count.asNumber().longValue());
+        assertThat(count.asNumber().longValue()).isEqualTo(1L);
 
     }
 
@@ -147,11 +137,11 @@ class MongoDBSpecificFeaturesTest {
         );
         entityManager.insert(getEntity());
         Stream<CommunicationEntity> aggregate = entityManager.aggregate(COLLECTION_NAME, predicates);
-        Assertions.assertNotNull(aggregate);
+        assertThat(aggregate).isNotNull();
         CommunicationEntity result = aggregate.findFirst()
                 .orElseThrow(() -> new IllegalStateException("There is an issue with the aggregate test result"));
 
-        Assertions.assertNotNull(result);
+        assertThat(result).isNotNull();
     }
 
     private CommunicationEntity getEntity() {
@@ -169,13 +159,13 @@ class MongoDBSpecificFeaturesTest {
 
         entityManager.insert(getEntity());
         var filter = eq("name", "Poliana");
-        Assertions.assertEquals(1L, entityManager.count(COLLECTION_NAME, filter));
+        assertThat(entityManager.count(COLLECTION_NAME, filter)).isEqualTo(1L);
 
         var filter2 = and(filter, eq("city", "Salvador"));
-        Assertions.assertEquals(1L, entityManager.count(COLLECTION_NAME, filter2));
+        assertThat(entityManager.count(COLLECTION_NAME, filter2)).isEqualTo(1L);
 
         var filter3 = and(filter, eq("city", "São Paulo"));
-        Assertions.assertEquals(0L, entityManager.count(COLLECTION_NAME, filter3));
+        assertThat(entityManager.count(COLLECTION_NAME, filter3)).isEqualTo(0L);
 
     }
 
@@ -184,12 +174,9 @@ class MongoDBSpecificFeaturesTest {
 
         Bson filter = eq("name", "Poliana");
 
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.count(null, null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.count(COLLECTION_NAME, null));
-        Assertions.assertThrows(NullPointerException.class,
-                () -> entityManager.count(null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.count(null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.count(COLLECTION_NAME, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> entityManager.count(null, filter));
 
     }
 

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBValueWriteDecoratorTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBValueWriteDecoratorTest.java
@@ -18,7 +18,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 @SuppressWarnings("rawtypes")
 class MongoDBValueWriteDecoratorTest {
@@ -27,7 +28,7 @@ class MongoDBValueWriteDecoratorTest {
 
     @Test
     void shouldTestUUIDType() {
-        assertTrue(valueWriter.test(UUID.class));
+        assertThat(valueWriter.test(UUID.class)).isTrue();
     }
 
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DefaultMongoDBTemplateTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DefaultMongoDBTemplateTest.java
@@ -36,7 +36,6 @@ import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -47,10 +46,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.mongodb.client.model.Filters.eq;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class, MongoDBTemplate.class})
@@ -87,12 +86,12 @@ class DefaultMongoDBTemplateTest {
     @Test
     void shouldReturnErrorOnDeleteMethod() {
         Bson filter = eq("name", "Poliana");
-        assertThrows(NullPointerException.class,() -> template.delete((String) null, null));
-        assertThrows(NullPointerException.class,() -> template.delete("Collection", null));
-        assertThrows(NullPointerException.class,() -> template.delete((String) null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.delete((String) null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.delete("Collection", null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.delete((String) null, filter));
 
-        assertThrows(NullPointerException.class,() -> template.delete(Birthday.class, null));
-        assertThrows(NullPointerException.class,() -> template.delete((Class<Object>) null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.delete(Birthday.class, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.delete((Class<Object>) null, filter));
     }
 
     @Test
@@ -121,13 +120,13 @@ class DefaultMongoDBTemplateTest {
     void shouldReturnErrorOnSelectMethod() {
         Bson filter = eq("name", "Poliana");
 
-        assertThrows(NullPointerException.class, () -> template.select((String) null, null));
-        assertThrows(NullPointerException.class, () -> template.select("Collection", null));
-        assertThrows(NullPointerException.class, () -> template.select((String) null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.select((String) null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.select("Collection", null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.select((String) null, filter));
 
-        assertThrows(NullPointerException.class, () -> template.select((Class<?>) null, null));
-        assertThrows(NullPointerException.class, () -> template.select(Birthday.class, null));
-        assertThrows(NullPointerException.class, () -> template.select((Class<?>) null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.select((Class<?>) null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.select(Birthday.class, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.select((Class<?>) null, filter));
     }
 
     @Test
@@ -139,13 +138,13 @@ class DefaultMongoDBTemplateTest {
         Mockito.when(manager.select("Birthday", filter))
                 .thenReturn(Stream.of(entity));
         Stream<Birthday> stream = template.select("Birthday", filter);
-        Assertions.assertNotNull(stream);
+        assertThat(stream).isNotNull();
         Birthday poliana = stream.findFirst()
                 .orElseThrow(() -> new IllegalStateException("There is an issue on the test"));
 
-        Assertions.assertNotNull(poliana);
-        assertEquals("Poliana", poliana.getName());
-        assertEquals(30, poliana.getAge());
+        assertThat(poliana).isNotNull();
+        assertThat(poliana.getName()).isEqualTo("Poliana");
+        assertThat(poliana.getAge()).isEqualTo(30);
     }
 
     @Test
@@ -157,13 +156,13 @@ class DefaultMongoDBTemplateTest {
         Mockito.when(manager.select("Birthday", filter))
                 .thenReturn(Stream.of(entity));
         Stream<Birthday> stream = template.select(Birthday.class, filter);
-        Assertions.assertNotNull(stream);
+        assertThat(stream).isNotNull();
         Birthday poliana = stream.findFirst()
                 .orElseThrow(() -> new IllegalStateException("There is an issue on the test"));
 
-        Assertions.assertNotNull(poliana);
-        assertEquals("Poliana", poliana.getName());
-        assertEquals(30, poliana.getAge());
+        assertThat(poliana).isNotNull();
+        assertThat(poliana.getName()).isEqualTo("Poliana");
+        assertThat(poliana.getAge()).isEqualTo(30);
     }
 
     @Test
@@ -173,23 +172,23 @@ class DefaultMongoDBTemplateTest {
         var pipeline = Collections.singletonList(bson);
         var pipelineArray = new Bson[]{bson, bson};
 
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, (List<Bson>) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, (Bson[]) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, (Bson) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, pipeline));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, pipelineArray));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, bson));
-        assertThrows(NullPointerException.class, () -> template.aggregate(collectionName, (List<Bson>) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate(collectionName, (Bson[]) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, (List<Bson>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, (Bson[]) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, (Bson) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, pipeline));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, pipelineArray));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, bson));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate(collectionName, (List<Bson>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate(collectionName, (Bson[]) null));
 
-        assertThrows(NullPointerException.class, () -> template.aggregate((Class<?>) null, (List<Bson>) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate((Class<?>) null, (Bson[]) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate((Class<?>) null, (Bson) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, pipeline));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, pipelineArray));
-        assertThrows(NullPointerException.class, () -> template.aggregate((String) null, bson));
-        assertThrows(NullPointerException.class, () -> template.aggregate(Birthday.class, (List<Bson>) null));
-        assertThrows(NullPointerException.class, () -> template.aggregate(Birthday.class, (Bson[]) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((Class<?>) null, (List<Bson>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((Class<?>) null, (Bson[]) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((Class<?>) null, (Bson) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, pipeline));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, pipelineArray));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate((String) null, bson));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate(Birthday.class, (List<Bson>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.aggregate(Birthday.class, (Bson[]) null));
 
     }
 
@@ -236,11 +235,11 @@ class DefaultMongoDBTemplateTest {
     @Test
     void shouldReturnErrorOnCountByFilterMethod() {
         var filter = eq("name", "Poliana");
-        assertThrows(NullPointerException.class, () -> template.count((String) null, null));
-        assertThrows(NullPointerException.class, () -> template.count((String) null, filter));
-        assertThrows(NullPointerException.class, () -> template.count("Person", null));
-        assertThrows(NullPointerException.class, () -> template.count((Class<Birthday>) null, null));
-        assertThrows(NullPointerException.class, () -> template.count((Class<Birthday>) null, filter));
-        assertThrows(NullPointerException.class, () -> template.count(Birthday.class, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.count((String) null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.count((String) null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.count("Person", null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.count((Class<Birthday>) null, null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.count((Class<Birthday>) null, filter));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.count(Birthday.class, null));
     }
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DocumentEntityConverterTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DocumentEntityConverterTest.java
@@ -27,8 +27,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class, MongoDBTemplate.class})
@@ -46,11 +47,11 @@ class DocumentEntityConverterTest {
         ObjectId id = new ObjectId();
         Music music = new Music(id.toString(), "Music", 2021);
         CommunicationEntity entity = converter.toCommunication(music);
-        Assertions.assertNotNull(entity);
-        Assertions.assertEquals(Music.class.getSimpleName(), entity.name());
-        Assertions.assertEquals(id, entity.find("_id", ObjectId.class).get());
-        Assertions.assertEquals("Music", entity.find("name", String.class).get());
-        Assertions.assertEquals(2021, entity.find("year", int.class).get());
+        assertThat(entity).isNotNull();
+        assertThat(entity.name()).isEqualTo(Music.class.getSimpleName());
+        assertThat(entity.find("_id", ObjectId.class).get()).isEqualTo(id);
+        assertThat(entity.find("name", String.class).get()).isEqualTo("Music");
+        assertThat(entity.find("year", int.class).get()).isEqualTo(2021);
     }
 
     @Test
@@ -62,9 +63,9 @@ class DocumentEntityConverterTest {
         entity.add("_id", id);
 
         Music music = converter.toEntity(entity);
-        Assertions.assertNotNull(music);
-        Assertions.assertEquals("Music", music.getName());
-        Assertions.assertEquals(2022, music.getYear());
-        Assertions.assertEquals(id.toString(), music.getId());
+        assertThat(music).isNotNull();
+        assertThat(music.getName()).isEqualTo("Music");
+        assertThat(music.getYear()).isEqualTo(2022);
+        assertThat(music.getId()).isEqualTo(id.toString());
     }
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/MongoDBTemplateTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/MongoDBTemplateTest.java
@@ -24,8 +24,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnableAutoWeld
@@ -41,6 +42,6 @@ class MongoDBTemplateTest {
 
     @Test
     void shouldInjectMongoDBTemplate() {
-        Assertions.assertNotNull(template);
+        assertThat(template).isNotNull();
     }
 }

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/ObjectIdConverterTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/ObjectIdConverterTest.java
@@ -16,9 +16,10 @@ package org.eclipse.jnosql.databases.mongodb.mapping;
 
 import jakarta.nosql.AttributeConverter;
 import org.bson.types.ObjectId;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class ObjectIdConverterTest {
 
@@ -31,20 +32,20 @@ class ObjectIdConverterTest {
 
     @Test
     void shouldReturnNullWhenAttributeIsNull() {
-        Assertions.assertNull(this.converter.convertToDatabaseColumn(null));
+        assertThat(this.converter.convertToDatabaseColumn(null)).isNull();
     }
 
     @Test
     void shouldReturnNullWhenDataIsNull() {
-        Assertions.assertNull(this.converter.convertToEntityAttribute(null));
+        assertThat(this.converter.convertToEntityAttribute(null)).isNull();
     }
 
     @Test
     void shouldConvertToEntity() {
         ObjectId id = new ObjectId();
         String entityAttribute = this.converter.convertToEntityAttribute(id);
-        Assertions.assertNotNull(entityAttribute);
-        Assertions.assertEquals(id.toString(), entityAttribute);
+        assertThat(entityAttribute).isNotNull();
+        assertThat(entityAttribute).isEqualTo(id.toString());
     }
 
     @Test
@@ -52,7 +53,7 @@ class ObjectIdConverterTest {
         ObjectId objectId = new ObjectId();
         String entityAttribute = objectId.toString();
         ObjectId id = this.converter.convertToDatabaseColumn(entityAttribute);
-        Assertions.assertNotNull(id);
-        Assertions.assertEquals(objectId, id);
+        assertThat(id).isNotNull();
+        assertThat(id).isEqualTo(objectId);
     }
 }

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
@@ -43,9 +43,9 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class Neo4JDatabaseManagerTest {
@@ -68,7 +68,7 @@ class Neo4JDatabaseManagerTest {
     void shouldInsert() {
         var entity = getEntity();
         var communicationEntity = entityManager.insert(entity);
-        assertTrue(communicationEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id")));
+        assertThat(communicationEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id"))).isTrue();
     }
 
     @Test
@@ -86,7 +86,7 @@ class Neo4JDatabaseManagerTest {
         var entity = getEntity();
         entityManager.insert(entity);
         long count = entityManager.count(COLLECTION_NAME);
-        assertTrue(count > 0);
+        assertThat(count > 0).isTrue();
     }
 
     @Test
@@ -121,7 +121,7 @@ class Neo4JDatabaseManagerTest {
             softly.assertThat(result).isNotNull();
             softly.assertThat(result.find("name").orElseThrow().get()).isEqualTo("Lucas");
         });
-        assertTrue(result.find("name").isPresent());
+        assertThat(result.find("name").isPresent()).isTrue();
     }
 
     @Test

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/DefaultNeo4JTemplateTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/DefaultNeo4JTemplateTest.java
@@ -37,11 +37,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
 @EnableAutoWeld
@@ -84,13 +83,13 @@ class DefaultNeo4JTemplateTest {
         when(manager.cypher(cypher, parameters)).thenReturn(Stream.of(entity));
 
         Stream<Music> result = template.cypher(cypher, parameters);
-        assertNotNull(result);
-        assertTrue(result.findFirst().isPresent());
+        assertThat(result).isNotNull();
+        assertThat(result.findFirst().isPresent()).isTrue();
     }
 
     @Test
     void shouldThrowExceptionWhenQueryIsNull() {
-        assertThrows(NullPointerException.class, () -> template.cypher(null, Collections.emptyMap()));
-        assertThrows(NullPointerException.class, () -> template.cypher("MATCH (n) RETURN n", null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.cypher(null, Collections.emptyMap()));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> template.cypher("MATCH (n) RETURN n", null));
     }
 }

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JTemplateTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JTemplateTest.java
@@ -22,8 +22,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnableAutoWeld
@@ -38,6 +39,6 @@ class Neo4JTemplateTest {
 
     @Test
     void shouldInjectMongoDBTemplate() {
-        Assertions.assertNotNull(template);
+        assertThat(template).isNotNull();
     }
 }

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jExtensionTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jExtensionTest.java
@@ -26,8 +26,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, Neo4JRepository.class, EntityConverter.class, GraphTemplate.class})
@@ -48,12 +49,12 @@ public class Neo4jExtensionTest {
 
     @Test
     public void shouldCreteNeo4j() {
-        Assertions.assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 
     @Test
     public void shouldCreteGraph() {
-        Assertions.assertNotNull(repository2);
-        Assertions.assertNotNull(repository3);
+        assertThat(repository2).isNotNull();
+        assertThat(repository3).isNotNull();
     }
 }

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jRepositoryProxyTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jRepositoryProxyTest.java
@@ -37,11 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, Neo4JRepository.class, EntityConverter.class})
@@ -110,7 +110,7 @@ public class Neo4jRepositoryProxyTest {
         personRepository.findByName2("Ada");
         verify(template).cypher(Mockito.eq("MATCH (p:Person) WHERE p.name = $name RETURN p"), captor.capture());
         Map map = captor.getValue();
-        assertEquals("Ada", map.get("name"));
+        assertThat(map.get("name")).isEqualTo("Ada");
     }
 
     @Test

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DeploymentTypeTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DeploymentTypeTest.java
@@ -20,30 +20,31 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 class DeploymentTypeTest {
 
 
     @Test
     void shouldReturnOnPremiseWhenIsNull() {
-        assertEquals(DeploymentType.ON_PREMISES, DeploymentType.parse(null));
+        assertThat(DeploymentType.parse(null)).isEqualTo(DeploymentType.ON_PREMISES);
     }
 
     @Test
     void shouldReturnOnPremiseWhenTextIsInvalid() {
-        assertEquals(DeploymentType.ON_PREMISES, DeploymentType.parse("invalid"));
+        assertThat(DeploymentType.parse("invalid")).isEqualTo(DeploymentType.ON_PREMISES);
     }
 
     @ParameterizedTest
     @EnumSource(DeploymentType.class)
     void shouldParseEnum(DeploymentType type){
-        assertEquals(type, DeploymentType.parse(type.name()));
+        assertThat(DeploymentType.parse(type.name())).isEqualTo(type);
     }
 
     @ParameterizedTest
     @EnumSource(DeploymentType.class)
     void shouldParseEnumIgnoreCase(DeploymentType type){
-        assertEquals(type, DeploymentType.parse(type.name().toLowerCase(Locale.ROOT)));
+        assertThat(DeploymentType.parse(type.name().toLowerCase(Locale.ROOT))).isEqualTo(type);
     }
 }

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentConfigurationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentConfigurationTest.java
@@ -18,14 +18,14 @@ import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OracleDocumentConfigurationTest {
 
     @Test
     void shouldReturnErrorWhenMapSettingsIsNull() {
         OracleDocumentConfiguration configuration = new OracleDocumentConfiguration();
-        assertThrows(NullPointerException.class, () -> configuration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.apply(null));
     }
 
     @Test

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManagerTest.java
@@ -34,10 +34,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class OracleNoSQLBucketManagerTest {
@@ -63,16 +59,16 @@ public class OracleNoSQLBucketManagerTest {
     public void shouldPutValue() {
         keyValueEntityManager.put("otavio", otavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(this.otavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(this.otavio);
     }
 
     @Test
     public void shouldPutKeyValue() {
         keyValueEntityManager.put(entityOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(this.otavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(this.otavio);
     }
 
     @Test
@@ -86,12 +82,12 @@ public class OracleNoSQLBucketManagerTest {
 
         keyValueEntityManager.put(asList(entitySoro, entityOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(this.otavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(this.otavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(this.soro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(this.soro);
     }
 
     @Test
@@ -99,7 +95,7 @@ public class OracleNoSQLBucketManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
 
 
     }
@@ -108,9 +104,9 @@ public class OracleNoSQLBucketManagerTest {
     public void shouldRemoveKey() {
 
         keyValueEntityManager.put(entityOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -124,7 +120,7 @@ public class OracleNoSQLBucketManagerTest {
                 .contains(otavio, soro);
         keyValueEntityManager.delete(keys);
         Iterable<Value> users = values;
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 
 

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
@@ -21,7 +21,6 @@ import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
 import org.eclipse.jnosql.mapping.semistructured.MappingQuery;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -50,13 +49,8 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 class OracleNoSQLDocumentManagerTest {
@@ -78,14 +72,14 @@ class OracleNoSQLDocumentManagerTest {
     void shouldInsert() {
         var entity = getEntity();
         var documentEntity = entityManager.insert(entity);
-        assertTrue(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id")));
+        assertThat(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id"))).isTrue();
     }
 
     @Test
     void shouldThrowExceptionWhenInsertWithTTL() {
         var entity = getEntity();
         var ttl = Duration.ofSeconds(10);
-        assertThrows(UnsupportedOperationException.class, () -> entityManager.insert(entity, ttl));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> entityManager.insert(entity, ttl));
     }
 
     @Test
@@ -95,7 +89,7 @@ class OracleNoSQLDocumentManagerTest {
         var newField = Elements.of("newField", "10");
         entity.add(newField);
         var updated = entityManager.update(entity);
-        assertEquals(newField, updated.find("newField").orElseThrow());
+        assertThat(updated.find("newField").orElseThrow()).isEqualTo(newField);
     }
 
     @Test
@@ -111,7 +105,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         entityManager.delete(deleteQuery);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -124,7 +118,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -168,7 +162,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -185,7 +179,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
@@ -202,7 +196,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
@@ -244,7 +238,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).toList();
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
     }
 
     @Test
@@ -289,7 +283,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
@@ -299,7 +293,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertTrue(entitiesFound.isEmpty());
+        assertThat(entitiesFound.isEmpty()).isTrue();
 
     }
 
@@ -317,7 +311,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
@@ -327,7 +321,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
 
     }
 
@@ -344,7 +338,7 @@ class OracleNoSQLDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         List<Integer> ages = entitiesFound.stream()
                 .map(e -> e.find("age").orElseThrow().get(Integer.class))
                 .collect(Collectors.toList());
@@ -361,7 +355,7 @@ class OracleNoSQLDocumentManagerTest {
         ages = entitiesFound.stream()
                 .map(e -> e.find("age").orElseThrow().get(Integer.class))
                 .collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(ages).contains(25, 23);
 
     }
@@ -371,7 +365,7 @@ class OracleNoSQLDocumentManagerTest {
         entityManager.insert(getEntity());
         var query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -379,11 +373,11 @@ class OracleNoSQLDocumentManagerTest {
         entityManager.insert(getEntity());
         var query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         var deleteQuery = delete().from(COLLECTION_NAME).build();
         entityManager.delete(deleteQuery);
         entities = entityManager.select(query).toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -391,7 +385,7 @@ class OracleNoSQLDocumentManagerTest {
         entityManager.insert(getEntity());
         var query = select("name").from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         final CommunicationEntity entity = entities.getFirst();
         assertSoftly(soft -> {
             soft.assertThat(entity.find("name")).isPresent();
@@ -451,11 +445,11 @@ class OracleNoSQLDocumentManagerTest {
         List<CommunicationEntity> entities = entityManager.select(select().from("download")
                 .where("_id").eq(id).build()).toList();
 
-        assertEquals(1, entities.size());
+        assertThat(entities.size()).isEqualTo(1);
         var documentEntity = entities.getFirst();
-        assertEquals(id, documentEntity.find("_id").orElseThrow().get(Long.class));
+        assertThat(documentEntity.find("_id").orElseThrow().get(Long.class)).isEqualTo(id);
 
-        assertArrayEquals(contents, documentEntity.find("contents").orElseThrow().get(byte[].class));
+        assertThat(documentEntity.find("contents").orElseThrow().get(byte[].class)).isEqualTo(contents);
 
     }
 
@@ -473,7 +467,7 @@ class OracleNoSQLDocumentManagerTest {
         List<CommunicationEntity> entities = entityManager.select(select().from("download")
                 .where("_id").eq(id).build()).toList();
 
-        assertEquals(1, entities.size());
+        assertThat(entities.size()).isEqualTo(1);
         var documentEntity = entities.getFirst();
         assertSoftly(soft -> {
             soft.assertThat(id).isEqualTo(documentEntity.find("_id").orElseThrow().get(Long.class));
@@ -484,7 +478,7 @@ class OracleNoSQLDocumentManagerTest {
     @Test
     void shouldConvertFromListDocumentList() {
         var entity = createDocumentList();
-        assertDoesNotThrow(() -> entityManager.insert(entity));
+        assertThatCode(() -> entityManager.insert(entity)).doesNotThrowAnyException();
     }
 
     @Test
@@ -496,18 +490,18 @@ class OracleNoSQLDocumentManagerTest {
                 .eq(key.get()).build();
 
         var documentEntity = entityManager.singleResult(query).orElseThrow();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").orElseThrow().get();
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test
     void shouldCount() {
         entityManager.insert(getEntity());
-        assertTrue(entityManager.count(COLLECTION_NAME) > 0);
+        assertThat(entityManager.count(COLLECTION_NAME) > 0).isTrue();
     }
 
     @Test
@@ -543,7 +537,7 @@ class OracleNoSQLDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where("_id").eq(id).and("scope").eq("xxx").build();
         final Optional<CommunicationEntity> optional = entityManager.select(query).findFirst();
-        Assertions.assertTrue(optional.isPresent());
+        assertThat(optional.isPresent()).isTrue();
         CommunicationEntity documentEntity = optional.get();
         var properties = documentEntity.find("properties").orElseThrow();
         var document = properties.get(Element.class);

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLKeyValueConfigurationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLKeyValueConfigurationTest.java
@@ -18,14 +18,14 @@ import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class OracleNoSQLKeyValueConfigurationTest {
 
     @Test
     void shouldReturnErrorWhenMapSettingsIsNull() {
         OracleNoSQLKeyValueConfiguration configuration = new OracleNoSQLKeyValueConfiguration();
-        assertThrows(NullPointerException.class, () -> configuration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.apply(null));
     }
 
     @Test

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDBExtensionTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDBExtensionTest.java
@@ -23,10 +23,11 @@ import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtensi
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Convert.class})
@@ -42,6 +43,6 @@ public class OracleDBExtensionTest {
 
     @Test
     public void shouldSave() {
-        Assertions.assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 }

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurationTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurationTest.java
@@ -18,12 +18,11 @@ package org.eclipse.jnosql.databases.orientdb.communication;
 
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class OrientDBDocumentConfigurationTest {
 
@@ -34,7 +33,7 @@ public class OrientDBDocumentConfigurationTest {
         configuration.setUser("root");
         configuration.setPassword("rootpwd");
         var managerFactory = configuration.apply(Settings.builder().build());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
@@ -44,49 +43,47 @@ public class OrientDBDocumentConfigurationTest {
         configuration.setUser("root");
         configuration.setPassword("rootpwd");
         var managerFactory = configuration.apply(Settings.builder().build());
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
     @Test
     public void shouldThrowExceptionWhenURLIsNotSupported() {
 
-        assertThrows(IllegalArgumentException.class, ()-> {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(()-> {
             OrientDBDocumentConfiguration configuration = new OrientDBDocumentConfiguration();
             configuration.setHost("172.17.0.2");
             configuration.setUser("root");
             configuration.setPassword("rootpwd");
             configuration.apply(Settings.builder().build());
-            fail("Should throw exception");
         });
 
-        assertThrows(IllegalArgumentException.class, ()-> {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(()-> {
             OrientDBDocumentConfiguration configuration = new OrientDBDocumentConfiguration();
             configuration.setHost("/tmp/db/");
             configuration.setUser("root");
             configuration.setPassword("rootpwd");
             configuration.apply(Settings.builder().build());
-            fail("Should throw exception");
         });
     }
 
 
     @Test
     public void shouldThrowExceptionWhenSettingsIsNull() {
-        assertThrows(NullPointerException.class, () -> new OrientDBDocumentConfiguration().apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> new OrientDBDocumentConfiguration().apply(null));
     }
 
     @Test
     public void shouldReturnFromConfiguration() {
         var configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof DatabaseConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof DatabaseConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         OrientDBDocumentConfiguration configuration = DatabaseConfiguration
                 .getConfiguration(OrientDBDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof OrientDBDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof OrientDBDocumentConfiguration).isTrue();
     }
 }

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerFactoryTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerFactoryTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class OrientDBDocumentManagerFactoryTest {
@@ -36,6 +36,6 @@ public class OrientDBDocumentManagerFactoryTest {
     @Test
     public void shouldCreateEntityManager() {
         var database = managerFactory.apply("database");
-        assertNotNull(database);
+        assertThat(database).isNotNull();
     }
 }

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
@@ -52,11 +52,8 @@ import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class OrientDBDocumentManagerTest {
@@ -73,15 +70,15 @@ public class OrientDBDocumentManagerTest {
     void shouldInsert() {
         var entity = getEntity();
         var documentEntity = entityManager.insert(entity);
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
         Optional<Element> document = documentEntity.find(OrientDBConverter.RID_FIELD);
-        assertTrue(document.isPresent());
+        assertThat(document.isPresent()).isTrue();
 
     }
 
     @Test
     void shouldThrowExceptionWhenSaveWithTTL() {
-        assertThrows(UnsupportedOperationException.class, () -> entityManager.insert(getEntity(), Duration.ZERO));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> entityManager.insert(getEntity(), Duration.ZERO));
     }
 
     @Test
@@ -97,8 +94,8 @@ public class OrientDBDocumentManagerTest {
                 .build();
         Optional<CommunicationEntity> updated = entityManager.singleResult(query);
 
-        assertTrue(updated.isPresent());
-        assertEquals(newField, updated.get().find(newField.name()).get());
+        assertThat(updated.isPresent()).isTrue();
+        assertThat(updated.get().find(newField.name()).get()).isEqualTo(newField);
     }
 
     @Test
@@ -115,8 +112,8 @@ public class OrientDBDocumentManagerTest {
                 .build();
         Optional<CommunicationEntity> updated = entityManager.singleResult(query);
 
-        assertTrue(updated.isPresent());
-        assertEquals(newField, updated.get().find(newField.name()).get());
+        assertThat(updated.isPresent()).isTrue();
+        assertThat(updated.get().find(newField.name()).get()).isEqualTo(newField);
     }
 
     @Test
@@ -128,7 +125,7 @@ public class OrientDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
         var deleteQuery = delete().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
         entityManager.delete(deleteQuery);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -138,7 +135,7 @@ public class OrientDBDocumentManagerTest {
 
         var query = select().from(COLLECTION_NAME).where(id.name()).eq(id.get()).build();
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities, contains(entity));
     }
 
@@ -149,7 +146,7 @@ public class OrientDBDocumentManagerTest {
 
         List<CommunicationEntity> entities = entityManager.sql("select * from person where name = ?", id.get().get())
                 .collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities, contains(entity));
     }
 
@@ -160,7 +157,7 @@ public class OrientDBDocumentManagerTest {
 
         List<CommunicationEntity> entities = entityManager.sql("select * from person where name = :name",
                 singletonMap("name", id.get().get())).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities, contains(entity));
     }
 
@@ -206,10 +203,10 @@ public class OrientDBDocumentManagerTest {
         var deleteQuery = delete().from(COLLECTION_NAME).where("name").eq("Poliana")
                 .and("age").gte(10).build();
 
-        assertFalse(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isFalse();
 
         entityManager.delete(deleteQuery);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -225,10 +222,10 @@ public class OrientDBDocumentManagerTest {
         var deleteQuery = delete().from(COLLECTION_NAME).where("name").eq("Poliana")
                 .or("age").gte(10).build();
 
-        assertFalse(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isFalse();
 
         entityManager.delete(deleteQuery);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -240,12 +237,12 @@ public class OrientDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where("age").gt(25)
                 .build();
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
 
         var query2 = select().from(COLLECTION_NAME)
                 .where("age").gt(24)
                 .build();
-        assertEquals(1, (int) entityManager.select(query2).count());
+        assertThat((int) entityManager.select(query2).count()).isEqualTo(1);
     }
 
     @Test
@@ -257,12 +254,12 @@ public class OrientDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where("age").lt(25)
                 .build();
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
 
         var query2 = select().from(COLLECTION_NAME)
                 .where("age").lt(26)
                 .build();
-        assertEquals(1, (int) entityManager.select(query2).count());
+        assertThat((int) entityManager.select(query2).count()).isEqualTo(1);
     }
 
     @Test
@@ -274,17 +271,17 @@ public class OrientDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where("age").lte(24)
                 .build();
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
 
         var query2 = select().from(COLLECTION_NAME)
                 .where("age").lte(25)
                 .build();
-        assertEquals(1, (int) entityManager.select(query2).count());
+        assertThat((int) entityManager.select(query2).count()).isEqualTo(1);
 
         var query3 = select().from(COLLECTION_NAME)
                 .where("age").lte(26)
                 .build();
-        assertEquals(1, (int) entityManager.select(query3).count());
+        assertThat((int) entityManager.select(query3).count()).isEqualTo(1);
     }
 
     @Test
@@ -294,14 +291,14 @@ public class OrientDBDocumentManagerTest {
         var query = select().from(COLLECTION_NAME)
                 .where("city").in(asList("Salvador", "Assis"))
                 .build();
-        assertEquals(2, (int) entityManager.select(query).count());
+        assertThat((int) entityManager.select(query).count()).isEqualTo(2);
 
         var deleteQuery = delete().from(COLLECTION_NAME)
                 .where("city").in(asList("Salvador", "Assis", "Sao Paulo"))
                 .build();
         entityManager.delete(deleteQuery);
 
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -314,7 +311,7 @@ public class OrientDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entities.size());
+        assertThat(entities.size()).isEqualTo(2);
         assertThat(entities, containsInAnyOrder(entitiesSaved.get(0), entitiesSaved.get(1)));
     }
 
@@ -327,7 +324,7 @@ public class OrientDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entities.size());
+        assertThat(entities.size()).isEqualTo(2);
         assertThat(entities, containsInAnyOrder(entitiesSaved.get(0), entitiesSaved.get(1)));
     }
 
@@ -340,7 +337,7 @@ public class OrientDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertEquals(2, entities.size());
+        assertThat(entities.size()).isEqualTo(2);
     }
 
     @Test
@@ -352,7 +349,7 @@ public class OrientDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertEquals(2, entities.size());
+        assertThat(entities.size()).isEqualTo(2);
     }
 
     @Test
@@ -409,7 +406,7 @@ public class OrientDBDocumentManagerTest {
         entityManager.live(query, OrientDBLiveCallbackBuilder.builder().onCreate(callback).build());
         entityManager.insert(getEntity());
         await().untilTrue(condition);
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -431,8 +428,8 @@ public class OrientDBDocumentManagerTest {
         entity.add(newName);
         entityManager.update(entity);
         await().untilTrue(condition);
-        assertFalse(entities.isEmpty());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -463,7 +460,7 @@ public class OrientDBDocumentManagerTest {
         entityManager.live("SELECT FROM person", OrientDBLiveCallbackBuilder.builder().onCreate(callback).build());
         entityManager.insert(getEntity());
         await().untilTrue(condition);
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -480,20 +477,20 @@ public class OrientDBDocumentManagerTest {
         SelectQuery query = select().from("AppointmentBook").where(key.name()).eq(key.get()).build();
 
         var documentEntity = entityManager.singleResult(query).get();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").get().get();
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     @Test
     void shouldCount() {
         CommunicationEntity entity = getEntity();
         CommunicationEntity documentEntity = entityManager.insert(entity);
-        assertNotNull(documentEntity);
-        assertTrue(entityManager.count(COLLECTION_NAME) > 0);
+        assertThat(documentEntity).isNotNull();
+        assertThat(entityManager.count(COLLECTION_NAME) > 0).isTrue();
 
     }
 

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallbackBuilderTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallbackBuilderTest.java
@@ -17,8 +17,9 @@ package org.eclipse.jnosql.databases.orientdb.communication;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class OrientDBLiveCallbackBuilderTest {
 
@@ -27,11 +28,11 @@ public class OrientDBLiveCallbackBuilderTest {
         OrientDBLiveCallback build = OrientDBLiveCallbackBuilder.builder().onCreate(d -> {
         }).build();
 
-        assertNotNull(build);
+        assertThat(build).isNotNull();
     }
 
     @Test
     public void shouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> OrientDBLiveCallbackBuilder.builder().build());
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> OrientDBLiveCallbackBuilder.builder().build());
     }
 }

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBDocumentRepositoryProxyTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBDocumentRepositoryProxyTest.java
@@ -39,11 +39,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnableAutoWeld
@@ -101,7 +101,7 @@ public class OrientDBDocumentRepositoryProxyTest {
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class);
         verify(template).sql(Mockito.eq("select * from Person where age = :age"), argumentCaptor.capture());
         Map value = argumentCaptor.getValue();
-        assertEquals(10, value.get("age"));
+        assertThat(value.get("age")).isEqualTo(10);
     }
 
     @Test

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBExtensionTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBExtensionTest.java
@@ -24,8 +24,9 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class,
@@ -42,6 +43,6 @@ public class OrientDBExtensionTest {
 
     @Test
     public void shouldSaveOrientDB() {
-        Assertions.assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 }

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentConfigurationTest.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentConfigurationTest.java
@@ -21,8 +21,9 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class RavenDBDocumentConfigurationTest {
 
@@ -32,14 +33,14 @@ public class RavenDBDocumentConfigurationTest {
         map.put("ravendb-server-host-1", "172.17.0.2:8080");
         RavenDBDocumentConfiguration configuration = new RavenDBDocumentConfiguration();
         var managerFactory = configuration.apply(Settings.of(map));
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
 
     @Test
     public void shouldReturnErrorWhenSettingsIsNull() {
         var configuration = new RavenDBDocumentConfiguration();
-        assertThrows(NullPointerException.class, () -> configuration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.apply(null));
     }
 
 

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerFactoryTest.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerFactoryTest.java
@@ -18,8 +18,9 @@ package org.eclipse.jnosql.databases.ravendb.communication;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class RavenDBDocumentManagerFactoryTest {
 
@@ -33,12 +34,12 @@ public class RavenDBDocumentManagerFactoryTest {
     @Test
     public void shouldCreateEntityManager() {
         RavenDBDocumentManagerFactory ravenDBFactory = configuration.apply(DocumentConfigurationUtils.INSTANCE.getSettings());
-        assertNotNull(ravenDBFactory.apply("database"));
+        assertThat(ravenDBFactory.apply("database")).isNotNull();
     }
 
     @Test
     public void shouldReturnNPEWhenSettingsIsNull() {
-        assertThrows(NullPointerException.class, () -> configuration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.apply(null));
     }
 
 

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerTest.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerTest.java
@@ -42,10 +42,6 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RavenDBDocumentManagerTest {
@@ -77,7 +73,7 @@ public class RavenDBDocumentManagerTest {
     public void shouldInsert() {
         var entity = getEntity();
         var documentEntity = manager.insert(entity);
-        assertTrue(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id")));
+        assertThat(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals("_id"))).isTrue();
     }
 
     @Test
@@ -97,7 +93,7 @@ public class RavenDBDocumentManagerTest {
         var newField = Elements.of("newField", "10");
         entity.add(newField);
         var updated = manager.update(entity);
-        assertEquals(newField, updated.find("newField").get());
+        assertThat(updated.find("newField").get()).isEqualTo(newField);
     }
 
     @Test
@@ -114,7 +110,7 @@ public class RavenDBDocumentManagerTest {
                 .build();
 
         manager.delete(deleteQuery);
-        assertTrue(manager.select(query).findAny().isEmpty());
+        assertThat(manager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -128,7 +124,7 @@ public class RavenDBDocumentManagerTest {
 
         List<CommunicationEntity> entities = manager.select(query)
                 .collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -142,8 +138,8 @@ public class RavenDBDocumentManagerTest {
                 .build();
 
         Optional<CommunicationEntity> result = manager.singleResult(query);
-        assertTrue(result.isPresent());
-        assertEquals(entity, result.get());
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo(entity);
     }
 
     @Test
@@ -157,7 +153,7 @@ public class RavenDBDocumentManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = manager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -173,7 +169,7 @@ public class RavenDBDocumentManagerTest {
 
         List<CommunicationEntity> entities = manager.select(query)
                 .collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -208,7 +204,7 @@ public class RavenDBDocumentManagerTest {
 
         Thread.sleep(TIME_LIMIT);
         List<CommunicationEntity> entitiesFound = manager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
@@ -261,7 +257,7 @@ public class RavenDBDocumentManagerTest {
                 .and("type").eq("V")
                 .build();
         Thread.sleep(TIME_LIMIT);
-        assertEquals(entities, manager.select(query).collect(Collectors.toList()));
+        assertThat(manager.select(query).collect(Collectors.toList())).isEqualTo(entities);
     }
 
     @Test
@@ -269,7 +265,7 @@ public class RavenDBDocumentManagerTest {
         manager.insert(getEntity());
         var query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = manager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
 
@@ -324,12 +320,12 @@ public class RavenDBDocumentManagerTest {
                 .eq(key.get()).build();
 
         var documentEntity = manager.singleResult(query).get();
-        assertNotNull(documentEntity);
+        assertThat(documentEntity).isNotNull();
 
         List<List<Element>> contacts = (List<List<Element>>) documentEntity.find("contacts").get().get();
 
-        assertEquals(3, contacts.size());
-        assertTrue(contacts.stream().allMatch(d -> d.size() == 3));
+        assertThat(contacts.size()).isEqualTo(3);
+        assertThat(contacts.stream().allMatch(d -> d.size() == 3)).isTrue();
     }
 
     private CommunicationEntity createSubdocumentList() {
@@ -355,7 +351,7 @@ public class RavenDBDocumentManagerTest {
     public void shouldCount() {
         CommunicationEntity entity = getEntity();
         manager.insert(entity);
-        assertTrue(manager.count(COLLECTION_NAME) > 0);
+        assertThat(manager.count(COLLECTION_NAME) > 0).isTrue();
     }
 
 

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounterTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounterTest.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -41,21 +41,21 @@ public class DefaultCounterTest {
 
     @Test
     public void shouldIncrement() {
-        assertEquals(1D, counter.increment());
-        assertEquals(10D, counter.increment(9));
+        assertThat(counter.increment()).isEqualTo(1D);
+        assertThat(counter.increment(9)).isEqualTo(10D);
     }
 
     @Test
     public void shouldDecrement() {
         counter.increment(10.15);
-        assertEquals(9.15D, counter.decrement());
-        assertEquals(0.15D, counter.decrement(9));
+        assertThat(counter.decrement()).isEqualTo(9.15D);
+        assertThat(counter.decrement(9)).isEqualTo(0.15D);
     }
 
     @Test
     public void shouldGet() {
         counter.increment(10.15);
-        assertEquals(10.15D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(10.15D);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class DefaultCounterTest {
         counter.increment(10.15);
         counter.expire(Duration.ofSeconds(1));
         Thread.sleep(2_000L);
-        assertEquals(0D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(0D);
     }
 
     @Test
@@ -72,14 +72,14 @@ public class DefaultCounterTest {
         counter.expire(Duration.ofSeconds(1));
         counter.persist();
         Thread.sleep(2_000L);
-        assertEquals(10.15D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(10.15D);
     }
 
     @Test
     public void shouldDelete() {
         counter.increment(10.15);
         counter.delete();
-        assertEquals(0D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(0D);
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSetTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSetTest.java
@@ -25,9 +25,6 @@ import java.time.Duration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class DefaultSortedSetTest {
@@ -53,19 +50,19 @@ public class DefaultSortedSetTest {
 
     @Test
     public void shouldSize() {
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
         sortedSet.add(BRAZIL, 10);
-        assertEquals(Integer.valueOf(sortedSet.size()), Integer.valueOf(1));
+        assertThat(Integer.valueOf(1)).isEqualTo(Integer.valueOf(sortedSet.size()));
     }
 
     @Test
     public void shouldCheckIfEmpty() {
 
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
         sortedSet.add(BRAZIL, 1);
         sortedSet.add(USA, 2);
         sortedSet.add(ENGLAND, 3);
-        assertFalse(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isFalse();
 
     }
 
@@ -74,9 +71,9 @@ public class DefaultSortedSetTest {
         sortedSet.add(BRAZIL, 1);
         sortedSet.add(USA, 2);
         sortedSet.add(ENGLAND, 3);
-        assertFalse(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isFalse();
         sortedSet.delete();
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
     }
 
     @Test
@@ -84,30 +81,30 @@ public class DefaultSortedSetTest {
         sortedSet.add(BRAZIL, 1);
         sortedSet.add(USA, 2);
         sortedSet.add(ENGLAND, 3);
-        assertFalse(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isFalse();
         sortedSet.clear();
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldIncrement() {
         sortedSet.add(BRAZIL, 10);
         Number points = sortedSet.increment(BRAZIL, 2);
-        assertEquals(Long.valueOf(12), Long.valueOf(points.longValue()));
+        assertThat(Long.valueOf(points.longValue())).isEqualTo(Long.valueOf(12));
     }
 
     @Test
     public void shouldDecrement() {
         sortedSet.add(BRAZIL, 10);
         Number points = sortedSet.decrement(BRAZIL, 2);
-        assertEquals(Long.valueOf(8), Long.valueOf(points.longValue()));
+        assertThat(Long.valueOf(points.longValue())).isEqualTo(Long.valueOf(8));
     }
 
     @Test
     public void shouldRemoveMember() {
         sortedSet.add(BRAZIL, 10);
         sortedSet.remove(BRAZIL);
-        assertEquals(0, sortedSet.size());
+        assertThat(sortedSet.size()).isEqualTo(0);
     }
 
     @Test
@@ -115,7 +112,7 @@ public class DefaultSortedSetTest {
         sortedSet.add(BRAZIL, 10);
         sortedSet.expire(Duration.ofSeconds(1));
         Thread.sleep(2_000L);
-        assertEquals(0, sortedSet.size());
+        assertThat(sortedSet.size()).isEqualTo(0);
     }
 
     @Test
@@ -124,7 +121,7 @@ public class DefaultSortedSetTest {
         sortedSet.expire(Duration.ofSeconds(1));
         sortedSet.persist();
         Thread.sleep(2_000L);
-        assertEquals(1, sortedSet.size());
+        assertThat(sortedSet.size()).isEqualTo(1);
     }
 
     @Test

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerFactoryTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerFactoryTest.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -45,31 +45,31 @@ public class RedisBucketManagerFactoryTest {
     @Test
     public void shouldCreateKeyValueEntityManager() {
         BucketManager keyValueEntityManager = managerFactory.apply(BUCKET_NAME);
-        assertNotNull(keyValueEntityManager);
+        assertThat(keyValueEntityManager).isNotNull();
     }
 
     @Test
     public void shouldCreateMap() {
         Map<String, String> map = managerFactory.getMap(BUCKET_NAME, String.class, String.class);
-        assertNotNull(map);
+        assertThat(map).isNotNull();
     }
 
     @Test
     public void shouldCreateSet() {
         Set<String> set = managerFactory.getSet(BUCKET_NAME, String.class);
-        assertNotNull(set);
+        assertThat(set).isNotNull();
     }
 
     @Test
     public void shouldCreateList() {
         List<String> list = managerFactory.getList(BUCKET_NAME, String.class);
-        assertNotNull(list);
+        assertThat(list).isNotNull();
     }
 
     @Test
     public void shouldCreateQueue() {
         Queue<String> queue = managerFactory.getQueue(BUCKET_NAME, String.class);
-        assertNotNull(queue);
+        assertThat(queue).isNotNull();
     }
 
 }

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerTest.java
@@ -35,10 +35,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisBucketManagerTest {
@@ -64,28 +60,28 @@ public class RedisBucketManagerTest {
     public void shouldPutValue() {
         keyValueEntityManager.put("otavio", userOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     public void shouldPutKeyValue() {
         keyValueEntityManager.put(keyValueOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     public void shouldPutIterableKeyValue() {
         keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
     @Test
@@ -93,15 +89,15 @@ public class RedisBucketManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
     }
 
     @Test
     public void shouldRemoveKey() {
         keyValueEntityManager.put(keyValueOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -113,7 +109,7 @@ public class RedisBucketManagerTest {
                 .map(value -> value.get(User.class)).collect(Collectors.toList()))
                 .contains(userOtavio, userSoro);
         keyValueEntityManager.delete(keys);
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationTest.java
@@ -17,14 +17,14 @@ package org.eclipse.jnosql.databases.redis.communication;
 
 import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class RedisConfigurationTest {
 
@@ -40,23 +40,23 @@ public class RedisConfigurationTest {
         Map<String, String> map = new HashMap<>();
         map.put("redis-master-hoster", "localhost");
         BucketManagerFactory managerFactory = configuration.getManagerFactory(map);
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
 
     @Test
     public void shouldReturnFromConfiguration() {
         KeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof KeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof KeyValueConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         RedisConfiguration configuration = KeyValueConfiguration
                 .getConfiguration(RedisConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof RedisConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof RedisConfiguration).isTrue();
     }
 
 }

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListStringTest.java
@@ -27,10 +27,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisListStringTest {
@@ -50,37 +46,37 @@ public class RedisListStringTest {
 
     @Test
     public void shouldReturnsList() {
-        assertNotNull(fruits);
+        assertThat(fruits).isNotNull();
     }
 
     @Test
     public void shouldAddList() {
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
         fruits.add("banana");
-        assertFalse(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isFalse();
         String banana = fruits.getFirst();
-        assertNotNull(banana);
-        assertEquals(banana, "banana");
+        assertThat(banana).isNotNull();
+        assertThat("banana").isEqualTo(banana);
     }
     
     @Test
     public void shouldAddAll() {
         fruits.addAll(Arrays.asList("banana", "orange"));
-        assertEquals(2, fruits.size());
+        assertThat(fruits.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldSetList() {
         fruits.add("banana");
         fruits.addFirst("orange");
-        assertEquals(2, fruits.size());
+        assertThat(fruits.size()).isEqualTo(2);
 
-        assertEquals(fruits.get(0), "orange");
-        assertEquals(fruits.get(1), "banana");
+        assertThat("orange").isEqualTo(fruits.get(0));
+        assertThat("banana").isEqualTo(fruits.get(1));
 
         fruits.set(0, "waterMelon");
-        assertEquals(fruits.get(0), "waterMelon");
-        assertEquals(fruits.get(1), "banana");
+        assertThat("waterMelon").isEqualTo(fruits.get(0));
+        assertThat("banana").isEqualTo(fruits.get(1));
 
     }
 
@@ -100,12 +96,12 @@ public class RedisListStringTest {
         fruits.add("banana");
         fruits.add("watermellon");
         fruits.add("banana");
-        assertEquals(1, fruits.indexOf("banana"));
-        assertEquals(3, fruits.lastIndexOf("banana"));
+        assertThat(fruits.indexOf("banana")).isEqualTo(1);
+        assertThat(fruits.lastIndexOf("banana")).isEqualTo(3);
 
-        assertTrue(fruits.contains("banana"));
-        assertEquals(-1, fruits.indexOf("melon"));
-        assertEquals(-1, fruits.lastIndexOf("melon"));
+        assertThat(fruits.contains("banana")).isTrue();
+        assertThat(fruits.indexOf("melon")).isEqualTo(-1);
+        assertThat(fruits.lastIndexOf("melon")).isEqualTo(-1);
     }
 
     @Test
@@ -113,10 +109,10 @@ public class RedisListStringTest {
         fruits.add("orange");
         fruits.add("banana");
         fruits.add("watermellon");
-        assertTrue(fruits.contains("banana"));
-        assertFalse(fruits.contains("melon"));
-        assertTrue(fruits.containsAll(Arrays.asList("banana", "orange")));
-        assertFalse(fruits.containsAll(Arrays.asList("banana", "melon")));
+        assertThat(fruits.contains("banana")).isTrue();
+        assertThat(fruits.contains("melon")).isFalse();
+        assertThat(fruits.containsAll(Arrays.asList("banana", "orange"))).isTrue();
+        assertThat(fruits.containsAll(Arrays.asList("banana", "melon"))).isFalse();
 
     }
 
@@ -129,14 +125,14 @@ public class RedisListStringTest {
         for (String fruiCart : fruits) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         fruits.removeFirst();
         fruits.removeFirst();
         count = 0;
         for (String fruiCart : fruits) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
@@ -146,7 +142,7 @@ public class RedisListStringTest {
         fruits.add("watermellon");
 
         fruits.clear();
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListTest.java
@@ -29,11 +29,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisListTest {
@@ -57,31 +53,31 @@ public class RedisListTest {
 
     @Test
     public void shouldReturnsList() {
-        assertNotNull(fruits);
+        assertThat(fruits).isNotNull();
     }
 
     @Test
     public void shouldAddList() {
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
         fruits.add(banana);
-        assertFalse(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isFalse();
         ProductCart banana = fruits.getFirst();
-        assertNotNull(banana);
-        assertEquals(banana.name(), "banana");
+        assertThat(banana).isNotNull();
+        assertThat("banana").isEqualTo(banana.name());
     }
 
     @Test
     public void shouldSetList() {
         fruits.add(banana);
         fruits.addFirst(orange);
-        assertEquals(2, fruits.size());
+        assertThat(fruits.size()).isEqualTo(2);
 
-        assertEquals(fruits.get(0).name(), "orange");
-        assertEquals(fruits.get(1).name(), "banana");
+        assertThat("orange").isEqualTo(fruits.get(0).name());
+        assertThat("banana").isEqualTo(fruits.get(1).name());
 
         fruits.set(0, waterMelon);
-        assertEquals(fruits.get(0).name(), "waterMelon");
-        assertEquals(fruits.get(1).name(), "banana");
+        assertThat("waterMelon").isEqualTo(fruits.get(0).name());
+        assertThat("banana").isEqualTo(fruits.get(1).name());
     }
 
     @Test
@@ -101,7 +97,7 @@ public class RedisListTest {
         fruits.add(waterMelon);
 
         fruits.removeAll(Arrays.asList(orange, banana));
-        assertEquals(1, fruits.size());
+        assertThat(fruits.size()).isEqualTo(1);
         assertThat(fruits).contains(waterMelon);
     }
 
@@ -121,12 +117,12 @@ public class RedisListTest {
         fruits.add(banana);
         fruits.add(new ProductCart("watermellon", BigDecimal.ONE));
         fruits.add(banana);
-        assertEquals(1, fruits.indexOf(banana));
-        assertEquals(3, fruits.lastIndexOf(banana));
+        assertThat(fruits.indexOf(banana)).isEqualTo(1);
+        assertThat(fruits.lastIndexOf(banana)).isEqualTo(3);
 
-        assertTrue(fruits.contains(banana));
-        assertEquals(-1, fruits.indexOf(melon));
-        assertEquals(-1, fruits.lastIndexOf(melon));
+        assertThat(fruits.contains(banana)).isTrue();
+        assertThat(fruits.indexOf(melon)).isEqualTo(-1);
+        assertThat(fruits.lastIndexOf(melon)).isEqualTo(-1);
     }
 
     @Test
@@ -134,10 +130,10 @@ public class RedisListTest {
         fruits.add(orange);
         fruits.add(banana);
         fruits.add(waterMelon);
-        assertTrue(fruits.contains(banana));
-        assertFalse(fruits.contains(melon));
-        assertTrue(fruits.containsAll(Arrays.asList(banana, orange)));
-        assertFalse(fruits.containsAll(Arrays.asList(banana, melon)));
+        assertThat(fruits.contains(banana)).isTrue();
+        assertThat(fruits.contains(melon)).isFalse();
+        assertThat(fruits.containsAll(Arrays.asList(banana, orange))).isTrue();
+        assertThat(fruits.containsAll(Arrays.asList(banana, melon))).isFalse();
     }
 
     @SuppressWarnings("unused")
@@ -149,14 +145,14 @@ public class RedisListTest {
         for (ProductCart fruiCart : fruits) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         fruits.removeFirst();
         fruits.removeFirst();
         count = 0;
         for (ProductCart fruiCart : fruits) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
@@ -166,12 +162,12 @@ public class RedisListTest {
         fruits.add(waterMelon);
 
         fruits.clear();
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldThrowExceptionRetainAll() {
-        assertThrows(UnsupportedOperationException.class, () -> fruits.retainAll(Collections.singletonList(orange)));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> fruits.retainAll(Collections.singletonList(orange)));
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapStringTest.java
@@ -28,11 +28,6 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisMapStringTest {
@@ -54,21 +49,21 @@ public class RedisMapStringTest {
 
     @Test
     public void shouldPutAndGetMap() {
-        assertNotNull(vertebrates.put(MAMMALS, MAMMALS));
+        assertThat(vertebrates.put(MAMMALS, MAMMALS)).isNotNull();
         String species = vertebrates.get(MAMMALS);
-        assertNotNull(species);
-        assertEquals(MAMMALS, vertebrates.get(MAMMALS));
-        assertEquals(1, vertebrates.size());
+        assertThat(species).isNotNull();
+        assertThat(vertebrates.get(MAMMALS)).isEqualTo(MAMMALS);
+        assertThat(vertebrates.size()).isEqualTo(1);
     }
 
     @Test
     public void shouldVerifyExist() {
         vertebrates.put(MAMMALS, MAMMALS);
-        assertTrue(vertebrates.containsKey(MAMMALS));
-        assertFalse(vertebrates.containsKey(FISHES));
+        assertThat(vertebrates.containsKey(MAMMALS)).isTrue();
+        assertThat(vertebrates.containsKey(FISHES)).isFalse();
 
-        assertTrue(vertebrates.containsValue(MAMMALS));
-        assertFalse(vertebrates.containsValue(FISHES));
+        assertThat(vertebrates.containsValue(MAMMALS)).isTrue();
+        assertThat(vertebrates.containsValue(FISHES)).isFalse();
     }
 
     @Test
@@ -80,12 +75,12 @@ public class RedisMapStringTest {
         Set<String> keys = vertebrates.keySet();
         Collection<String> collectionSpecies = vertebrates.values();
 
-        assertEquals(3, keys.size());
-        assertEquals(3, collectionSpecies.size());
-        assertNotNull(vertebrates.remove(MAMMALS));
-        assertNull(vertebrates.remove(MAMMALS));
-        assertNull(vertebrates.get(MAMMALS));
-        assertEquals(2, vertebrates.size());
+        assertThat(keys.size()).isEqualTo(3);
+        assertThat(collectionSpecies.size()).isEqualTo(3);
+        assertThat(vertebrates.remove(MAMMALS)).isNotNull();
+        assertThat(vertebrates.remove(MAMMALS)).isNull();
+        assertThat(vertebrates.get(MAMMALS)).isNull();
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @Test
@@ -95,7 +90,7 @@ public class RedisMapStringTest {
         vertebrates.put(AMPHIBIANS, AMPHIBIANS);
 
         vertebrates.remove(FISHES);
-        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates.size()).isEqualTo(2);
         assertThat(vertebrates).isNotIn(FISHES);
     }
 
@@ -105,7 +100,7 @@ public class RedisMapStringTest {
         vertebrates.put(FISHES, FISHES);
 
         vertebrates.clear();
-        assertTrue(vertebrates.isEmpty());
+        assertThat(vertebrates.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapTest.java
@@ -29,11 +29,6 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisMapTest {
@@ -54,11 +49,11 @@ public class RedisMapTest {
 
     @Test
     public void shouldPutAndGetMap() {
-        assertNotNull(vertebrates.put("mammals", mammals));
+        assertThat(vertebrates.put("mammals", mammals)).isNotNull();
         Species species = vertebrates.get("mammals");
-        assertNotNull(species);
-        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
-        assertEquals(1, vertebrates.size());
+        assertThat(species).isNotNull();
+        assertThat(mammals.getAnimals().getFirst()).isEqualTo(species.getAnimals().getFirst());
+        assertThat(vertebrates.size()).isEqualTo(1);
     }
 
     @Test
@@ -68,17 +63,17 @@ public class RedisMapTest {
         toPutAll.put("fishes", fishes);
 
         vertebrates.putAll(toPutAll);
-        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldVerifyExist() {
         vertebrates.put("mammals", mammals);
-        assertTrue(vertebrates.containsKey("mammals"));
-        assertFalse(vertebrates.containsKey("redfish"));
+        assertThat(vertebrates.containsKey("mammals")).isTrue();
+        assertThat(vertebrates.containsKey("redfish")).isFalse();
 
-        assertTrue(vertebrates.containsValue(mammals));
-        assertFalse(vertebrates.containsValue(fishes));
+        assertThat(vertebrates.containsValue(mammals)).isTrue();
+        assertThat(vertebrates.containsValue(fishes)).isFalse();
     }
 
     @Test
@@ -90,12 +85,12 @@ public class RedisMapTest {
         Set<String> keys = vertebrates.keySet();
         Collection<Species> collectionSpecies = vertebrates.values();
 
-        assertEquals(3, keys.size());
-        assertEquals(3, collectionSpecies.size());
-        assertNotNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.get("mammals"));
-        assertEquals(2, vertebrates.size());
+        assertThat(keys.size()).isEqualTo(3);
+        assertThat(collectionSpecies.size()).isEqualTo(3);
+        assertThat(vertebrates.remove("mammals")).isNotNull();
+        assertThat(vertebrates.remove("mammals")).isNull();
+        assertThat(vertebrates.get("mammals")).isNull();
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @Test
@@ -105,7 +100,7 @@ public class RedisMapTest {
         vertebrates.put("amphibians", amphibians);
 
         vertebrates.remove("fishes");
-        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates.size()).isEqualTo(2);
         assertThat(vertebrates).isNotIn(fishes);
     }
 
@@ -115,7 +110,7 @@ public class RedisMapTest {
         vertebrates.put("fishes", fishes);
 
         vertebrates.clear();
-        assertTrue(vertebrates.isEmpty());
+        assertThat(vertebrates.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueStringTest.java
@@ -27,10 +27,7 @@ import java.util.Queue;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisQueueStringTest {
@@ -48,36 +45,36 @@ public class RedisQueueStringTest {
 
     @Test
     public void shouldPushInTheLine() {
-        assertTrue(lineBank.add("Otavio"));
-        assertEquals(1, lineBank.size());
+        assertThat(lineBank.add("Otavio")).isTrue();
+        assertThat(lineBank.size()).isEqualTo(1);
         String otavio = lineBank.poll();
-        assertEquals(otavio, "Otavio");
-        assertNull(lineBank.poll());
-        assertTrue(lineBank.isEmpty());
+        assertThat("Otavio").isEqualTo(otavio);
+        assertThat(lineBank.poll()).isNull();
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldPeekInTheLine() {
         lineBank.add("Otavio");
         String otavio = lineBank.peek();
-        assertNotNull(otavio);
-        assertNotNull(lineBank.peek());
+        assertThat(otavio).isNotNull();
+        assertThat(lineBank.peek()).isNotNull();
         String otavio2 = lineBank.remove();
-        assertEquals(otavio, otavio2);
+        assertThat(otavio2).isEqualTo(otavio);
         boolean happendException = false;
         try {
             lineBank.remove();
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @Test
     public void shouldElementInTheLine() {
         lineBank.add("Otavio");
-        assertNotNull(lineBank.element());
-        assertNotNull(lineBank.element());
+        assertThat(lineBank.element()).isNotNull();
+        assertThat(lineBank.element()).isNotNull();
         lineBank.remove("Otavio");
         boolean happendException = false;
         try {
@@ -85,7 +82,7 @@ public class RedisQueueStringTest {
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @SuppressWarnings("unused")
@@ -97,21 +94,21 @@ public class RedisQueueStringTest {
         for (String line : lineBank) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         lineBank.remove();
         lineBank.remove();
         count = 0;
         for (String line : lineBank) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
     public void shouldClear() {
         lineBank.add("Otavio");
         lineBank.clear();
-        assertTrue(lineBank.isEmpty());
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueTest.java
@@ -27,10 +27,7 @@ import java.util.Queue;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisQueueTest {
@@ -48,36 +45,36 @@ public class RedisQueueTest {
 
     @Test
     public void shouldPushInTheLine() {
-        assertTrue(lineBank.add(new LineBank("Otavio", 25)));
-        assertEquals(1, lineBank.size());
+        assertThat(lineBank.add(new LineBank("Otavio", 25))).isTrue();
+        assertThat(lineBank.size()).isEqualTo(1);
         LineBank otavio = lineBank.poll();
-        assertEquals(otavio.name(), "Otavio");
-        assertNull(lineBank.poll());
-        assertTrue(lineBank.isEmpty());
+        assertThat("Otavio").isEqualTo(otavio.name());
+        assertThat(lineBank.poll()).isNull();
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldPeekInTheLine() {
         lineBank.add(new LineBank("Otavio", 25));
         LineBank otavio = lineBank.peek();
-        assertNotNull(otavio);
-        assertNotNull(lineBank.peek());
+        assertThat(otavio).isNotNull();
+        assertThat(lineBank.peek()).isNotNull();
         LineBank otavio2 = lineBank.remove();
-        assertEquals(otavio.name(), otavio2.name());
+        assertThat(otavio2.name()).isEqualTo(otavio.name());
         boolean happendException = false;
         try {
             lineBank.remove();
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @Test
     public void shouldElementInTheLine() {
         lineBank.add(new LineBank("Otavio", 25));
-        assertNotNull(lineBank.element());
-        assertNotNull(lineBank.element());
+        assertThat(lineBank.element()).isNotNull();
+        assertThat(lineBank.element()).isNotNull();
         lineBank.remove(new LineBank("Otavio", 25));
         boolean happendException = false;
         try {
@@ -85,7 +82,7 @@ public class RedisQueueTest {
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @SuppressWarnings("unused")
@@ -97,21 +94,21 @@ public class RedisQueueTest {
         for (LineBank line : lineBank) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         lineBank.remove();
         lineBank.remove();
         count = 0;
         for (LineBank line : lineBank) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
     public void shouldClear() {
         lineBank.add(new LineBank("Otavio", 25));
         lineBank.clear();
-        assertTrue(lineBank.isEmpty());
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetStringTest.java
@@ -27,8 +27,7 @@ import java.util.Set;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisSetStringTest {
@@ -47,17 +46,17 @@ public class RedisSetStringTest {
     @Test
     public void shouldAddUsers() {
         users.add("otaviojava");
-        assertEquals(1, users.size());
+        assertThat(users.size()).isEqualTo(1);
 
         String user = users.iterator().next();
-        assertEquals("otaviojava", user);
+        assertThat(user).isEqualTo("otaviojava");
     }
 
     @Test
     public void shouldRemoveSet() {
         users.add("otaviojava");
         users.remove("otaviojava");
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
     }
 
 
@@ -73,27 +72,27 @@ public class RedisSetStringTest {
         for (String user : users) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         users.remove("otaviojava");
         users.remove("felipe");
         count = 0;
         for (String user : users) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
     public void shouldClear() {
         users.add("otaviojava");
         users.clear();
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldContains() {
         users.add("otaviojava");
-        assertTrue(users.contains("otaviojava"));
+        assertThat(users.contains("otaviojava")).isTrue();
     }
 
     @Test
@@ -101,7 +100,7 @@ public class RedisSetStringTest {
         users.add("otaviojava");
         users.add("furlaneto");
         users.add("joao");
-        assertTrue(users.containsAll(Arrays.asList("furlaneto", "otaviojava")));
+        assertThat(users.containsAll(Arrays.asList("furlaneto", "otaviojava"))).isTrue();
     }
 
     @Test
@@ -109,7 +108,7 @@ public class RedisSetStringTest {
         users.add("otaviojava");
         users.add("furlaneto");
         users.add("joao");
-        assertEquals(3, users.size());
+        assertThat(users.size()).isEqualTo(3);
     }
     
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetTest.java
@@ -29,9 +29,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisSetTest {
@@ -50,7 +48,7 @@ public class RedisSetTest {
     @Test
     public void shouldAddUsers() {
         users.add(userOtavioJava);
-        assertEquals(1, users.size());
+        assertThat(users.size()).isEqualTo(1);
     }
 
     @Test
@@ -59,7 +57,7 @@ public class RedisSetTest {
         users.add(felipe);
         users.remove(felipe);
 
-        assertEquals(1, users.size());
+        assertThat(users.size()).isEqualTo(1);
         assertThat(users).isNotIn(felipe);
    }
 
@@ -69,7 +67,7 @@ public class RedisSetTest {
         users.add(felipe);
         users.removeAll(Arrays.asList(felipe, userOtavioJava));
 
-        assertEquals(0, users.size());
+        assertThat(users.size()).isEqualTo(0);
     }
 
     @SuppressWarnings("unused")
@@ -84,27 +82,27 @@ public class RedisSetTest {
         for (User user : users) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
     }
 
     @Test
     public void shouldContains() {
         users.add(userOtavioJava);
-        assertTrue(users.contains(userOtavioJava));
+        assertThat(users.contains(userOtavioJava)).isTrue();
     }
 
     @Test
     public void shouldContainsAll() {
         users.add(userOtavioJava);
         users.add(felipe);
-        assertTrue(users.containsAll(Arrays.asList(userOtavioJava, felipe)));
+        assertThat(users.containsAll(Arrays.asList(userOtavioJava, felipe))).isTrue();
     }
 
     @Test
     public void shouldReturnSize() {
         users.add(userOtavioJava);
         users.add(felipe);
-        assertEquals(2, users.size());
+        assertThat(users.size()).isEqualTo(2);
     }
 
     @Test
@@ -113,12 +111,12 @@ public class RedisSetTest {
         users.add(felipe);
 
         users.clear();
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldThrowExceptionRetainAll() {
-        assertThrows(UnsupportedOperationException.class, () -> users.retainAll(Collections.singletonList(userOtavioJava)));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> users.retainAll(Collections.singletonList(userOtavioJava)));
     }
 
     @AfterEach

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisUtilsTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisUtilsTest.java
@@ -17,18 +17,19 @@ package org.eclipse.jnosql.databases.redis.communication;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class RedisUtilsTest {
 
     @Test
     public void shouldReturnNameSpace() {
-        assertEquals("namespace:key", RedisUtils.createKeyWithNameSpace("key", "namespace"));
+        assertThat(RedisUtils.createKeyWithNameSpace("key", "namespace")).isEqualTo("namespace:key");
     }
 
     @Test
     public void shouldThrowWithNullKey() {
-        assertThrows(IrregularKeyValue.class, () -> RedisUtils.createKeyWithNameSpace(null, ""));
+        assertThatExceptionOfType(IrregularKeyValue.class).isThrownBy(() -> RedisUtils.createKeyWithNameSpace(null, ""));
     }
 }

--- a/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManagerTest.java
+++ b/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManagerTest.java
@@ -32,10 +32,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -62,16 +58,16 @@ public class RiakBucketManagerTest {
     public void shouldPutValue() {
         keyValueEntityManager.put("otavio", userOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     public void shouldPutKeyValue() {
         keyValueEntityManager.put(keyValueOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
@@ -80,12 +76,12 @@ public class RiakBucketManagerTest {
 
         keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
     @Test
@@ -93,7 +89,7 @@ public class RiakBucketManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
 
 
     }
@@ -102,9 +98,9 @@ public class RiakBucketManagerTest {
     public void shouldRemoveKey() {
 
         keyValueEntityManager.put(keyValueOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -117,6 +113,6 @@ public class RiakBucketManagerTest {
                 .collect(Collectors.toList())).contains(userOtavio, userSoro);
         keyValueEntityManager.delete(keys);
         Iterable<Value> users = values;
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 }

--- a/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakKeyValueConfigurationTest.java
+++ b/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakKeyValueConfigurationTest.java
@@ -16,11 +16,12 @@
 package org.eclipse.jnosql.databases.riak.communication;
 
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class RiakKeyValueConfigurationTest {
 
@@ -33,22 +34,22 @@ public class RiakKeyValueConfigurationTest {
 
     @Test
     public void shouldReturnErrorWhenNodeIsNull() {
-        assertThrows(NullPointerException.class, () -> configuration.add((String) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.add((String) null));
     }
 
 
     @Test
     public void shouldReturnFromConfiguration() {
         KeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof KeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof KeyValueConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         RiakKeyValueConfiguration configuration = KeyValueConfiguration
                 .getConfiguration(RiakKeyValueConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof RiakKeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof RiakKeyValueConfiguration).isTrue();
     }
 }

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
@@ -15,12 +15,10 @@
 
 package org.eclipse.jnosql.databases.solr.communication;
 
-import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
 import org.eclipse.jnosql.communication.semistructured.Element;
 import org.eclipse.jnosql.communication.semistructured.Elements;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -41,15 +39,13 @@ import java.util.stream.StreamSupport;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 @DisplayName("Default Solr Document Manager")
@@ -75,20 +71,22 @@ public class DefaultSolrDocumentManagerTest {
         void shouldInsert() {
             var entity = getEntity();
             var documentEntity = entityManager.insert(entity);
-            assertTrue(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals(ID)));
+            assertThat(documentEntity.elements().stream().map(Element::name))
+                    .contains(ID);
         }
 
         @Test
         @DisplayName("Should reject insert with TTL because Solr does not support TTL saves")
         void shouldThrowExceptionWhenInsertWithTTL() {
-            assertThrows(UnsupportedOperationException.class,
-                    () -> entityManager.insert(getEntity(), Duration.ofSeconds(10)));
+            assertThatExceptionOfType(UnsupportedOperationException.class)
+                    .isThrownBy(() -> entityManager.insert(getEntity(), Duration.ofSeconds(10)));
         }
 
         @Test
         @DisplayName("Should reject null entity on insert")
         void shouldThrowExceptionWhenInsertIsNull() {
-            assertThrows(NullPointerException.class, () -> entityManager.insert((CommunicationEntity) null));
+            assertThatNullPointerException()
+                    .isThrownBy(() -> entityManager.insert((CommunicationEntity) null));
         }
 
         @Test
@@ -98,7 +96,7 @@ public class DefaultSolrDocumentManagerTest {
             entity.add(Element.of("name", null));
             var documentEntity = entityManager.insert(entity);
             Optional<Element> name = documentEntity.find("name");
-            SoftAssertions.assertSoftly(soft -> {
+            assertSoftly(soft -> {
                 soft.assertThat(name).isPresent();
                 soft.assertThat(name).get().extracting(Element::name).isEqualTo("name");
                 soft.assertThat(name).get().extracting(Element::get).isNull();
@@ -110,7 +108,8 @@ public class DefaultSolrDocumentManagerTest {
         void shouldReturnErrorWhenSaveSubDocument() {
             var entity = getEntity();
             entity.add(Element.of("phones", Element.of("mobile", "1231231")));
-            Assertions.assertThrows(SolrException.class, () -> entityManager.insert(entity));
+            assertThatExceptionOfType(SolrException.class)
+                    .isThrownBy(() -> entityManager.insert(entity));
         }
     }
 
@@ -126,13 +125,14 @@ public class DefaultSolrDocumentManagerTest {
             var newField = Elements.of("newField", "10");
             entity.add(newField);
             var updated = entityManager.update(entity);
-            assertEquals(newField, updated.find("newField").get());
+            assertThat(updated.find("newField")).get().isEqualTo(newField);
         }
 
         @Test
         @DisplayName("Should reject null entity on update")
         void shouldThrowExceptionWhenUpdateIsNull() {
-            assertThrows(NullPointerException.class, () -> entityManager.update((CommunicationEntity) null));
+            assertThatNullPointerException()
+                    .isThrownBy(() -> entityManager.update((CommunicationEntity) null));
         }
 
         @Test
@@ -142,7 +142,7 @@ public class DefaultSolrDocumentManagerTest {
             entity.add(Element.of("name", null));
             var documentEntity = entityManager.update(entity);
             Optional<Element> name = documentEntity.find("name");
-            SoftAssertions.assertSoftly(soft -> {
+            assertSoftly(soft -> {
                 soft.assertThat(name).isPresent();
                 soft.assertThat(name).get().extracting(Element::name).isEqualTo("name");
                 soft.assertThat(name).get().extracting(Element::get).isNull();
@@ -168,13 +168,14 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             entityManager.delete(deleteQuery);
-            assertTrue(entityManager.select(query).findAny().isEmpty());
+            assertThat(entityManager.select(query).findAny()).isEmpty();
         }
 
         @Test
         @DisplayName("Should reject null delete query")
         void shouldThrowExceptionWhenDeleteQueryIsNull() {
-            assertThrows(NullPointerException.class, () -> entityManager.delete(null));
+            assertThatNullPointerException()
+                    .isThrownBy(() -> entityManager.delete(null));
         }
     }
 
@@ -193,11 +194,11 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entities = entityManager.select(query).toList();
-            assertFalse(entities.isEmpty());
+            assertThat(entities).isNotEmpty();
             final CommunicationEntity result = entities.getFirst();
 
-            assertEquals(entity.find("name").get(), result.find("name").get());
-            assertEquals(entity.find("city").get(), result.find("city").get());
+            assertThat(result.find("name")).get().isEqualTo(entity.find("name").get());
+            assertThat(result.find("city")).get().isEqualTo(entity.find("city").get());
         }
 
         @Test
@@ -212,11 +213,11 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entities = entityManager.select(query).toList();
-            assertFalse(entities.isEmpty());
+            assertThat(entities).isNotEmpty();
             final CommunicationEntity result = entities.getFirst();
 
-            assertEquals(entity.find("name").get(), result.find("name").get());
-            assertEquals(entity.find("city").get(), result.find("city").get());
+            assertThat(result.find("name")).get().isEqualTo(entity.find("name").get());
+            assertThat(result.find("city")).get().isEqualTo(entity.find("city").get());
         }
 
         @Test
@@ -231,10 +232,10 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entities = entityManager.select(query).toList();
-            assertFalse(entities.isEmpty());
+            assertThat(entities).isNotEmpty();
             final CommunicationEntity result = entities.getFirst();
-            assertEquals(entity.find("name").get(), result.find("name").get());
-            assertEquals(entity.find("city").get(), result.find("city").get());
+            assertThat(result.find("name")).get().isEqualTo(entity.find("name").get());
+            assertThat(result.find("city")).get().isEqualTo(entity.find("city").get());
         }
 
         @Test
@@ -250,7 +251,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entitiesFound = entityManager.select(query).toList();
-            assertEquals(3, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(3);
         }
 
         @Test
@@ -262,7 +263,7 @@ public class DefaultSolrDocumentManagerTest {
             var query = select().from(COLLECTION_NAME)
                     .where("name").not().eq("Lucas").build();
             List<CommunicationEntity> entitiesFound = entityManager.select(query).toList();
-            assertEquals(2, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(2);
         }
 
         @Test
@@ -279,7 +280,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-            assertEquals(2, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(2);
             assertThat(entitiesFound).isNotIn(entities.getFirst());
         }
 
@@ -296,7 +297,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entitiesFound = entityManager.select(query).toList();
-            assertEquals(2, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(2);
         }
 
         @Test
@@ -312,7 +313,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entitiesFound = entityManager.select(query).toList();
-            assertEquals(2, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(2);
         }
 
         @Test
@@ -328,7 +329,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entitiesFound = entityManager.select(query).toList();
-            assertEquals(2, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(2);
         }
 
         @Test
@@ -343,7 +344,7 @@ public class DefaultSolrDocumentManagerTest {
                     .and("type").eq("V")
                     .build();
 
-            assertEquals(3, (int) entityManager.select(query).count());
+            assertThat(entityManager.select(query).count()).isEqualTo(3);
         }
 
         @Test
@@ -361,7 +362,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-            assertEquals(2, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(2);
             assertThat(entitiesFound).isNotIn(entities.getFirst());
 
             query = select().from(COLLECTION_NAME)
@@ -371,7 +372,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             entitiesFound = entityManager.select(query).collect(Collectors.toList());
-            assertTrue(entitiesFound.isEmpty());
+            assertThat(entitiesFound).isEmpty();
         }
 
         @Test
@@ -389,7 +390,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-            assertEquals(1, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(1);
             assertThat(entitiesFound).isNotIn(entities.getFirst());
 
             query = select().from(COLLECTION_NAME)
@@ -399,7 +400,7 @@ public class DefaultSolrDocumentManagerTest {
                     .build();
 
             entitiesFound = entityManager.select(query).collect(Collectors.toList());
-            assertEquals(2, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(2);
             entityManager.delete(deleteQuery);
         }
 
@@ -442,13 +443,14 @@ public class DefaultSolrDocumentManagerTest {
             entityManager.insert(getEntity());
             var query = select().from(COLLECTION_NAME).build();
             List<CommunicationEntity> entities = entityManager.select(query).toList();
-            assertFalse(entities.isEmpty());
+            assertThat(entities).isNotEmpty();
         }
 
         @Test
         @DisplayName("Should reject null select query")
         void shouldThrowExceptionWhenSelectQueryIsNull() {
-            assertThrows(NullPointerException.class, () -> entityManager.select(null));
+            assertThatNullPointerException()
+                    .isThrownBy(() -> entityManager.select(null));
         }
     }
 
@@ -464,7 +466,7 @@ public class DefaultSolrDocumentManagerTest {
             entityManager.insert(getEntitiesWithValues());
 
             List<CommunicationEntity> entitiesFound = entityManager.solr("age:22 AND type:V AND _entity:person");
-            assertEquals(1, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(1);
         }
 
         @Test
@@ -481,7 +483,7 @@ public class DefaultSolrDocumentManagerTest {
 
             List<CommunicationEntity> entitiesFound = entityManager.solr("age:@age AND type:@type AND _entity:@entity",
                     params);
-            assertEquals(1, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(1);
         }
 
         @Test
@@ -496,7 +498,7 @@ public class DefaultSolrDocumentManagerTest {
             params.put("age", 22);
 
             List<CommunicationEntity> entitiesFound = entityManager.solr("age:@age AND age:@age", params);
-            assertEquals(1, entitiesFound.size());
+            assertThat(entitiesFound).hasSize(1);
         }
     }
 
@@ -562,10 +564,14 @@ public class DefaultSolrDocumentManagerTest {
             List<CommunicationEntity> entities = entityManager.select(select().from("download")
                     .where(ID).eq(id).build()).toList();
 
-            assertEquals(1, entities.size());
+            assertThat(entities).hasSize(1);
             var documentEntity = entities.getFirst();
-            assertEquals(date, documentEntity.find("date").get().get(Date.class));
-            assertEquals(now, documentEntity.find("date").get().get(LocalDate.class));
+            assertThat(documentEntity.find("date")).get()
+                    .extracting(element -> element.get(Date.class))
+                    .isEqualTo(date);
+            assertThat(documentEntity.find("date")).get()
+                    .extracting(element -> element.get(LocalDate.class))
+                    .isEqualTo(now);
         }
     }
 

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfigurationTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfigurationTest.java
@@ -16,10 +16,11 @@
 package org.eclipse.jnosql.databases.solr.communication;
 
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class SolrDocumentConfigurationTest {
 
@@ -27,23 +28,23 @@ public class SolrDocumentConfigurationTest {
     @Test
     public void shouldReturnErrorWhenSettingsIsNull() {
         var configuration = new SolrDocumentConfiguration();
-        assertThrows(NullPointerException.class, () -> configuration.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> configuration.apply(null));
     }
 
 
     @Test
     public void shouldReturnFromConfiguration() {
         var configuration = DatabaseConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof DatabaseConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof DatabaseConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         SolrDocumentConfiguration configuration = DatabaseConfiguration
                 .getConfiguration(SolrDocumentConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof SolrDocumentConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof SolrDocumentConfiguration).isTrue();
     }
 
 }

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrExtensionTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrExtensionTest.java
@@ -24,10 +24,11 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class,
@@ -48,8 +49,8 @@ public class SolrExtensionTest {
 
         @Test
         @DisplayName("Should provide a Solr repository bean")
-        public void shouldSaveOrientDB() {
-            Assertions.assertNotNull(repository);
+        public void shouldProvideRepositoryBean() {
+            assertThat(repository).isNotNull();
         }
     }
 }

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryProxyTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryProxyTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -104,7 +104,7 @@ public class SolrRepositoryProxyTest {
 
             Map<String, Object> value = captor.getValue();
 
-            assertEquals("Ada", value.get("name"));
+            assertThat(value.get("name")).isEqualTo("Ada");
         }
     }
 

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
@@ -48,11 +48,7 @@ import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
 import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete;
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
 import static org.eclipse.jnosql.databases.tinkerpop.communication.TinkerpopGraphDatabaseManager.ID;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
@@ -110,7 +106,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         entity.add("name", name);
         entity.add("age", age);
         var communicationEntity = entityManager.insert(entity);
-        assertNotNull(communicationEntity);
+        assertThat(communicationEntity).isNotNull();
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(communicationEntity.find("name", String.class)).get().isEqualTo(name);
@@ -136,7 +132,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         var communicationEntities = StreamSupport
                 .stream(entityManager.insert(List.of(entity, entity2)).spliterator(), false).toList();
 
-        assertNotNull(communicationEntities);
+        assertThat(communicationEntities).isNotNull();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(communicationEntities).hasSize(2);
             softly.assertThat(communicationEntities.getFirst().find("name", String.class)).get().isEqualTo(name);
@@ -154,14 +150,14 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
     void shouldInsert() {
         var entity = getEntity();
         var documentEntity = entityManager.insert(entity);
-        assertTrue(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals(ID)));
+        assertThat(documentEntity.elements().stream().map(Element::name).anyMatch(s -> s.equals(ID))).isTrue();
     }
 
     @Test
     void shouldThrowExceptionWhenInsertWithTTL() {
         var entity = getEntity();
         var ttl = Duration.ofSeconds(10);
-        assertThrows(UnsupportedOperationException.class, () -> entityManager.insert(entity, ttl));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> entityManager.insert(entity, ttl));
     }
 
     @Test
@@ -170,7 +166,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         var newField = Elements.of("newField", "10");
         entity.add(newField);
         var updated = entityManager.update(entity);
-        assertEquals(newField, updated.find("newField").orElseThrow());
+        assertThat(updated.find("newField").orElseThrow()).isEqualTo(newField);
     }
 
     @Test
@@ -186,7 +182,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         entityManager.delete(deleteQuery);
-        assertTrue(entityManager.select(query).findAny().isEmpty());
+        assertThat(entityManager.select(query).findAny().isEmpty()).isTrue();
     }
 
     @Test
@@ -199,7 +195,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         var entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -215,7 +211,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -230,7 +226,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         assertThat(entities).contains(entity);
     }
 
@@ -247,7 +243,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
@@ -264,7 +260,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
     }
 
@@ -282,7 +278,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).contains(entities.getFirst());
     }
 
@@ -299,7 +295,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).contains(entities.get(0), entities.get(2));
     }
 
@@ -354,7 +350,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
@@ -364,7 +360,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertTrue(entitiesFound.isEmpty());
+        assertThat(entitiesFound.isEmpty()).isTrue();
 
     }
 
@@ -382,7 +378,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(1, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(1);
         assertThat(entitiesFound).isNotIn(entities.getFirst());
 
         query = select().from(COLLECTION_NAME)
@@ -392,7 +388,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
 
     }
 
@@ -409,7 +405,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         List<Integer> ages = entitiesFound.stream()
                 .map(e -> e.find("age").orElseThrow().get(Integer.class))
                 .collect(Collectors.toList());
@@ -426,7 +422,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         ages = entitiesFound.stream()
                 .map(e -> e.find("age").orElseThrow().get(Integer.class))
                 .collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(ages).contains(25, 23);
 
     }
@@ -436,7 +432,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         entityManager.insert(getEntity());
         SelectQuery query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
     }
 
     @Test
@@ -444,11 +440,11 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         entityManager.insert(getEntity());
         SelectQuery query = select().from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).collect(Collectors.toList());
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         DeleteQuery deleteQuery = delete().from(COLLECTION_NAME).build();
         entityManager.delete(deleteQuery);
         entities = entityManager.select(query).toList();
-        assertTrue(entities.isEmpty());
+        assertThat(entities.isEmpty()).isTrue();
     }
 
     @Test
@@ -456,9 +452,9 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         entityManager.insert(getEntity());
         SelectQuery query = select("name").from(COLLECTION_NAME).build();
         List<CommunicationEntity> entities = entityManager.select(query).toList();
-        assertFalse(entities.isEmpty());
+        assertThat(entities.isEmpty()).isFalse();
         final CommunicationEntity entity = entities.getFirst();
-        assertEquals(3, entity.size());
+        assertThat(entity.size()).isEqualTo(3);
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(entity.find("name")).isPresent();
             softly.assertThat(entity.find(ID)).isPresent();
@@ -522,11 +518,11 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
         var edge = entityManager.edge(person1, label, person2, properties);
 
-        assertNotNull(edge);
-        assertEquals(label, edge.label());
-        assertEquals(person1.find(ID).orElseThrow().get(), edge.source().find(ID).orElseThrow().get());
-        assertEquals(person2.find(ID).orElseThrow().get(), edge.target().find(ID).orElseThrow().get());
-        assertEquals(properties, edge.properties());
+        assertThat(edge).isNotNull();
+        assertThat(edge.label()).isEqualTo(label);
+        assertThat(edge.source().find(ID).orElseThrow().get()).isEqualTo(person1.find(ID).orElseThrow().get());
+        assertThat(edge.target().find(ID).orElseThrow().get()).isEqualTo(person2.find(ID).orElseThrow().get());
+        assertThat(edge.properties()).isEqualTo(properties);
     }
 
     @Test
@@ -553,7 +549,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
         entityManager.deleteEdge(edge.id());
 
         Optional<CommunicationEdge> foundEdge = entityManager.findEdgeById(edge.id());
-        assertFalse(foundEdge.isPresent());
+        assertThat(foundEdge.isPresent()).isFalse();
     }
 
     @Test
@@ -565,11 +561,11 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
 
         Optional<CommunicationEdge> foundEdge = entityManager.findEdgeById(edge.id());
 
-        assertTrue(foundEdge.isPresent());
-        assertEquals(edge.id(), foundEdge.get().id());
-        assertEquals(edge.label(), foundEdge.get().label());
-        assertEquals(edge.source().find(ID).orElseThrow().get(), foundEdge.get().source().find(ID).orElseThrow().get());
-        assertEquals(edge.target().find(ID).orElseThrow().get(), foundEdge.get().target().find(ID).orElseThrow().get());
+        assertThat(foundEdge.isPresent()).isTrue();
+        assertThat(foundEdge.get().id()).isEqualTo(edge.id());
+        assertThat(foundEdge.get().label()).isEqualTo(edge.label());
+        assertThat(foundEdge.get().source().find(ID).orElseThrow().get()).isEqualTo(edge.source().find(ID).orElseThrow().get());
+        assertThat(foundEdge.get().target().find(ID).orElseThrow().get()).isEqualTo(edge.target().find(ID).orElseThrow().get());
     }
 
     @Test
@@ -630,7 +626,7 @@ abstract class DefaultTinkerpopGraphDatabaseManagerTest {
                 .build();
 
         List<CommunicationEntity> entitiesFound = entityManager.select(query).collect(Collectors.toList());
-        assertEquals(2, entitiesFound.size());
+        assertThat(entitiesFound.size()).isEqualTo(2);
         assertThat(entitiesFound).contains(entities.get(0), entities.get(2));
     }
 

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplateTest.java
@@ -28,7 +28,6 @@ import org.eclipse.jnosql.databases.tinkerpop.mapping.entities.Human;
 import org.eclipse.jnosql.databases.tinkerpop.mapping.entities.Magazine;
 import org.eclipse.jnosql.mapping.PreparedStatement;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -43,14 +42,8 @@ import java.util.stream.StreamSupport;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public abstract class AbstractTinkerpopTemplateTest {
 
@@ -66,7 +59,7 @@ public abstract class AbstractTinkerpopTemplateTest {
 
     @Test
     void shouldReturnErrorWhenEntityIsNull() {
-        assertThrows(NullPointerException.class, () -> getGraphTemplate().insert(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> getGraphTemplate().insert(null));
     }
 
     @Test
@@ -82,16 +75,14 @@ public abstract class AbstractTinkerpopTemplateTest {
     void shouldReturnErrorWhenInsertWithTTL() {
         Human human = Human.builder().withAge()
                 .withName("Otavio").build();
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> getGraphTemplate().insert(human, Duration.ZERO));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> getGraphTemplate().insert(human, Duration.ZERO));
     }
 
     @Test
     void shouldReturnErrorWhenInsertIterableWithTTL() {
         Human human = Human.builder().withAge()
                 .withName("Otavio").build();
-        Assertions.assertThrows(UnsupportedOperationException.class,
-                () -> getGraphTemplate().insert(Collections.singleton(human), Duration.ZERO));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> getGraphTemplate().insert(Collections.singleton(human), Duration.ZERO));
     }
 
     @Test
@@ -108,7 +99,7 @@ public abstract class AbstractTinkerpopTemplateTest {
         final boolean allHasId = StreamSupport.stream(people.spliterator(), false)
                 .map(Human::getId)
                 .allMatch(Objects::nonNull);
-        assertTrue(allHasId);
+        assertThat(allHasId).isTrue();
     }
 
     @Test
@@ -116,12 +107,12 @@ public abstract class AbstractTinkerpopTemplateTest {
         Human human = Human.builder().withAge()
                 .withName("Otavio").build();
         Human updated = getGraphTemplate().insert(human);
-        assertSame(human, updated);
+        assertThat(updated).isSameAs(human);
     }
 
     @Test
     void shouldGetErrorWhenIdIsNullWhenUpdate() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
             Human human = Human.builder().withAge()
                     .withName("Otavio").build();
             getGraphTemplate().update(human);
@@ -130,7 +121,7 @@ public abstract class AbstractTinkerpopTemplateTest {
 
     @Test
     void shouldGetErrorWhenEntityIsNotSavedYet() {
-        assertThrows(EmptyResultException.class, () -> {
+        assertThatExceptionOfType(EmptyResultException.class).isThrownBy(() -> {
             Human human = Human.builder().withAge()
                     .withId("10")
                     .withName("Otavio").build();
@@ -151,7 +142,7 @@ public abstract class AbstractTinkerpopTemplateTest {
 
         Human update = getGraphTemplate().update(newHuman);
 
-        assertEquals(newHuman, update);
+        assertThat(update).isEqualTo(newHuman);
 
         getGraphTemplate().delete(update.getId());
     }
@@ -175,7 +166,7 @@ public abstract class AbstractTinkerpopTemplateTest {
         final boolean allUpdated = StreamSupport.stream(update.spliterator(), false)
                 .map(Human::getName).allMatch(name -> name.contains(" updated"));
 
-        assertTrue(allUpdated);
+        assertThat(allUpdated).isTrue();
     }
 
 
@@ -191,12 +182,12 @@ public abstract class AbstractTinkerpopTemplateTest {
 
         Human update = getGraphTemplate().update(newHuman);
 
-        assertSame(update, newHuman);
+        assertThat(newHuman).isSameAs(update);
     }
 
     @Test
     void shouldReturnErrorInFindWhenIdIsNull() {
-        assertThrows(NullPointerException.class, () -> getGraphTemplate().find(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> getGraphTemplate().find(null));
     }
 
     @Test
@@ -206,8 +197,8 @@ public abstract class AbstractTinkerpopTemplateTest {
         Human updated = getGraphTemplate().insert(human);
         Optional<Human> personFound = getGraphTemplate().find(updated.getId());
 
-        assertTrue(personFound.isPresent());
-        assertEquals(updated, personFound.get());
+        assertThat(personFound.isPresent()).isTrue();
+        assertThat(personFound.get()).isEqualTo(updated);
 
         getGraphTemplate().delete(updated.getId());
     }
@@ -215,7 +206,7 @@ public abstract class AbstractTinkerpopTemplateTest {
     @Test
     void shouldNotFindAnEntity() {
         Optional<Human> personFound = getGraphTemplate().find("0");
-        assertFalse(personFound.isPresent());
+        assertThat(personFound.isPresent()).isFalse();
     }
 
     @Test
@@ -224,9 +215,9 @@ public abstract class AbstractTinkerpopTemplateTest {
         Human human = getGraphTemplate().insert(Human.builder().withAge()
                 .withName("Otavio").build());
 
-        assertTrue(getGraphTemplate().find(human.getId()).isPresent());
+        assertThat(getGraphTemplate().find(human.getId()).isPresent()).isTrue();
         getGraphTemplate().delete(human.getId());
-        assertFalse(getGraphTemplate().find(human.getId()).isPresent());
+        assertThat(getGraphTemplate().find(human.getId()).isPresent()).isFalse();
     }
 
 
@@ -236,9 +227,9 @@ public abstract class AbstractTinkerpopTemplateTest {
         Human human = getGraphTemplate().insert(Human.builder().withAge()
                 .withName("Otavio").build());
 
-        assertTrue(getGraphTemplate().find(human.getId()).isPresent());
+        assertThat(getGraphTemplate().find(human.getId()).isPresent()).isTrue();
         getGraphTemplate().delete(Human.class, human.getId());
-        assertFalse(getGraphTemplate().find(human.getId()).isPresent());
+        assertThat(getGraphTemplate().find(human.getId()).isPresent()).isFalse();
     }
 
     @Test
@@ -247,11 +238,11 @@ public abstract class AbstractTinkerpopTemplateTest {
         Human human = getGraphTemplate().insert(Human.builder().withAge()
                 .withName("Otavio").build());
 
-        assertTrue(getGraphTemplate().find(human.getId()).isPresent());
+        assertThat(getGraphTemplate().find(human.getId()).isPresent()).isTrue();
         getGraphTemplate().delete(Magazine.class, human.getId());
-        assertTrue(getGraphTemplate().find(human.getId()).isPresent());
+        assertThat(getGraphTemplate().find(human.getId()).isPresent()).isTrue();
         getGraphTemplate().delete(Human.class, human.getId());
-        assertFalse(getGraphTemplate().find(human.getId()).isPresent());
+        assertThat(getGraphTemplate().find(human.getId()).isPresent()).isFalse();
     }
 
 
@@ -264,26 +255,26 @@ public abstract class AbstractTinkerpopTemplateTest {
         Human poliana = getGraphTemplate().insert(Human.builder().withAge()
                 .withName("Poliana").build());
 
-        assertTrue(getGraphTemplate().find(otavio.getId()).isPresent());
+        assertThat(getGraphTemplate().find(otavio.getId()).isPresent()).isTrue();
         getGraphTemplate().delete(Arrays.asList(otavio.getId(), poliana.getId()));
-        assertFalse(getGraphTemplate().find(otavio.getId()).isPresent());
-        assertFalse(getGraphTemplate().find(poliana.getId()).isPresent());
+        assertThat(getGraphTemplate().find(otavio.getId()).isPresent()).isFalse();
+        assertThat(getGraphTemplate().find(poliana.getId()).isPresent()).isFalse();
     }
 
     @Test
     void shouldReturnErrorWhenGetEdgesIdHasNullId() {
-        assertThrows(NullPointerException.class, () -> getGraphTemplate().edgesById(null, Direction.BOTH));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> getGraphTemplate().edgesById(null, Direction.BOTH));
     }
 
     @Test
     void shouldReturnErrorWhenGetEdgesIdHasNullDirection() {
-        assertThrows(NullPointerException.class, () -> getGraphTemplate().edgesById("10", null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> getGraphTemplate().edgesById("10", null));
     }
 
     @Test
     void shouldReturnEmptyWhenVertexDoesNotExist() {
         Collection<EdgeEntity> edges = getGraphTemplate().edgesById("10", Direction.BOTH);
-        assertTrue(edges.isEmpty());
+        assertThat(edges.isEmpty()).isTrue();
     }
 
     @Test
@@ -303,7 +294,7 @@ public abstract class AbstractTinkerpopTemplateTest {
         Collection<EdgeEntity> edgesById3 = getGraphTemplate().edgesById(otavio.getId(), Direction.OUT);
         Collection<EdgeEntity> edgesById4 = getGraphTemplate().edgesById(cleanCode.getId(), Direction.IN);
 
-        assertEquals(edgesById, edgesById3);
+        assertThat(edgesById3).isEqualTo(edgesById);
         assertThat(edgesById).contains(likes, reads);
         assertThat(edgesById1).contains(reads);
         assertThat(edgesById2).contains(likes);
@@ -320,10 +311,10 @@ public abstract class AbstractTinkerpopTemplateTest {
         EdgeEntity likes = getGraphTemplate().edge(otavio, "likes", dog);
 
         final Optional<EdgeEntity> edge = getGraphTemplate().edge(likes.id());
-        Assertions.assertTrue(edge.isPresent());
+        assertThat(edge.isPresent()).isTrue();
 
         getGraphTemplate().deleteEdge(likes.id());
-        assertFalse(getGraphTemplate().edge(likes.id()).isPresent());
+        assertThat(getGraphTemplate().edge(likes.id()).isPresent()).isFalse();
     }
 
     @Test
@@ -337,16 +328,16 @@ public abstract class AbstractTinkerpopTemplateTest {
         EdgeEntity reads = getGraphTemplate().edge(otavio, "reads", cleanCode);
 
         final Optional<EdgeEntity> edge = getGraphTemplate().edge(likes.id());
-        Assertions.assertTrue(edge.isPresent());
+        assertThat(edge.isPresent()).isTrue();
 
         getGraphTemplate().deleteEdge(Arrays.asList(likes.id(), reads.id()));
-        assertFalse(getGraphTemplate().edge(likes.id()).isPresent());
-        assertFalse(getGraphTemplate().edge(reads.id()).isPresent());
+        assertThat(getGraphTemplate().edge(likes.id()).isPresent()).isFalse();
+        assertThat(getGraphTemplate().edge(reads.id()).isPresent()).isFalse();
     }
 
     @Test
     void shouldReturnErrorWhenGetEdgesHasNullId() {
-        assertThrows(NullPointerException.class, () -> getGraphTemplate().edges(null, Direction.BOTH));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> getGraphTemplate().edges(null, Direction.BOTH));
     }
 
     @Test
@@ -358,7 +349,7 @@ public abstract class AbstractTinkerpopTemplateTest {
 
     @Test
     void shouldReturnErrorWhenGetEdgesHasNullDirection() {
-        assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             Human otavio = getGraphTemplate().insert(Human.builder().withAge()
                     .withName("Otavio").build());
             getGraphTemplate().edges(otavio, null);
@@ -369,7 +360,7 @@ public abstract class AbstractTinkerpopTemplateTest {
     void shouldReturnEmptyWhenEntityDoesNotExist() {
         Human otavio = Human.builder().withAge().withName("Otavio").withId("10").build();
         Collection<EdgeEntity> edges = getGraphTemplate().edges(otavio, Direction.BOTH);
-        assertTrue(edges.isEmpty());
+        assertThat(edges.isEmpty()).isTrue();
     }
 
 
@@ -403,7 +394,7 @@ public abstract class AbstractTinkerpopTemplateTest {
     void shouldGetTransaction() {
         assumeTrue(getGraph().features().graph().supportsTransactions(), "transactions not supported");
         Transaction transaction = getGraphTemplate().transaction();
-        assertNotNull(transaction);
+        assertThat(transaction).isNotNull();
     }
 
     @Test
@@ -434,7 +425,7 @@ public abstract class AbstractTinkerpopTemplateTest {
     @Test
     void shouldReturnEmpty() {
         Optional<Human> person = getGraphTemplate().gremlinSingleResult("g.V().hasLabel('person')");
-        assertFalse(person.isPresent());
+        assertThat(person.isPresent()).isFalse();
     }
 
     @Test
@@ -443,7 +434,7 @@ public abstract class AbstractTinkerpopTemplateTest {
                 .withName("Otavio").build();
         getGraphTemplate().insert(otavio);
         Optional<Human> person = getGraphTemplate().gremlinSingleResult("g.V().hasLabel('Human')");
-        assertTrue(person.isPresent());
+        assertThat(person.isPresent()).isTrue();
     }
 
     @Test
@@ -451,7 +442,7 @@ public abstract class AbstractTinkerpopTemplateTest {
 
         getGraphTemplate().insert(Human.builder().withAge().withName("Otavio").build());
         getGraphTemplate().insert(Human.builder().withAge().withName("Poliana").build());
-        assertThrows(NonUniqueResultException.class, () -> getGraphTemplate().gremlinSingleResult("g.V().hasLabel('Human')"));
+        assertThatExceptionOfType(NonUniqueResultException.class).isThrownBy(() -> getGraphTemplate().gremlinSingleResult("g.V().hasLabel('Human')"));
     }
 
     @Test
@@ -469,7 +460,7 @@ public abstract class AbstractTinkerpopTemplateTest {
         PreparedStatement prepare = getGraphTemplate().gremlinPrepare("g.V().hasLabel(@param)");
         prepare.bind("param", "Human");
         Optional<Human> otavio = prepare.singleResult();
-        assertTrue(otavio.isPresent());
+        assertThat(otavio.isPresent()).isTrue();
     }
 
     @Test
@@ -477,7 +468,7 @@ public abstract class AbstractTinkerpopTemplateTest {
         PreparedStatement prepare = getGraphTemplate().gremlinPrepare("g.V().hasLabel(@param)");
         prepare.bind("param", "Person");
         Optional<Human> otavio = prepare.singleResult();
-        assertFalse(otavio.isPresent());
+        assertThat(otavio.isPresent()).isFalse();
     }
 
     @Test
@@ -486,28 +477,28 @@ public abstract class AbstractTinkerpopTemplateTest {
         getGraphTemplate().insert(Human.builder().withAge().withName("Poliana").build());
         PreparedStatement prepare = getGraphTemplate().gremlinPrepare("g.V().hasLabel(@param)");
         prepare.bind("param", "Human");
-        assertThrows(NonUniqueResultException.class, prepare::singleResult);
+        assertThatExceptionOfType(NonUniqueResultException.class).isThrownBy(prepare::singleResult);
     }
 
     @Test
     void shouldCount() {
         getGraphTemplate().insert(Human.builder().withAge().withName("Otavio").build());
         getGraphTemplate().insert(Human.builder().withAge().withName("Poliana").build());
-        assertEquals(2L, getGraphTemplate().count("Human"));
+        assertThat(getGraphTemplate().count("Human")).isEqualTo(2L);
     }
 
     @Test
     void shouldCountFromEntity() {
         getGraphTemplate().insert(Human.builder().withAge().withName("Otavio").build());
         getGraphTemplate().insert(Human.builder().withAge().withName("Poliana").build());
-        assertEquals(2L, getGraphTemplate().count(Human.class));
+        assertThat(getGraphTemplate().count(Human.class)).isEqualTo(2L);
     }
 
     @Test
     void shouldCountFromSelectQuery() {
         getGraphTemplate().insert(Human.builder().withAge().withName("Otavio").build());
         getGraphTemplate().insert(Human.builder().withAge().withName("Poliana").build());
-        assertEquals(2L, getGraphTemplate().count(SelectQuery.builder().select().from("Human").build()));
+        assertThat(getGraphTemplate().count(SelectQuery.builder().select().from("Human").build())).isEqualTo(2L);
     }
 
 
@@ -517,9 +508,9 @@ public abstract class AbstractTinkerpopTemplateTest {
                 .withName("Otavio").build());
 
         final Optional<Human> person = getGraphTemplate().find(Human.class, otavio.getId());
-        assertNotNull(person);
-        assertTrue(person.isPresent());
-        assertEquals(otavio.getName(), person.map(Human::getName).get());
+        assertThat(person).isNotNull();
+        assertThat(person.isPresent()).isTrue();
+        assertThat(person.map(Human::getName).get()).isEqualTo(otavio.getName());
     }
 
     @Test
@@ -552,8 +543,8 @@ public abstract class AbstractTinkerpopTemplateTest {
     @Test
     void shouldReturnEmptyWhenFindByIdNotFound() {
         final Optional<Human> person = getGraphTemplate().find(Human.class, "-2");
-        assertNotNull(person);
-        assertFalse(person.isPresent());
+        assertThat(person).isNotNull();
+        assertThat(person.isPresent()).isFalse();
     }
 
     @Test
@@ -561,10 +552,10 @@ public abstract class AbstractTinkerpopTemplateTest {
         final Human otavio = getGraphTemplate().insert(Human.builder().withAge()
                 .withName("Otavio").build());
 
-        assertEquals("Otavio", otavio.getName());
+        assertThat(otavio.getName()).isEqualTo("Otavio");
         otavio.setName(null);
         final Human human = getGraphTemplate().update(otavio);
-        assertNull(human.getName());
+        assertThat(human.getName()).isNull();
 
     }
 

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversalTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversalTest.java
@@ -48,12 +48,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, TinkerpopTemplate.class})
@@ -77,7 +72,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
 
     @Test
     void shouldReturnErrorWhenEdgeIdIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalEdge(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalEdge(null));
     }
 
     @Test
@@ -85,8 +80,8 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
         Optional<EdgeEntity> edgeEntity = tinkerpopTemplate.traversalEdge(reads.id())
                 .next();
 
-        assertTrue(edgeEntity.isPresent());
-        assertEquals(reads.id(), edgeEntity.get().id());
+        assertThat(edgeEntity.isPresent()).isTrue();
+        assertThat(edgeEntity.get().id()).isEqualTo(reads.id());
     }
 
     @Test
@@ -95,7 +90,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .stream()
                 .collect(toList());
 
-        assertEquals(3, edges.size());
+        assertThat(edges.size()).isEqualTo(3);
         assertThat(edges).contains(reads, reads2, reads3);
     }
 
@@ -105,13 +100,13 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .stream()
                 .collect(toList());
 
-        assertEquals(3, edges.size());
+        assertThat(edges.size()).isEqualTo(3);
         assertThat(edges).contains(reads, reads2, reads3);
     }
 
     @Test
     void shouldReturnErrorOutEWhenIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().outE((String) null)
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().outE((String) null)
                 .stream()
                 .toList());
     }
@@ -122,7 +117,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .stream()
                 .collect(toList());
 
-        assertEquals(3, edges.size());
+        assertThat(edges.size()).isEqualTo(3);
         assertThat(edges).contains(reads, reads2, reads3);
     }
 
@@ -132,14 +127,14 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .stream()
                 .collect(toList());
 
-        assertEquals(3, edges.size());
+        assertThat(edges.size()).isEqualTo(3);
         assertThat(edges).contains(reads, reads2, reads3);
     }
 
 
     @Test
     void shouldReturnErrorWhenInEIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().inE((String) null)
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().inE((String) null)
                 .stream()
                 .toList());
 
@@ -151,7 +146,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .stream()
                 .toList();
 
-        assertEquals(6, edges.size());
+        assertThat(edges.size()).isEqualTo(6);
     }
 
     @Test
@@ -160,12 +155,12 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .stream()
                 .toList();
 
-        assertEquals(6, edges.size());
+        assertThat(edges.size()).isEqualTo(6);
     }
 
     @Test
     void shouldReturnErrorWhenBothEIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().bothE((String) null)
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().bothE((String) null)
                 .stream()
                 .toList());
     }
@@ -174,14 +169,14 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
     @Test
     void shouldReturnOut() {
         List<Human> people = tinkerpopTemplate.traversalVertex().outE(READS).outV().<Human>result().collect(toList());
-        assertEquals(3, people.size());
+        assertThat(people.size()).isEqualTo(3);
         assertThat(people).contains(poliana, otavio, paulo);
     }
 
     @Test
     void shouldReturnIn() {
         List<Magazine> magazines = tinkerpopTemplate.traversalVertex().outE(READS).inV().<Magazine>result().collect(toList());
-        assertEquals(3, magazines.size());
+        assertThat(magazines.size()).isEqualTo(3);
         assertThat(magazines).contains(shack, effectiveJava, license);
     }
 
@@ -189,7 +184,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
     @Test
     void shouldReturnBoth() {
         List<Object> entities = tinkerpopTemplate.traversalVertex().outE(READS).bothV().result().collect(toList());
-        assertEquals(6, entities.size());
+        assertThat(entities.size()).isEqualTo(6);
         assertThat(entities).contains(shack, effectiveJava, license, paulo, otavio, poliana);
     }
 
@@ -201,7 +196,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .outE(READS)
                 .has(T.id, "notFound").next();
 
-        assertFalse(edgeEntity.isPresent());
+        assertThat(edgeEntity.isPresent()).isFalse();
     }
 
 
@@ -211,8 +206,8 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .outE(READS)
                 .has("motivation", "hobby").next();
 
-        assertTrue(edgeEntity.isPresent());
-        assertEquals(reads.id(), edgeEntity.get().id());
+        assertThat(edgeEntity.isPresent()).isTrue();
+        assertThat(edgeEntity.get().id()).isEqualTo(reads.id());
     }
 
     @Test
@@ -221,8 +216,8 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .outE(READS)
                 .has(() -> "motivation", "hobby").next();
 
-        assertTrue(edgeEntity.isPresent());
-        assertEquals(reads.id(), edgeEntity.get().id());
+        assertThat(edgeEntity.isPresent()).isTrue();
+        assertThat(edgeEntity.get().id()).isEqualTo(reads.id());
     }
 
     @Test
@@ -232,8 +227,8 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .outE(READS)
                 .has("motivation", P.eq("hobby")).next();
 
-        assertTrue(edgeEntity.isPresent());
-        assertEquals(reads.id(), edgeEntity.get().id());
+        assertThat(edgeEntity.isPresent()).isTrue();
+        assertThat(edgeEntity.get().id()).isEqualTo(reads.id());
     }
 
 
@@ -244,21 +239,21 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .outE(READS)
                 .has(() -> "motivation", P.eq("hobby")).next();
 
-        assertTrue(edgeEntity.isPresent());
-        assertEquals(reads.id(), edgeEntity.get().id());
+        assertThat(edgeEntity.isPresent()).isTrue();
+        assertThat(edgeEntity.get().id()).isEqualTo(reads.id());
     }
 
 
     @Test
     void shouldReturnErrorWhenHasPropertyWhenKeyIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex()
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex()
                 .outE(READS)
                 .has((String) null, "hobby").next());
     }
 
     @Test
     void shouldReturnErrorWhenHasPropertyWhenValueIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex()
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex()
                 .outE(READS)
                 .has("motivation", null).next());
     }
@@ -270,39 +265,39 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .stream()
                 .toList();
 
-        assertEquals(2, edgeEntities.size());
+        assertThat(edgeEntities.size()).isEqualTo(2);
     }
 
     @Test
     void shouldCount() {
         long count = tinkerpopTemplate.traversalVertex().outE(READS).count();
-        assertEquals(3L, count);
+        assertThat(count).isEqualTo(3L);
     }
 
     @Test
     void shouldReturnZeroWhenCountIsEmpty() {
         long count = tinkerpopTemplate.traversalVertex().outE("WRITES").count();
-        assertEquals(0L, count);
+        assertThat(count).isEqualTo(0L);
     }
 
     @Test
     void shouldReturnErrorWhenHasNotIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().outE(READS).hasNot((String) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().outE(READS).hasNot((String) null));
     }
 
 
     @Test
     void shouldDefinesLimit() {
         long count = tinkerpopTemplate.traversalEdge().limit(1L).count();
-        assertEquals(1L, count);
-        assertNotEquals(tinkerpopTemplate.traversalEdge().count(), count);
+        assertThat(count).isEqualTo(1L);
+        assertThat(count).isNotEqualTo(tinkerpopTemplate.traversalEdge().count());
     }
 
     @Test
     void shouldDefinesRange() {
         long count = tinkerpopTemplate.traversalEdge().range(1, 3).count();
-        assertEquals(2L, count);
-        assertNotEquals(tinkerpopTemplate.traversalEdge().count(), count);
+        assertThat(count).isEqualTo(2L);
+        assertThat(count).isNotEqualTo(tinkerpopTemplate.traversalEdge().count());
     }
 
     @Test
@@ -310,8 +305,8 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
         List<Map<String, Object>> maps = tinkerpopTemplate.traversalVertex().inE("reads")
                 .valueMap("motivation").stream().toList();
 
-        assertFalse(maps.isEmpty());
-        assertEquals(3, maps.size());
+        assertThat(maps.isEmpty()).isFalse();
+        assertThat(maps.size()).isEqualTo(3);
 
         List<String> names = new ArrayList<>();
 
@@ -325,8 +320,8 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
         List<Map<String, Object>> maps = tinkerpopTemplate.traversalVertex().inE("reads")
                 .valueMap("motivation").next(2).toList();
 
-        assertFalse(maps.isEmpty());
-        assertEquals(2, maps.size());
+        assertThat(maps.isEmpty()).isFalse();
+        assertThat(maps.size()).isEqualTo(2);
     }
 
 
@@ -334,7 +329,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
     void shouldReturnMapValueAsEmptyStream() {
         Stream<Map<String, Object>> stream = tinkerpopTemplate.traversalVertex().inE("reads")
                 .valueMap("noFoundProperty").stream();
-        assertTrue(stream.allMatch(m -> Objects.isNull(m.get("noFoundProperty"))));
+        assertThat(stream.allMatch(m -> Objects.isNull(m.get("noFoundProperty")))).isTrue();
     }
 
     @Test
@@ -342,8 +337,8 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
         Map<String, Object> map = tinkerpopTemplate.traversalVertex().inE("reads")
                 .valueMap("motivation").next();
 
-        assertNotNull(map);
-        assertFalse(map.isEmpty());
+        assertThat(map).isNotNull();
+        assertThat(map.isEmpty()).isFalse();
     }
 
 
@@ -360,7 +355,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
 
 
         Optional<EdgeEntity> result = tinkerpopTemplate.traversalEdge().has("when").next();
-        assertNotNull(result);
+        assertThat(result).isNotNull();
 
         tinkerpopTemplate.deleteEdge(lion.getId());
     }
@@ -376,9 +371,9 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
         tinkerpopTemplate.edge(snake, "eats", mouse);
         tinkerpopTemplate.edge(mouse, "eats", plant);
         Optional<EdgeEntity> result = tinkerpopTemplate.traversalEdge().repeat().has("when").times(2).next();
-        assertNotNull(result);
-        assertEquals(snake, result.get().incoming());
-        assertEquals(lion, result.get().outgoing());
+        assertThat(result).isNotNull();
+        assertThat((Object) result.get().incoming()).isEqualTo(snake);
+        assertThat((Object) result.get().outgoing()).isEqualTo(lion);
     }
 
     @Test
@@ -395,10 +390,10 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
         Optional<EdgeEntity> result = tinkerpopTemplate.traversalEdge().repeat().has("when")
                 .until().has("when").next();
 
-        assertTrue(result.isPresent());
+        assertThat(result.isPresent()).isTrue();
 
-        assertEquals(snake, result.get().incoming());
-        assertEquals(lion, result.get().outgoing());
+        assertThat((Object) result.get().incoming()).isEqualTo(snake);
+        assertThat((Object) result.get().outgoing()).isEqualTo(lion);
 
     }
 
@@ -416,10 +411,10 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
         Optional<EdgeEntity> result = tinkerpopTemplate.traversalEdge().repeat().has("when")
                 .until().has("when", "night").next();
 
-        assertTrue(result.isPresent());
+        assertThat(result.isPresent()).isTrue();
 
-        assertEquals(snake, result.get().incoming());
-        assertEquals(lion, result.get().outgoing());
+        assertThat((Object) result.get().incoming()).isEqualTo(snake);
+        assertThat((Object) result.get().outgoing()).isEqualTo(lion);
 
     }
 
@@ -450,12 +445,12 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
 
     @Test
     void shouldReturnErrorWhenTheOrderIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalEdge().orderBy(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalEdge().orderBy(null));
     }
 
     @Test
     void shouldReturnErrorWhenThePropertyDoesNotExist() {
-       assertThrows(NoSuchElementException.class, () ->
+       assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() ->
                tinkerpopTemplate.traversalEdge().orderBy("wrong property").asc().next().get());
     }
 
@@ -498,36 +493,36 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
     void shouldReturnResultAsList() {
         List<EdgeEntity> entities = tinkerpopTemplate.traversalEdge().result()
                 .toList();
-        assertEquals(3, entities.size());
+        assertThat(entities.size()).isEqualTo(3);
     }
 
     @Test
     void shouldReturnErrorWhenThereAreMoreThanOneInGetSingleResult() {
-        assertThrows(NonUniqueResultException.class, () -> tinkerpopTemplate.traversalEdge().singleResult());
+        assertThatExceptionOfType(NonUniqueResultException.class).isThrownBy(() -> tinkerpopTemplate.traversalEdge().singleResult());
     }
 
     @Test
     void shouldReturnOptionalEmptyWhenThereIsNotResultInSingleResult() {
         Optional<EdgeEntity> entity = tinkerpopTemplate.traversalEdge("-1").singleResult();
-        assertFalse(entity.isPresent());
+        assertThat(entity.isPresent()).isFalse();
     }
 
     @Test
     void shouldReturnSingleResult() {
         String name = "Poliana";
         Optional<EdgeEntity> entity = tinkerpopTemplate.traversalEdge(reads.id()).singleResult();
-        assertEquals(reads, entity.get());
+        assertThat(entity.get()).isEqualTo(reads);
     }
 
     @Test
     void shouldReturnErrorWhenPredicateIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalEdge().filter(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalEdge().filter(null));
     }
 
     @Test
     void shouldReturnFromPredicate() {
         long count = tinkerpopTemplate.traversalEdge().filter(reads::equals).count();
-        assertEquals(1L, count);
+        assertThat(count).isEqualTo(1L);
     }
 
     @Test
@@ -545,7 +540,7 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .inE("knows").result()
                 .collect(Collectors.toList());
 
-        assertEquals(6, edges.size());
+        assertThat(edges.size()).isEqualTo(6);
 
         edges = tinkerpopTemplate.traversalVertex()
                 .hasLabel(Human.class)
@@ -554,6 +549,6 @@ abstract class DefaultEdgeTraversalTest extends AbstractTraversalTest {
                 .result()
                 .toList();
 
-        assertEquals(6, edges.size());
+        assertThat(edges.size()).isEqualTo(6);
     }
 }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultTinkerpopTemplateProducerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultTinkerpopTemplateProducerTest.java
@@ -25,11 +25,12 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 
 @EnableAutoWeld
@@ -45,13 +46,13 @@ class DefaultGraphTemplateProducerTest {
 
     @Test
     void shouldReturnErrorWhenManagerNull() {
-        Assertions.assertThrows(NullPointerException.class, () -> producer.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> producer.apply(null));
     }
 
     @Test
     void shouldReturn() {
         var graph = Mockito.mock(Graph.class);
         var template = producer.apply(graph);
-        assertNotNull(template);
+        assertThat(template).isNotNull();
     }
 }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversalTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversalTest.java
@@ -39,10 +39,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, TinkerpopTemplate.class})
@@ -68,7 +65,7 @@ abstract class DefaultValueMapTraversalTest extends AbstractTraversalTest {
     void shouldCount() {
         long count = tinkerpopTemplate.traversalVertex()
                 .hasLabel(Human.class).valueMap("name").count();
-        assertEquals(3L, count);
+        assertThat(count).isEqualTo(3L);
     }
 
 
@@ -88,8 +85,8 @@ abstract class DefaultValueMapTraversalTest extends AbstractTraversalTest {
         Stream<Map<String, Object>> stream = tinkerpopTemplate.traversalVertex()
                 .hasLabel(Human.class).valueMap("name")
                 .stream();
-        assertNotNull(stream);
-        assertEquals(3L, stream.count());
+        assertThat(stream).isNotNull();
+        assertThat(stream.count()).isEqualTo(3L);
     }
 
 
@@ -98,12 +95,12 @@ abstract class DefaultValueMapTraversalTest extends AbstractTraversalTest {
         List<Map<String, Object>> maps = tinkerpopTemplate.traversalVertex()
                 .hasLabel(Human.class).valueMap("name")
                 .resultList();
-        assertEquals(3, maps.size());
+        assertThat(maps.size()).isEqualTo(3);
     }
 
     @Test
     void shouldReturnErrorWhenThereAreMoreThanOneInGetSingleResult() {
-        assertThrows(NonUniqueResultException.class, () -> tinkerpopTemplate.traversalVertex()
+        assertThatExceptionOfType(NonUniqueResultException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex()
                 .hasLabel(Human.class).valueMap("name")
                 .singleResult());
     }
@@ -112,7 +109,7 @@ abstract class DefaultValueMapTraversalTest extends AbstractTraversalTest {
     void shouldReturnOptionalEmptyWhenThereIsNotResultInSingleResult() {
         Optional<Map<String, Object>> entity =   tinkerpopTemplate.traversalVertex()
                 .hasLabel("not_found").valueMap("name").singleResult();
-        assertFalse(entity.isPresent());
+        assertThat(entity.isPresent()).isFalse();
     }
 
     @Test
@@ -120,6 +117,6 @@ abstract class DefaultValueMapTraversalTest extends AbstractTraversalTest {
         String name = "Poliana";
         Optional<Map<String, Object>> poliana = tinkerpopTemplate.traversalVertex().hasLabel("Human").
                 has("name", name).valueMap("name").singleResult();
-        assertEquals(name, poliana.map(m ->  m.get("name")).orElse(""));
+        assertThat(poliana.map(m ->  m.get("name")).orElse("")).isEqualTo(name);
     }
 }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversalTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversalTest.java
@@ -48,12 +48,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 
 @EnableAutoWeld
@@ -78,7 +73,7 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
 
     @Test
     void shouldReturnErrorWhenVertexIdIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex(null));
     }
 
     @Test
@@ -96,7 +91,7 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
                 .<Human>result()
                 .collect(toList());
 
-        assertEquals(1, people.size());
+        assertThat(people.size()).isEqualTo(1);
         assertThat(people).contains(otavio);
     }
 
@@ -106,33 +101,33 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
                 <Human>next(2)
                 .collect(toList());
 
-        assertEquals(2, people.size());
+        assertThat(people.size()).isEqualTo(2);
         assertThat(people).contains(otavio, poliana);
     }
 
     @Test
     void shouldNext() {
         Optional<?> next = tinkerpopTemplate.traversalVertex().next();
-        assertTrue(next.isPresent());
+        assertThat(next.isPresent()).isTrue();
     }
 
     @Test
     void shouldEmptyNext() {
         Optional<?> next = tinkerpopTemplate.traversalVertex("-12").next();
-        assertFalse(next.isPresent());
+        assertThat(next.isPresent()).isFalse();
     }
 
 
     @Test
     void shouldHave() {
         Optional<Human> person = tinkerpopTemplate.traversalVertex().has("name", "Poliana").next();
-        assertTrue(person.isPresent());
-        assertEquals(person.get(), poliana);
+        assertThat(person.isPresent()).isTrue();
+        assertThat(poliana).isEqualTo(person.get());
     }
 
     @Test
     void shouldReturnErrorWhenHasNullKey() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex()
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex()
                 .has((String) null, "Poliana")
                 .next());
     }
@@ -140,25 +135,25 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
 
     @Test
     void shouldReturnErrorWhenHasNullValue() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().has("name", null)
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().has("name", null)
                 .next());
     }
 
     @Test
     void shouldHaveId() {
         Optional<Human> person = tinkerpopTemplate.traversalVertex().has(T.id, poliana.getId()).next();
-        assertTrue(person.isPresent());
-        assertEquals(person.get(), poliana);
+        assertThat(person.isPresent()).isTrue();
+        assertThat(poliana).isEqualTo(person.get());
     }
 
     @Test
     void shouldReturnErrorWhenHasIdHasNullValue() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().has(T.id, null).next());
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().has(T.id, null).next());
     }
 
     @Test
     void shouldReturnErrorWhenHasIdHasNullAccessor() {
-        assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             T id = null;
             tinkerpopTemplate.traversalVertex().has(id, poliana.getId()).next();
         });
@@ -170,12 +165,12 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         List<?> result = tinkerpopTemplate.traversalVertex().has("age", P.gt(26))
                 .result()
                 .toList();
-        assertEquals(5, result.size());
+        assertThat(result.size()).isEqualTo(5);
     }
 
     @Test
     void shouldReturnErrorWhenHasPredicateIsNull() {
-        assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             P<Integer> gt = null;
             tinkerpopTemplate.traversalVertex().has("age", gt)
                     .result()
@@ -185,7 +180,7 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
 
     @Test
     void shouldReturnErrorWhenHasKeyIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().has((String) null,
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().has((String) null,
                         P.gt(26))
                 .result()
                 .toList());
@@ -194,7 +189,7 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
     @Test
     void shouldHaveLabel() {
         List<Magazine> magazines = tinkerpopTemplate.traversalVertex().hasLabel("Magazine").<Magazine>result().collect(toList());
-        assertEquals(3, magazines.size());
+        assertThat(magazines.size()).isEqualTo(3);
         assertThat(magazines).contains(shack, license, effectiveJava);
     }
 
@@ -209,83 +204,83 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
 
     @Test
     void shouldReturnErrorWhenHasLabelHasNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().hasLabel((String) null)
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().hasLabel((String) null)
                 .<Magazine>result().toList());
     }
 
     @Test
     void shouldIn() {
         List<Magazine> magazines = tinkerpopTemplate.traversalVertex().out(READS).<Magazine>result().collect(toList());
-        assertEquals(3, magazines.size());
+        assertThat(magazines.size()).isEqualTo(3);
         assertThat(magazines).contains(shack, license, effectiveJava);
     }
 
     @Test
     void shouldReturnErrorWhenInIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().out((String) null).<Magazine>result().toList());
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().out((String) null).<Magazine>result().toList());
     }
 
     @Test
     void shouldOut() {
         List<Human> people = tinkerpopTemplate.traversalVertex().in(READS).<Human>result().collect(toList());
-        assertEquals(3, people.size());
+        assertThat(people.size()).isEqualTo(3);
         assertThat(people).contains(otavio, poliana, paulo);
     }
 
     @Test
     void shouldReturnErrorWhenOutIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().in((String) null).<Human>result().toList());
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().in((String) null).<Human>result().toList());
     }
 
     @Test
     void shouldBoth() {
         List<?> entities = tinkerpopTemplate.traversalVertex().both(READS)
                 .<Human>result().toList();
-        assertEquals(6, entities.size());
+        assertThat(entities.size()).isEqualTo(6);
     }
 
     @Test
     void shouldReturnErrorWhenBothIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().both((String) null)
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().both((String) null)
                 .<Human>result().toList());
     }
 
     @Test
     void shouldNot() {
         List<?> result = tinkerpopTemplate.traversalVertex().hasNot("year").result().toList();
-        assertEquals(6, result.size());
+        assertThat(result.size()).isEqualTo(6);
     }
 
     @Test
     void shouldReturnErrorWhenHasNotIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().hasNot((String) null)
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().hasNot((String) null)
                 .result().toList());
     }
 
     @Test
     void shouldCount() {
         long count = tinkerpopTemplate.traversalVertex().both(READS).count();
-        assertEquals(6L, count);
+        assertThat(count).isEqualTo(6L);
     }
 
     @Test
     void shouldReturnZeroWhenCountIsEmpty() {
         long count = tinkerpopTemplate.traversalVertex().both("WRITES").count();
-        assertEquals(0L, count);
+        assertThat(count).isEqualTo(0L);
     }
 
     @Test
     void shouldDefinesLimit() {
         long count = tinkerpopTemplate.traversalVertex().limit(1L).count();
-        assertEquals(1L, count);
-        assertNotEquals(tinkerpopTemplate.traversalVertex().count(), count);
+        assertThat(count).isEqualTo(1L);
+        assertThat(count).isNotEqualTo(tinkerpopTemplate.traversalVertex().count());
     }
 
     @Test
     void shouldDefinesRange() {
         long count = tinkerpopTemplate.traversalVertex().range(1, 3).count();
-        assertEquals(2L, count);
-        assertNotEquals(tinkerpopTemplate.traversalVertex().count(), count);
+        assertThat(count).isEqualTo(2L);
+        assertThat(count).isNotEqualTo(tinkerpopTemplate.traversalVertex().count());
     }
 
     @Test
@@ -293,8 +288,8 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         List<Map<String, Object>> maps = tinkerpopTemplate.traversalVertex().hasLabel("Human")
                 .valueMap("name").stream().toList();
 
-        assertFalse(maps.isEmpty());
-        assertEquals(3, maps.size());
+        assertThat(maps.isEmpty()).isFalse();
+        assertThat(maps.size()).isEqualTo(3);
 
         List<String> names = new ArrayList<>();
 
@@ -308,8 +303,8 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         List<Map<String, Object>> maps = tinkerpopTemplate.traversalVertex().hasLabel("Human")
                 .valueMap("name").next(2).toList();
 
-        assertFalse(maps.isEmpty());
-        assertEquals(2, maps.size());
+        assertThat(maps.isEmpty()).isFalse();
+        assertThat(maps.size()).isEqualTo(2);
     }
 
 
@@ -317,7 +312,7 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
     void shouldReturnMapValueAsEmptyStream() {
         Stream<Map<String, Object>> stream = tinkerpopTemplate.traversalVertex().hasLabel("Person")
                 .valueMap("noField").stream();
-        assertTrue(stream.allMatch(m -> Objects.isNull(m.get("noFoundProperty"))));
+        assertThat(stream.allMatch(m -> Objects.isNull(m.get("noFoundProperty")))).isTrue();
     }
 
     @Test
@@ -325,8 +320,8 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         Map<String, Object> map = tinkerpopTemplate.traversalVertex().hasLabel("Human")
                 .valueMap("name").next();
 
-        assertNotNull(map);
-        assertFalse(map.isEmpty());
+        assertThat(map).isNotNull();
+        assertThat(map.isEmpty()).isFalse();
     }
 
 
@@ -341,8 +336,8 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         tinkerpopTemplate.edge(snake, "eats", mouse);
         tinkerpopTemplate.edge(mouse, "eats", plant);
         Optional<Creature> animal = tinkerpopTemplate.traversalVertex().repeat().out("eats").times(3).next();
-        assertTrue(animal.isPresent());
-        assertEquals(plant, animal.get());
+        assertThat(animal.isPresent()).isTrue();
+        assertThat(animal.get()).isEqualTo(plant);
 
     }
 
@@ -357,8 +352,8 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         tinkerpopTemplate.edge(snake, "eats", mouse);
         tinkerpopTemplate.edge(mouse, "eats", plant);
         Optional<Creature> animal = tinkerpopTemplate.traversalVertex().repeat().in("eats").times(3).next();
-        assertTrue(animal.isPresent());
-        assertEquals(lion, animal.get());
+        assertThat(animal.isPresent()).isTrue();
+        assertThat(animal.get()).isEqualTo(lion);
 
     }
 
@@ -377,10 +372,10 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
                 .repeat().out("eats")
                 .until().has("name", "plant").next();
 
-        assertTrue(animal.isPresent());
+        assertThat(animal.isPresent()).isTrue();
 
 
-        assertEquals(plant, animal.get());
+        assertThat(animal.get()).isEqualTo(plant);
     }
 
     @Test
@@ -398,21 +393,21 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
                 .repeat().in("eats")
                 .until().has("name", "lion").next();
 
-        assertTrue(animal.isPresent());
+        assertThat(animal.isPresent()).isTrue();
 
 
-        assertEquals(lion, animal.get());
+        assertThat(animal.get()).isEqualTo(lion);
     }
 
 
     @Test
     void shouldReturnErrorWhenTheOrderIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().orderBy(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().orderBy(null));
     }
 
     @Test
     void shouldReturnErrorWhenThePropertyDoesNotExist() {
-        assertThrows(NoSuchElementException.class, () ->
+        assertThatExceptionOfType(NoSuchElementException.class).isThrownBy(() ->
                 tinkerpopTemplate.traversalVertex().orderBy("wrong property").asc().next().get());
     }
 
@@ -448,24 +443,24 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
 
     @Test
     void shouldReturnErrorWhenHasLabelStringNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().hasLabel((String) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().hasLabel((String) null));
     }
 
     @Test
     void shouldReturnErrorWhenHasLabelSupplierNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().hasLabel((Supplier<String>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().hasLabel((Supplier<String>) null));
     }
 
     @Test
     void shouldReturnErrorWhenHasLabelEntityClassNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().hasLabel((Class<?>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().hasLabel((Class<?>) null));
     }
 
     @Test
     void shouldReturnHasLabel() {
-        assertTrue(tinkerpopTemplate.traversalVertex().hasLabel("Person").result().allMatch(Human.class::isInstance));
-        assertTrue(tinkerpopTemplate.traversalVertex().hasLabel(() -> "Book").result().allMatch(Magazine.class::isInstance));
-        assertTrue(tinkerpopTemplate.traversalVertex().hasLabel(Creature.class).result().allMatch(Creature.class::isInstance));
+        assertThat(tinkerpopTemplate.traversalVertex().hasLabel("Person").result().allMatch(Human.class::isInstance)).isTrue();
+        assertThat(tinkerpopTemplate.traversalVertex().hasLabel(() -> "Book").result().allMatch(Magazine.class::isInstance)).isTrue();
+        assertThat(tinkerpopTemplate.traversalVertex().hasLabel(Creature.class).result().allMatch(Creature.class::isInstance)).isTrue();
     }
 
     @Test
@@ -473,18 +468,18 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         List<Human> people = tinkerpopTemplate.traversalVertex().hasLabel("Human")
                 .<Human>result()
                 .toList();
-        assertEquals(3, people.size());
+        assertThat(people.size()).isEqualTo(3);
     }
 
     @Test
     void shouldReturnErrorWhenThereAreMoreThanOneInGetSingleResult() {
-        assertThrows(NonUniqueResultException.class, () -> tinkerpopTemplate.traversalVertex().hasLabel("Human").singleResult());
+        assertThatExceptionOfType(NonUniqueResultException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().hasLabel("Human").singleResult());
     }
 
     @Test
     void shouldReturnOptionalEmptyWhenThereIsNotResultInSingleResult() {
         Optional<Object> entity = tinkerpopTemplate.traversalVertex().hasLabel("NoEntity").singleResult();
-        assertFalse(entity.isPresent());
+        assertThat(entity.isPresent()).isFalse();
     }
 
     @Test
@@ -492,12 +487,12 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         String name = "Poliana";
         Optional<Human> poliana = tinkerpopTemplate.traversalVertex().hasLabel("Human").
                 has("name", name).singleResult();
-        assertEquals(name, poliana.map(Human::getName).orElse(""));
+        assertThat(poliana.map(Human::getName).orElse("")).isEqualTo(name);
     }
 
     @Test
     void shouldReturnErrorWhenPredicateIsNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.traversalVertex().filter(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.traversalVertex().filter(null));
     }
 
     @Test
@@ -505,7 +500,7 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
         long count = tinkerpopTemplate.traversalVertex()
                 .hasLabel(Human.class)
                 .filter(Human::isAdult).count();
-        assertEquals(3L, count);
+        assertThat(count).isEqualTo(3L);
     }
 
     @Test
@@ -523,14 +518,14 @@ abstract class DefaultVertexTraversalTest extends AbstractTraversalTest {
                 .in("knows").<Human>result()
                 .collect(Collectors.toList());
 
-        assertEquals(6, people.size());
+        assertThat(people.size()).isEqualTo(6);
 
         people = tinkerpopTemplate.traversalVertex()
                 .hasLabel(Human.class)
                 .in("knows").dedup().<Human>result()
                 .toList();
 
-        assertEquals(3, people.size());
+        assertThat(people.size()).isEqualTo(3);
     }
 
 }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeEntityTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeEntityTest.java
@@ -31,7 +31,6 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
@@ -40,12 +39,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, TinkerpopTemplate.class})
@@ -73,7 +67,7 @@ abstract class EdgeEntityTest {
 
     @Test
     void shouldReturnErrorWhenInboundIsNull() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             Human human = Human.builder().withName("Poliana").withAge().build();
             Magazine magazine = null;
             tinkerpopTemplate.edge(human, "reads", magazine);
@@ -82,7 +76,7 @@ abstract class EdgeEntityTest {
 
     @Test
     void shouldReturnErrorWhenOutboundIsNull() {
-        Assertions.assertThrows(IllegalStateException.class, () -> {
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
             Human human = Human.builder().withName("Poliana").withAge().build();
             Magazine magazine = Magazine.builder().withAge(2007).withName("The Shack").build();
             tinkerpopTemplate.edge(human, "reads", magazine);
@@ -91,7 +85,7 @@ abstract class EdgeEntityTest {
 
     @Test
     void shouldReturnErrorWhenLabelIsNull() {
-        Assertions.assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             Human human = Human.builder().withName("Poliana").withAge().build();
             Magazine magazine = Magazine.builder().withAge(2007).withName("The Shack").build();
             tinkerpopTemplate.edge(human, (String) null, magazine);
@@ -100,7 +94,7 @@ abstract class EdgeEntityTest {
 
     @Test
     void shouldReturnNullWhenInboundIdIsNull() {
-        Assertions.assertThrows(EmptyResultException.class, () -> {
+        assertThatExceptionOfType(EmptyResultException.class).isThrownBy(() -> {
             Human human = Human.builder().withId("-5").withName("Poliana").withAge().build();
             Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
             tinkerpopTemplate.edge(human, "reads", magazine);
@@ -110,7 +104,7 @@ abstract class EdgeEntityTest {
 
     @Test
     void shouldReturnNullWhenOutboundIdIsNull() {
-        Assertions.assertThrows(IllegalStateException.class, () -> {
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> {
             Human human = tinkerpopTemplate.insert(Human.builder().withName("Poliana").withAge().build());
             Magazine magazine = Magazine.builder().withAge(2007).withName("The Shack").build();
             tinkerpopTemplate.edge(human, "reads", magazine);
@@ -119,7 +113,7 @@ abstract class EdgeEntityTest {
 
     @Test
     void shouldReturnEntityNotFoundWhenOutBoundDidNotFound() {
-        Assertions.assertThrows( EmptyResultException.class, () -> {
+        assertThatExceptionOfType(EmptyResultException.class).isThrownBy(() -> {
             Human human = Human.builder().withId("-10").withName("Poliana").withAge().build();
             Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
             tinkerpopTemplate.edge(human, "reads", magazine);
@@ -128,7 +122,7 @@ abstract class EdgeEntityTest {
 
     @Test
     void shouldReturnEntityNotFoundWhenInBoundDidNotFound() {
-        Assertions.assertThrows( EmptyResultException.class, () -> {
+        assertThatExceptionOfType(EmptyResultException.class).isThrownBy(() -> {
             Human human = tinkerpopTemplate.insert(Human.builder().withName("Poliana").withAge().build());
             Magazine magazine = Magazine.builder().withId("10").withAge(2007).withName("The Shack").build();
             tinkerpopTemplate.edge(human, "reads", magazine);
@@ -141,11 +135,11 @@ abstract class EdgeEntityTest {
         Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
         EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
 
-        assertEquals("reads", edge.label());
-        assertEquals(human, edge.outgoing());
-        assertEquals(magazine, edge.incoming());
-        assertTrue(edge.isEmpty());
-        assertNotNull(edge.id());
+        assertThat(edge.label()).isEqualTo("reads");
+        assertThat((Object) edge.outgoing()).isEqualTo(human);
+        assertThat((Object) edge.incoming()).isEqualTo(magazine);
+        assertThat(edge.isEmpty()).isTrue();
+        assertThat(edge.id()).isNotNull();
     }
 
     @Test
@@ -154,15 +148,15 @@ abstract class EdgeEntityTest {
         Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
         EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
 
-        assertEquals("reads", edge.label());
-        assertEquals(human, edge.outgoing());
-        assertEquals(magazine, edge.incoming());
-        assertTrue(edge.isEmpty());
-        assertNotNull(edge.id());
+        assertThat(edge.label()).isEqualTo("reads");
+        assertThat((Object) edge.outgoing()).isEqualTo(human);
+        assertThat((Object) edge.incoming()).isEqualTo(magazine);
+        assertThat(edge.isEmpty()).isTrue();
+        assertThat(edge.id()).isNotNull();
         final String id = edge.id(String.class);
-        assertNotNull(id);
+        assertThat(id).isNotNull();
 
-        assertEquals(id, edge.id(String.class));
+        assertThat(edge.id(String.class)).isEqualTo(id);
 
     }
 
@@ -172,11 +166,11 @@ abstract class EdgeEntityTest {
         Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
         EdgeEntity edge = tinkerpopTemplate.edge(human, () -> "reads", magazine);
 
-        assertEquals("reads", edge.label());
-        assertEquals(human, edge.outgoing());
-        assertEquals(magazine, edge.incoming());
-        assertTrue(edge.isEmpty());
-        assertNotNull(edge.id());
+        assertThat(edge.label()).isEqualTo("reads");
+        assertThat((Object) edge.outgoing()).isEqualTo(human);
+        assertThat((Object) edge.incoming()).isEqualTo(magazine);
+        assertThat(edge.isEmpty()).isTrue();
+        assertThat(edge.id()).isNotNull();
     }
 
     @Test
@@ -187,8 +181,8 @@ abstract class EdgeEntityTest {
 
         EdgeEntity sameEdge = tinkerpopTemplate.edge(human, "reads", magazine);
 
-        assertEquals(edge.id(), sameEdge.id());
-        assertEquals(edge, sameEdge);
+        assertThat(sameEdge.id()).isEqualTo(edge.id());
+        assertThat(sameEdge).isEqualTo(edge);
     }
 
     @Test
@@ -203,11 +197,11 @@ abstract class EdgeEntityTest {
         EdgeEntity sameEdge = tinkerpopTemplate.edge(poliana, "reads", magazine);
         EdgeEntity sameEdge1 = tinkerpopTemplate.edge(nilzete, "reads", magazine);
 
-        assertEquals(edge.id(), sameEdge.id());
-        assertEquals(edge, sameEdge);
+        assertThat(sameEdge.id()).isEqualTo(edge.id());
+        assertThat(sameEdge).isEqualTo(edge);
 
-        assertEquals(edge1.id(), sameEdge1.id());
-        assertEquals(edge1, sameEdge1);
+        assertThat(sameEdge1.id()).isEqualTo(edge1.id());
+        assertThat(sameEdge1).isEqualTo(edge1);
 
     }
 
@@ -223,15 +217,15 @@ abstract class EdgeEntityTest {
         EdgeEntity sameEdge = tinkerpopTemplate.edge(poliana, "reads", magazine);
         EdgeEntity sameEdge1 = tinkerpopTemplate.edge(nilzete, "reads", magazine);
 
-        assertNotEquals(edge.id(), edge1.id());
-        assertNotEquals(edge.id(), sameEdge1.id());
+        assertThat(edge1.id()).isNotEqualTo(edge.id());
+        assertThat(sameEdge1.id()).isNotEqualTo(edge.id());
 
-        assertNotEquals(sameEdge1.id(), sameEdge.id());
+        assertThat(sameEdge.id()).isNotEqualTo(sameEdge1.id());
     }
 
     @Test
     void shouldReturnErrorWhenAddKeyIsNull() {
-        assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             Human human = tinkerpopTemplate.insert(Human.builder().withName("Poliana").withAge().build());
             Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
             EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
@@ -242,7 +236,7 @@ abstract class EdgeEntityTest {
     @Test
     void shouldReturnErrorWhenAddValueIsNull() {
 
-        assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             Human human = tinkerpopTemplate.insert(Human.builder().withName("Poliana").withAge().build());
             Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
             EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
@@ -257,8 +251,8 @@ abstract class EdgeEntityTest {
         EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
         edge.add("where", "Brazil");
 
-        assertFalse(edge.isEmpty());
-        assertEquals(1, edge.size());
+        assertThat(edge.isEmpty()).isFalse();
+        assertThat(edge.size()).isEqualTo(1);
         assertThat(edge.properties()).contains(Element.of("where", "Brazil"));
     }
 
@@ -269,22 +263,22 @@ abstract class EdgeEntityTest {
         EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
         edge.add("where", Value.of("Brazil"));
 
-        assertFalse(edge.isEmpty());
-        assertEquals(1, edge.size());
+        assertThat(edge.isEmpty()).isFalse();
+        assertThat(edge.size()).isEqualTo(1);
         assertThat(edge.properties()).contains(Element.of("where", "Brazil"));
     }
 
 
     @Test
     void shouldReturnErrorWhenRemoveNullKeyProperty() {
-        assertThrows(NullPointerException.class, () -> {
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
             Human human = tinkerpopTemplate.insert(Human.builder().withName("Poliana").withAge().build());
             Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
             EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
             edge.add("where", "Brazil");
 
 
-            assertFalse(edge.isEmpty());
+            assertThat(edge.isEmpty()).isFalse();
             edge.remove(null);
         });
     }
@@ -295,11 +289,11 @@ abstract class EdgeEntityTest {
         Magazine magazine = tinkerpopTemplate.insert(Magazine.builder().withAge(2007).withName("The Shack").build());
         EdgeEntity edge = tinkerpopTemplate.edge(human, "reads", magazine);
         edge.add("where", "Brazil");
-        assertEquals(1, edge.size());
-        assertFalse(edge.isEmpty());
+        assertThat(edge.size()).isEqualTo(1);
+        assertThat(edge.isEmpty()).isFalse();
         edge.remove("where");
-        assertTrue(edge.isEmpty());
-        assertEquals(0, edge.size());
+        assertThat(edge.isEmpty()).isTrue();
+        assertThat(edge.size()).isEqualTo(0);
     }
 
     @Test
@@ -310,9 +304,9 @@ abstract class EdgeEntityTest {
         edge.add("where", "Brazil");
 
         Optional<Value> where = edge.get("where");
-        assertTrue(where.isPresent());
-        assertEquals("Brazil", where.get().get());
-        assertFalse(edge.get("not").isPresent());
+        assertThat(where.isPresent()).isTrue();
+        assertThat(where.get().get()).isEqualTo("Brazil");
+        assertThat(edge.get("not").isPresent()).isFalse();
 
     }
 
@@ -324,14 +318,14 @@ abstract class EdgeEntityTest {
         edge.delete();
 
         EdgeEntity newEdge = tinkerpopTemplate.edge(human, "reads", magazine);
-        assertNotEquals(edge.id(), newEdge.id());
+        assertThat(newEdge.id()).isNotEqualTo(edge.id());
 
         tinkerpopTemplate.deleteEdge(newEdge.id());
     }
 
     @Test
     void shouldReturnErrorWhenDeleteAnEdgeWithNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.delete((Iterable<Object>) null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.delete((Iterable<Object>) null));
     }
 
     @Test
@@ -344,13 +338,13 @@ abstract class EdgeEntityTest {
         tinkerpopTemplate.deleteEdge(edge.id());
 
         EdgeEntity newEdge = tinkerpopTemplate.edge(human, "reads", magazine);
-        assertNotEquals(edge.id(), newEdge.id());
+        assertThat(newEdge.id()).isNotEqualTo(edge.id());
     }
 
 
     @Test
     void shouldReturnErrorWhenFindEdgeWithNull() {
-        assertThrows(NullPointerException.class, () -> tinkerpopTemplate.edge(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> tinkerpopTemplate.edge(null));
     }
 
 
@@ -362,8 +356,8 @@ abstract class EdgeEntityTest {
 
         Optional<EdgeEntity> newEdge = tinkerpopTemplate.edge(edge.id());
 
-        assertTrue(newEdge.isPresent());
-        assertEquals(edge.id(), newEdge.get().id());
+        assertThat(newEdge.isPresent()).isTrue();
+        assertThat(newEdge.get().id()).isEqualTo(edge.id());
 
         tinkerpopTemplate.deleteEdge(edge.id());
     }
@@ -372,7 +366,7 @@ abstract class EdgeEntityTest {
     void shouldNotFindAnEdge() {
         Optional<EdgeEntity> edgeEntity = tinkerpopTemplate.edge("-12");
 
-        assertFalse(edgeEntity.isPresent());
+        assertThat(edgeEntity.isPresent()).isFalse();
     }
 
 }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphTemplateTest.java
@@ -30,10 +30,10 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.eclipse.jnosql.mapping.DatabaseType.GRAPH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, TinkerpopTemplate.class, GraphTemplate.class})
@@ -63,11 +63,11 @@ abstract class GraphTemplateTest {
 
     @Test
     void shouldInjectTemplate() {
-        Assertions.assertNotNull(template);
+        assertThat(template).isNotNull();
     }
 
     @Test
     void shouldInjectQualifier() {
-        Assertions.assertNotNull(qualifier);
+        assertThat(qualifier).isNotNull();
     }
 }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/MagazineTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/MagazineTemplateTest.java
@@ -40,10 +40,8 @@ import static org.apache.tinkerpop.gremlin.structure.Transaction.Status.COMMIT;
 import static org.apache.tinkerpop.gremlin.structure.Transaction.Status.ROLLBACK;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, TinkerpopTemplate.class})
@@ -81,8 +79,8 @@ abstract class MagazineTemplateTest {
         Transaction transaction = graph.tx();
         transaction.addTransactionListener(status::set);
         template.insert(magazine);
-        assertFalse(transaction.isOpen());
-        assertEquals(COMMIT, status.get());
+        assertThat(transaction.isOpen()).isFalse();
+        assertThat(status.get()).isEqualTo(COMMIT);
     }
 
     @Test
@@ -101,8 +99,8 @@ abstract class MagazineTemplateTest {
 
         }
 
-        assertFalse(transaction.isOpen());
-        assertEquals(ROLLBACK, status.get());
+        assertThat(transaction.isOpen()).isFalse();
+        assertThat(status.get()).isEqualTo(ROLLBACK);
     }
 
     @Test
@@ -114,10 +112,10 @@ abstract class MagazineTemplateTest {
         Magazine magazine = Magazine.builder().withName("The Book").build();
         Transaction transaction = graph.tx();
         transaction.addTransactionListener(status::set);
-        assertNull(status.get());
+        assertThat(status.get()).isNull();
         template.normalInsertion(magazine);
-        assertEquals(COMMIT, status.get());
-        assertFalse(transaction.isOpen());
+        assertThat(status.get()).isEqualTo(COMMIT);
+        assertThat(transaction.isOpen()).isFalse();
     }
 }
 

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateProducerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateProducerTest.java
@@ -28,8 +28,9 @@ import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, TinkerpopTemplate.class})
@@ -43,14 +44,14 @@ class GraphTemplateProducerTest {
 
     @Test
     void shouldReturnErrorWhenManagerNull() {
-        assertThrows(NullPointerException.class, () -> producer.apply(null));
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> producer.apply(null));
     }
 
     @Test
     void shouldReturnGraphTemplateWhenGetGraph() {
         Graph graph = Mockito.mock(Graph.class);
         TinkerpopTemplate template = producer.apply(graph);
-        assertNotNull(template);
+        assertThat(template).isNotNull();
     }
 
 

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateTest.java
@@ -28,10 +28,10 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.eclipse.jnosql.mapping.DatabaseType.GRAPH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class, TinkerpopTemplate.class, GraphTemplate.class})
@@ -50,11 +50,11 @@ class TinkerpopTemplateTest {
 
     @Test
     void shouldInjectTemplate() {
-        Assertions.assertNotNull(template);
+        assertThat(template).isNotNull();
     }
 
     @Test
     void shouldInjectQualifier() {
-        Assertions.assertNotNull(qualifier);
+        assertThat(qualifier).isNotNull();
     }
 }

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphSupplierTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphSupplierTest.java
@@ -26,7 +26,6 @@ import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -52,7 +51,7 @@ class GraphSupplierTest {
     void shouldGetGraph() {
         System.setProperty(DatabaseConfigurationAdapter.TINKERPOP_PROVIDER, GraphConfigurationMock.class.getName());
         Graph graph = supplier.get();
-        Assertions.assertNotNull(graph);
+        assertThat(graph).isNotNull();
         assertThat(graph).isInstanceOf(GraphConfigurationMock.GraphMock.class);
     }
 
@@ -61,14 +60,14 @@ class GraphSupplierTest {
     void shouldUseDefaultConfigurationWhenProviderIsWrong() {
         System.setProperty(GRAPH_PROVIDER.get(), Integer.class.getName());
         Graph graph = supplier.get();
-        Assertions.assertNotNull(graph);
+        assertThat(graph).isNotNull();
         assertThat(graph).isInstanceOf(GraphConfigurationMock2.GraphMock.class);
     }
 
     @Test
     void shouldUseDefaultConfiguration() {
         Graph graph = supplier.get();
-        Assertions.assertNotNull(graph);
+        assertThat(graph).isNotNull();
         assertThat(graph).isInstanceOf(GraphConfigurationMock2.GraphMock.class);
     }
 

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TinkerpopExtensionTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TinkerpopExtensionTest.java
@@ -31,7 +31,8 @@ import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 
 @EnableAutoWeld
@@ -62,24 +63,24 @@ class TinkerpopExtensionTest {
 
     @Test
     void shouldInitiate() {
-        assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 
     @Test
     void shouldUseMock() {
-        assertNotNull(repositoryMock);
+        assertThat(repositoryMock).isNotNull();
     }
 
     @Test
     void shouldInjectTemplate() {
-        assertNotNull(templateMock);
-        assertNotNull(template);
-        assertNotNull(repository2);
+        assertThat(templateMock).isNotNull();
+        assertThat(template).isNotNull();
+        assertThat(repository2).isNotNull();
     }
 
     @Test
     void shouldInjectRepository() {
-        assertNotNull(repository);
-        assertNotNull(repositoryMock);
+        assertThat(repository).isNotNull();
+        assertThat(repositoryMock).isNotNull();
     }
 }

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounterTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounterTest.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -41,21 +41,21 @@ public class DefaultCounterTest {
 
     @Test
     public void shouldIncrement() {
-        assertEquals(1D, counter.increment());
-        assertEquals(10D, counter.increment(9));
+        assertThat(counter.increment()).isEqualTo(1D);
+        assertThat(counter.increment(9)).isEqualTo(10D);
     }
 
     @Test
     public void shouldDecrement() {
         counter.increment(10.15);
-        assertEquals(9.15D, counter.decrement());
-        assertEquals(0.15D, counter.decrement(9));
+        assertThat(counter.decrement()).isEqualTo(9.15D);
+        assertThat(counter.decrement(9)).isEqualTo(0.15D);
     }
 
     @Test
     public void shouldGet() {
         counter.increment(10.15);
-        assertEquals(10.15D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(10.15D);
     }
 
     @Test
@@ -63,7 +63,7 @@ public class DefaultCounterTest {
         counter.increment(10.15);
         counter.expire(Duration.ofSeconds(1));
         Thread.sleep(2_000L);
-        assertEquals(0D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(0D);
     }
 
     @Test
@@ -72,14 +72,14 @@ public class DefaultCounterTest {
         counter.expire(Duration.ofSeconds(1));
         counter.persist();
         Thread.sleep(2_000L);
-        assertEquals(10.15D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(10.15D);
     }
 
     @Test
     public void shouldDelete() {
         counter.increment(10.15);
         counter.delete();
-        assertEquals(0D, counter.get().doubleValue());
+        assertThat(counter.get().doubleValue()).isEqualTo(0D);
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSetTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSetTest.java
@@ -25,9 +25,6 @@ import java.time.Duration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class DefaultSortedSetTest {
@@ -53,19 +50,19 @@ public class DefaultSortedSetTest {
 
     @Test
     public void shouldSize() {
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
         sortedSet.add(BRAZIL, 10);
-        assertEquals(Integer.valueOf(sortedSet.size()), Integer.valueOf(1));
+        assertThat(Integer.valueOf(1)).isEqualTo(Integer.valueOf(sortedSet.size()));
     }
 
     @Test
     public void shouldCheckIfEmpty() {
 
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
         sortedSet.add(BRAZIL, 1);
         sortedSet.add(USA, 2);
         sortedSet.add(ENGLAND, 3);
-        assertFalse(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isFalse();
 
     }
 
@@ -74,9 +71,9 @@ public class DefaultSortedSetTest {
         sortedSet.add(BRAZIL, 1);
         sortedSet.add(USA, 2);
         sortedSet.add(ENGLAND, 3);
-        assertFalse(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isFalse();
         sortedSet.delete();
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
     }
 
     @Test
@@ -84,30 +81,30 @@ public class DefaultSortedSetTest {
         sortedSet.add(BRAZIL, 1);
         sortedSet.add(USA, 2);
         sortedSet.add(ENGLAND, 3);
-        assertFalse(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isFalse();
         sortedSet.clear();
-        assertTrue(sortedSet.isEmpty());
+        assertThat(sortedSet.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldIncrement() {
         sortedSet.add(BRAZIL, 10);
         Number points = sortedSet.increment(BRAZIL, 2);
-        assertEquals(Long.valueOf(12), Long.valueOf(points.longValue()));
+        assertThat(Long.valueOf(points.longValue())).isEqualTo(Long.valueOf(12));
     }
 
     @Test
     public void shouldDecrement() {
         sortedSet.add(BRAZIL, 10);
         Number points = sortedSet.decrement(BRAZIL, 2);
-        assertEquals(Long.valueOf(8), Long.valueOf(points.longValue()));
+        assertThat(Long.valueOf(points.longValue())).isEqualTo(Long.valueOf(8));
     }
 
     @Test
     public void shouldRemoveMember() {
         sortedSet.add(BRAZIL, 10);
         sortedSet.remove(BRAZIL);
-        assertEquals(0, sortedSet.size());
+        assertThat(sortedSet.size()).isEqualTo(0);
     }
 
     @Test
@@ -115,7 +112,7 @@ public class DefaultSortedSetTest {
         sortedSet.add(BRAZIL, 10);
         sortedSet.expire(Duration.ofSeconds(1));
         Thread.sleep(2_000L);
-        assertEquals(0, sortedSet.size());
+        assertThat(sortedSet.size()).isEqualTo(0);
     }
 
     @Test
@@ -124,7 +121,7 @@ public class DefaultSortedSetTest {
         sortedSet.expire(Duration.ofSeconds(1));
         sortedSet.persist();
         Thread.sleep(2_000L);
-        assertEquals(1, sortedSet.size());
+        assertThat(sortedSet.size()).isEqualTo(1);
     }
 
     @Test

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
@@ -27,10 +27,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisListStringTest {
@@ -50,37 +46,37 @@ public class RedisListStringTest {
 
     @Test
     public void shouldReturnsList() {
-        assertNotNull(fruits);
+        assertThat(fruits).isNotNull();
     }
 
     @Test
     public void shouldAddList() {
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
         fruits.add("banana");
-        assertFalse(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isFalse();
         String banana = fruits.getFirst();
-        assertNotNull(banana);
-        assertEquals(banana, "banana");
+        assertThat(banana).isNotNull();
+        assertThat("banana").isEqualTo(banana);
     }
     
     @Test
     public void shouldAddAll() {
         fruits.addAll(Arrays.asList("banana", "orange"));
-        assertEquals(2, fruits.size());
+        assertThat(fruits.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldSetList() {
         fruits.add("banana");
         fruits.addFirst("orange");
-        assertEquals(2, fruits.size());
+        assertThat(fruits.size()).isEqualTo(2);
 
-        assertEquals(fruits.get(0), "orange");
-        assertEquals(fruits.get(1), "banana");
+        assertThat("orange").isEqualTo(fruits.get(0));
+        assertThat("banana").isEqualTo(fruits.get(1));
 
         fruits.set(0, "waterMelon");
-        assertEquals(fruits.get(0), "waterMelon");
-        assertEquals(fruits.get(1), "banana");
+        assertThat("waterMelon").isEqualTo(fruits.get(0));
+        assertThat("banana").isEqualTo(fruits.get(1));
 
     }
 
@@ -100,12 +96,12 @@ public class RedisListStringTest {
         fruits.add("banana");
         fruits.add("watermellon");
         fruits.add("banana");
-        assertEquals(1, fruits.indexOf("banana"));
-        assertEquals(3, fruits.lastIndexOf("banana"));
+        assertThat(fruits.indexOf("banana")).isEqualTo(1);
+        assertThat(fruits.lastIndexOf("banana")).isEqualTo(3);
 
-        assertTrue(fruits.contains("banana"));
-        assertEquals(-1, fruits.indexOf("melon"));
-        assertEquals(-1, fruits.lastIndexOf("melon"));
+        assertThat(fruits.contains("banana")).isTrue();
+        assertThat(fruits.indexOf("melon")).isEqualTo(-1);
+        assertThat(fruits.lastIndexOf("melon")).isEqualTo(-1);
     }
 
     @Test
@@ -113,10 +109,10 @@ public class RedisListStringTest {
         fruits.add("orange");
         fruits.add("banana");
         fruits.add("watermellon");
-        assertTrue(fruits.contains("banana"));
-        assertFalse(fruits.contains("melon"));
-        assertTrue(fruits.containsAll(Arrays.asList("banana", "orange")));
-        assertFalse(fruits.containsAll(Arrays.asList("banana", "melon")));
+        assertThat(fruits.contains("banana")).isTrue();
+        assertThat(fruits.contains("melon")).isFalse();
+        assertThat(fruits.containsAll(Arrays.asList("banana", "orange"))).isTrue();
+        assertThat(fruits.containsAll(Arrays.asList("banana", "melon"))).isFalse();
 
     }
 
@@ -129,14 +125,14 @@ public class RedisListStringTest {
         for (String fruiCart : fruits) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         fruits.removeFirst();
         fruits.removeFirst();
         count = 0;
         for (String fruiCart : fruits) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
@@ -146,7 +142,7 @@ public class RedisListStringTest {
         fruits.add("watermellon");
 
         fruits.clear();
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
@@ -29,11 +29,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisListTest {
@@ -57,31 +53,31 @@ public class RedisListTest {
 
     @Test
     public void shouldReturnsList() {
-        assertNotNull(fruits);
+        assertThat(fruits).isNotNull();
     }
 
     @Test
     public void shouldAddList() {
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
         fruits.add(banana);
-        assertFalse(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isFalse();
         ProductCart banana = fruits.getFirst();
-        assertNotNull(banana);
-        assertEquals(banana.name(), "banana");
+        assertThat(banana).isNotNull();
+        assertThat("banana").isEqualTo(banana.name());
     }
 
     @Test
     public void shouldSetList() {
         fruits.add(banana);
         fruits.addFirst(orange);
-        assertEquals(2, fruits.size());
+        assertThat(fruits.size()).isEqualTo(2);
 
-        assertEquals(fruits.get(0).name(), "orange");
-        assertEquals(fruits.get(1).name(), "banana");
+        assertThat("orange").isEqualTo(fruits.get(0).name());
+        assertThat("banana").isEqualTo(fruits.get(1).name());
 
         fruits.set(0, waterMelon);
-        assertEquals(fruits.get(0).name(), "waterMelon");
-        assertEquals(fruits.get(1).name(), "banana");
+        assertThat("waterMelon").isEqualTo(fruits.get(0).name());
+        assertThat("banana").isEqualTo(fruits.get(1).name());
     }
 
     @Test
@@ -101,7 +97,7 @@ public class RedisListTest {
         fruits.add(waterMelon);
 
         fruits.removeAll(Arrays.asList(orange, banana));
-        assertEquals(1, fruits.size());
+        assertThat(fruits.size()).isEqualTo(1);
         assertThat(fruits).contains(waterMelon);
     }
 
@@ -121,12 +117,12 @@ public class RedisListTest {
         fruits.add(banana);
         fruits.add(new ProductCart("watermellon", BigDecimal.ONE));
         fruits.add(banana);
-        assertEquals(1, fruits.indexOf(banana));
-        assertEquals(3, fruits.lastIndexOf(banana));
+        assertThat(fruits.indexOf(banana)).isEqualTo(1);
+        assertThat(fruits.lastIndexOf(banana)).isEqualTo(3);
 
-        assertTrue(fruits.contains(banana));
-        assertEquals(-1, fruits.indexOf(melon));
-        assertEquals(-1, fruits.lastIndexOf(melon));
+        assertThat(fruits.contains(banana)).isTrue();
+        assertThat(fruits.indexOf(melon)).isEqualTo(-1);
+        assertThat(fruits.lastIndexOf(melon)).isEqualTo(-1);
     }
 
     @Test
@@ -134,10 +130,10 @@ public class RedisListTest {
         fruits.add(orange);
         fruits.add(banana);
         fruits.add(waterMelon);
-        assertTrue(fruits.contains(banana));
-        assertFalse(fruits.contains(melon));
-        assertTrue(fruits.containsAll(Arrays.asList(banana, orange)));
-        assertFalse(fruits.containsAll(Arrays.asList(banana, melon)));
+        assertThat(fruits.contains(banana)).isTrue();
+        assertThat(fruits.contains(melon)).isFalse();
+        assertThat(fruits.containsAll(Arrays.asList(banana, orange))).isTrue();
+        assertThat(fruits.containsAll(Arrays.asList(banana, melon))).isFalse();
     }
 
     @SuppressWarnings("unused")
@@ -149,14 +145,14 @@ public class RedisListTest {
         for (ProductCart fruiCart : fruits) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         fruits.removeFirst();
         fruits.removeFirst();
         count = 0;
         for (ProductCart fruiCart : fruits) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
@@ -166,12 +162,12 @@ public class RedisListTest {
         fruits.add(waterMelon);
 
         fruits.clear();
-        assertTrue(fruits.isEmpty());
+        assertThat(fruits.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldThrowExceptionRetainAll() {
-        assertThrows(UnsupportedOperationException.class, () -> fruits.retainAll(Collections.singletonList(orange)));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> fruits.retainAll(Collections.singletonList(orange)));
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueStringTest.java
@@ -27,10 +27,7 @@ import java.util.Queue;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisQueueStringTest {
@@ -48,36 +45,36 @@ public class RedisQueueStringTest {
 
     @Test
     public void shouldPushInTheLine() {
-        assertTrue(lineBank.add("Otavio"));
-        assertEquals(1, lineBank.size());
+        assertThat(lineBank.add("Otavio")).isTrue();
+        assertThat(lineBank.size()).isEqualTo(1);
         String otavio = lineBank.poll();
-        assertEquals(otavio, "Otavio");
-        assertNull(lineBank.poll());
-        assertTrue(lineBank.isEmpty());
+        assertThat("Otavio").isEqualTo(otavio);
+        assertThat(lineBank.poll()).isNull();
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldPeekInTheLine() {
         lineBank.add("Otavio");
         String otavio = lineBank.peek();
-        assertNotNull(otavio);
-        assertNotNull(lineBank.peek());
+        assertThat(otavio).isNotNull();
+        assertThat(lineBank.peek()).isNotNull();
         String otavio2 = lineBank.remove();
-        assertEquals(otavio, otavio2);
+        assertThat(otavio2).isEqualTo(otavio);
         boolean happendException = false;
         try {
             lineBank.remove();
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @Test
     public void shouldElementInTheLine() {
         lineBank.add("Otavio");
-        assertNotNull(lineBank.element());
-        assertNotNull(lineBank.element());
+        assertThat(lineBank.element()).isNotNull();
+        assertThat(lineBank.element()).isNotNull();
         lineBank.remove("Otavio");
         boolean happendException = false;
         try {
@@ -85,7 +82,7 @@ public class RedisQueueStringTest {
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @SuppressWarnings("unused")
@@ -97,21 +94,21 @@ public class RedisQueueStringTest {
         for (String line : lineBank) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         lineBank.remove();
         lineBank.remove();
         count = 0;
         for (String line : lineBank) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
     public void shouldClear() {
         lineBank.add("Otavio");
         lineBank.clear();
-        assertTrue(lineBank.isEmpty());
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueTest.java
@@ -27,10 +27,7 @@ import java.util.Queue;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisQueueTest {
@@ -48,36 +45,36 @@ public class RedisQueueTest {
 
     @Test
     public void shouldPushInTheLine() {
-        assertTrue(lineBank.add(new LineBank("Otavio", 25)));
-        assertEquals(1, lineBank.size());
+        assertThat(lineBank.add(new LineBank("Otavio", 25))).isTrue();
+        assertThat(lineBank.size()).isEqualTo(1);
         LineBank otavio = lineBank.poll();
-        assertEquals(otavio.name(), "Otavio");
-        assertNull(lineBank.poll());
-        assertTrue(lineBank.isEmpty());
+        assertThat("Otavio").isEqualTo(otavio.name());
+        assertThat(lineBank.poll()).isNull();
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldPeekInTheLine() {
         lineBank.add(new LineBank("Otavio", 25));
         LineBank otavio = lineBank.peek();
-        assertNotNull(otavio);
-        assertNotNull(lineBank.peek());
+        assertThat(otavio).isNotNull();
+        assertThat(lineBank.peek()).isNotNull();
         LineBank otavio2 = lineBank.remove();
-        assertEquals(otavio.name(), otavio2.name());
+        assertThat(otavio2.name()).isEqualTo(otavio.name());
         boolean happendException = false;
         try {
             lineBank.remove();
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @Test
     public void shouldElementInTheLine() {
         lineBank.add(new LineBank("Otavio", 25));
-        assertNotNull(lineBank.element());
-        assertNotNull(lineBank.element());
+        assertThat(lineBank.element()).isNotNull();
+        assertThat(lineBank.element()).isNotNull();
         lineBank.remove(new LineBank("Otavio", 25));
         boolean happendException = false;
         try {
@@ -85,7 +82,7 @@ public class RedisQueueTest {
         } catch (NoSuchElementException e) {
             happendException = true;
         }
-        assertTrue(happendException);
+        assertThat(happendException).isTrue();
     }
 
     @SuppressWarnings("unused")
@@ -97,21 +94,21 @@ public class RedisQueueTest {
         for (LineBank line : lineBank) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         lineBank.remove();
         lineBank.remove();
         count = 0;
         for (LineBank line : lineBank) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
     public void shouldClear() {
         lineBank.add(new LineBank("Otavio", 25));
         lineBank.clear();
-        assertTrue(lineBank.isEmpty());
+        assertThat(lineBank.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetStringTest.java
@@ -27,8 +27,7 @@ import java.util.Set;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisSetStringTest {
@@ -47,17 +46,17 @@ public class RedisSetStringTest {
     @Test
     public void shouldAddUsers() {
         users.add("otaviojava");
-        assertEquals(1, users.size());
+        assertThat(users.size()).isEqualTo(1);
 
         String user = users.iterator().next();
-        assertEquals("otaviojava", user);
+        assertThat(user).isEqualTo("otaviojava");
     }
 
     @Test
     public void shouldRemoveSet() {
         users.add("otaviojava");
         users.remove("otaviojava");
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
     }
 
 
@@ -73,27 +72,27 @@ public class RedisSetStringTest {
         for (String user : users) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
         users.remove("otaviojava");
         users.remove("felipe");
         count = 0;
         for (String user : users) {
             count++;
         }
-        assertEquals(0, count);
+        assertThat(count).isEqualTo(0);
     }
 
     @Test
     public void shouldClear() {
         users.add("otaviojava");
         users.clear();
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldContains() {
         users.add("otaviojava");
-        assertTrue(users.contains("otaviojava"));
+        assertThat(users.contains("otaviojava")).isTrue();
     }
 
     @Test
@@ -101,7 +100,7 @@ public class RedisSetStringTest {
         users.add("otaviojava");
         users.add("furlaneto");
         users.add("joao");
-        assertTrue(users.containsAll(Arrays.asList("furlaneto", "otaviojava")));
+        assertThat(users.containsAll(Arrays.asList("furlaneto", "otaviojava"))).isTrue();
     }
 
     @Test
@@ -109,7 +108,7 @@ public class RedisSetStringTest {
         users.add("otaviojava");
         users.add("furlaneto");
         users.add("joao");
-        assertEquals(3, users.size());
+        assertThat(users.size()).isEqualTo(3);
     }
     
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetTest.java
@@ -29,9 +29,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class RedisSetTest {
@@ -50,7 +48,7 @@ public class RedisSetTest {
     @Test
     public void shouldAddUsers() {
         users.add(userOtavioJava);
-        assertEquals(1, users.size());
+        assertThat(users.size()).isEqualTo(1);
     }
 
     @Test
@@ -59,7 +57,7 @@ public class RedisSetTest {
         users.add(felipe);
         users.remove(felipe);
 
-        assertEquals(1, users.size());
+        assertThat(users.size()).isEqualTo(1);
         assertThat(users).isNotIn(felipe);
    }
 
@@ -69,7 +67,7 @@ public class RedisSetTest {
         users.add(felipe);
         users.removeAll(Arrays.asList(felipe, userOtavioJava));
 
-        assertEquals(0, users.size());
+        assertThat(users.size()).isEqualTo(0);
     }
 
     @SuppressWarnings("unused")
@@ -84,27 +82,27 @@ public class RedisSetTest {
         for (User user : users) {
             count++;
         }
-        assertEquals(2, count);
+        assertThat(count).isEqualTo(2);
     }
 
     @Test
     public void shouldContains() {
         users.add(userOtavioJava);
-        assertTrue(users.contains(userOtavioJava));
+        assertThat(users.contains(userOtavioJava)).isTrue();
     }
 
     @Test
     public void shouldContainsAll() {
         users.add(userOtavioJava);
         users.add(felipe);
-        assertTrue(users.containsAll(Arrays.asList(userOtavioJava, felipe)));
+        assertThat(users.containsAll(Arrays.asList(userOtavioJava, felipe))).isTrue();
     }
 
     @Test
     public void shouldReturnSize() {
         users.add(userOtavioJava);
         users.add(felipe);
-        assertEquals(2, users.size());
+        assertThat(users.size()).isEqualTo(2);
     }
 
     @Test
@@ -113,12 +111,12 @@ public class RedisSetTest {
         users.add(felipe);
 
         users.clear();
-        assertTrue(users.isEmpty());
+        assertThat(users.isEmpty()).isTrue();
     }
 
     @Test
     public void shouldThrowExceptionRetainAll() {
-        assertThrows(UnsupportedOperationException.class, () -> users.retainAll(Collections.singletonList(userOtavioJava)));
+        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> users.retainAll(Collections.singletonList(userOtavioJava)));
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactoryTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactoryTest.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
@@ -45,31 +45,31 @@ public class ValkeyBucketManagerFactoryTest {
     @Test
     public void shouldCreateKeyValueEntityManager() {
         BucketManager keyValueEntityManager = managerFactory.apply(BUCKET_NAME);
-        assertNotNull(keyValueEntityManager);
+        assertThat(keyValueEntityManager).isNotNull();
     }
 
     @Test
     public void shouldCreateMap() {
         Map<String, String> map = managerFactory.getMap(BUCKET_NAME, String.class, String.class);
-        assertNotNull(map);
+        assertThat(map).isNotNull();
     }
 
     @Test
     public void shouldCreateSet() {
         Set<String> set = managerFactory.getSet(BUCKET_NAME, String.class);
-        assertNotNull(set);
+        assertThat(set).isNotNull();
     }
 
     @Test
     public void shouldCreateList() {
         List<String> list = managerFactory.getList(BUCKET_NAME, String.class);
-        assertNotNull(list);
+        assertThat(list).isNotNull();
     }
 
     @Test
     public void shouldCreateQueue() {
         Queue<String> queue = managerFactory.getQueue(BUCKET_NAME, String.class);
-        assertNotNull(queue);
+        assertThat(queue).isNotNull();
     }
 
 }

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerTest.java
@@ -35,10 +35,6 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class ValkeyBucketManagerTest {
@@ -64,28 +60,28 @@ public class ValkeyBucketManagerTest {
     public void shouldPutValue() {
         keyValueEntityManager.put("otavio", userOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     public void shouldPutKeyValue() {
         keyValueEntityManager.put(keyValueOtavio);
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
     }
 
     @Test
     public void shouldPutIterableKeyValue() {
         keyValueEntityManager.put(asList(keyValueSoro, keyValueOtavio));
         Optional<Value> otavio = keyValueEntityManager.get("otavio");
-        assertTrue(otavio.isPresent());
-        assertEquals(userOtavio, otavio.get().get(User.class));
+        assertThat(otavio.isPresent()).isTrue();
+        assertThat(otavio.get().get(User.class)).isEqualTo(userOtavio);
 
         Optional<Value> soro = keyValueEntityManager.get("soro");
-        assertTrue(soro.isPresent());
-        assertEquals(userSoro, soro.get().get(User.class));
+        assertThat(soro.isPresent()).isTrue();
+        assertThat(soro.get().get(User.class)).isEqualTo(userSoro);
     }
 
     @Test
@@ -93,15 +89,15 @@ public class ValkeyBucketManagerTest {
         User user = new User("otavio");
         KeyValueEntity keyValue = KeyValueEntity.of("otavio", Value.of(user));
         keyValueEntityManager.put(keyValue);
-        assertNotNull(keyValueEntityManager.get("otavio"));
+        assertThat(keyValueEntityManager.get("otavio")).isNotNull();
     }
 
     @Test
     public void shouldRemoveKey() {
         keyValueEntityManager.put(keyValueOtavio);
-        assertTrue(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isTrue();
         keyValueEntityManager.delete("otavio");
-        assertFalse(keyValueEntityManager.get("otavio").isPresent());
+        assertThat(keyValueEntityManager.get("otavio").isPresent()).isFalse();
     }
 
     @Test
@@ -113,7 +109,7 @@ public class ValkeyBucketManagerTest {
                 .map(value -> value.get(User.class)).collect(Collectors.toList()))
                 .contains(userOtavio, userSoro);
         keyValueEntityManager.delete(keys);
-        assertEquals(0L, StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count());
+        assertThat(StreamSupport.stream(keyValueEntityManager.get(keys).spliterator(), false).count()).isEqualTo(0L);
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationTest.java
@@ -17,14 +17,14 @@ package org.eclipse.jnosql.databases.valkey.communication;
 
 import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ValkeyConfigurationTest {
 
@@ -40,23 +40,23 @@ public class ValkeyConfigurationTest {
         Map<String, String> map = new HashMap<>();
         map.put("redis-master-hoster", "localhost");
         BucketManagerFactory managerFactory = configuration.getManagerFactory(map);
-        assertNotNull(managerFactory);
+        assertThat(managerFactory).isNotNull();
     }
 
 
     @Test
     public void shouldReturnFromConfiguration() {
         KeyValueConfiguration configuration = KeyValueConfiguration.getConfiguration();
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof KeyValueConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof KeyValueConfiguration).isTrue();
     }
 
     @Test
     public void shouldReturnFromConfigurationQuery() {
         ValkeyConfiguration configuration = KeyValueConfiguration
                 .getConfiguration(ValkeyConfiguration.class);
-        Assertions.assertNotNull(configuration);
-        Assertions.assertTrue(configuration instanceof ValkeyConfiguration);
+        assertThat(configuration).isNotNull();
+        assertThat(configuration instanceof ValkeyConfiguration).isTrue();
     }
 
 }

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapStringTest.java
@@ -28,11 +28,6 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class ValkeyMapStringTest {
@@ -54,21 +49,21 @@ public class ValkeyMapStringTest {
 
     @Test
     public void shouldPutAndGetMap() {
-        assertNotNull(vertebrates.put(MAMMALS, MAMMALS));
+        assertThat(vertebrates.put(MAMMALS, MAMMALS)).isNotNull();
         String species = vertebrates.get(MAMMALS);
-        assertNotNull(species);
-        assertEquals(MAMMALS, vertebrates.get(MAMMALS));
-        assertEquals(1, vertebrates.size());
+        assertThat(species).isNotNull();
+        assertThat(vertebrates.get(MAMMALS)).isEqualTo(MAMMALS);
+        assertThat(vertebrates.size()).isEqualTo(1);
     }
 
     @Test
     public void shouldVerifyExist() {
         vertebrates.put(MAMMALS, MAMMALS);
-        assertTrue(vertebrates.containsKey(MAMMALS));
-        assertFalse(vertebrates.containsKey(FISHES));
+        assertThat(vertebrates.containsKey(MAMMALS)).isTrue();
+        assertThat(vertebrates.containsKey(FISHES)).isFalse();
 
-        assertTrue(vertebrates.containsValue(MAMMALS));
-        assertFalse(vertebrates.containsValue(FISHES));
+        assertThat(vertebrates.containsValue(MAMMALS)).isTrue();
+        assertThat(vertebrates.containsValue(FISHES)).isFalse();
     }
 
     @Test
@@ -80,12 +75,12 @@ public class ValkeyMapStringTest {
         Set<String> keys = vertebrates.keySet();
         Collection<String> collectionSpecies = vertebrates.values();
 
-        assertEquals(3, keys.size());
-        assertEquals(3, collectionSpecies.size());
-        assertNotNull(vertebrates.remove(MAMMALS));
-        assertNull(vertebrates.remove(MAMMALS));
-        assertNull(vertebrates.get(MAMMALS));
-        assertEquals(2, vertebrates.size());
+        assertThat(keys.size()).isEqualTo(3);
+        assertThat(collectionSpecies.size()).isEqualTo(3);
+        assertThat(vertebrates.remove(MAMMALS)).isNotNull();
+        assertThat(vertebrates.remove(MAMMALS)).isNull();
+        assertThat(vertebrates.get(MAMMALS)).isNull();
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @Test
@@ -95,7 +90,7 @@ public class ValkeyMapStringTest {
         vertebrates.put(AMPHIBIANS, AMPHIBIANS);
 
         vertebrates.remove(FISHES);
-        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates.size()).isEqualTo(2);
         assertThat(vertebrates).isNotIn(FISHES);
     }
 
@@ -105,7 +100,7 @@ public class ValkeyMapStringTest {
         vertebrates.put(FISHES, FISHES);
 
         vertebrates.clear();
-        assertTrue(vertebrates.isEmpty());
+        assertThat(vertebrates.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
@@ -29,11 +29,6 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.MATCHES;
 import static org.eclipse.jnosql.communication.driver.IntegrationTest.NAMED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIfSystemProperty(named = NAMED, matches = MATCHES)
 public class ValkeyMapTest {
@@ -54,11 +49,11 @@ public class ValkeyMapTest {
 
     @Test
     public void shouldPutAndGetMap() {
-        assertNotNull(vertebrates.put("mammals", mammals));
+        assertThat(vertebrates.put("mammals", mammals)).isNotNull();
         Species species = vertebrates.get("mammals");
-        assertNotNull(species);
-        assertEquals(species.getAnimals().getFirst(), mammals.getAnimals().getFirst());
-        assertEquals(1, vertebrates.size());
+        assertThat(species).isNotNull();
+        assertThat(mammals.getAnimals().getFirst()).isEqualTo(species.getAnimals().getFirst());
+        assertThat(vertebrates.size()).isEqualTo(1);
     }
 
     @Test
@@ -68,17 +63,17 @@ public class ValkeyMapTest {
         toPutAll.put("fishes", fishes);
 
         vertebrates.putAll(toPutAll);
-        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @Test
     public void shouldVerifyExist() {
         vertebrates.put("mammals", mammals);
-        assertTrue(vertebrates.containsKey("mammals"));
-        assertFalse(vertebrates.containsKey("redfish"));
+        assertThat(vertebrates.containsKey("mammals")).isTrue();
+        assertThat(vertebrates.containsKey("redfish")).isFalse();
 
-        assertTrue(vertebrates.containsValue(mammals));
-        assertFalse(vertebrates.containsValue(fishes));
+        assertThat(vertebrates.containsValue(mammals)).isTrue();
+        assertThat(vertebrates.containsValue(fishes)).isFalse();
     }
 
     @Test
@@ -90,12 +85,12 @@ public class ValkeyMapTest {
         Set<String> keys = vertebrates.keySet();
         Collection<Species> collectionSpecies = vertebrates.values();
 
-        assertEquals(3, keys.size());
-        assertEquals(3, collectionSpecies.size());
-        assertNotNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.remove("mammals"));
-        assertNull(vertebrates.get("mammals"));
-        assertEquals(2, vertebrates.size());
+        assertThat(keys.size()).isEqualTo(3);
+        assertThat(collectionSpecies.size()).isEqualTo(3);
+        assertThat(vertebrates.remove("mammals")).isNotNull();
+        assertThat(vertebrates.remove("mammals")).isNull();
+        assertThat(vertebrates.get("mammals")).isNull();
+        assertThat(vertebrates.size()).isEqualTo(2);
     }
 
     @Test
@@ -105,7 +100,7 @@ public class ValkeyMapTest {
         vertebrates.put("amphibians", amphibians);
 
         vertebrates.remove("fishes");
-        assertEquals(2, vertebrates.size());
+        assertThat(vertebrates.size()).isEqualTo(2);
         assertThat(vertebrates).isNotIn(fishes);
     }
 
@@ -115,7 +110,7 @@ public class ValkeyMapTest {
         vertebrates.put("fishes", fishes);
 
         vertebrates.clear();
-        assertTrue(vertebrates.isEmpty());
+        assertThat(vertebrates.isEmpty()).isTrue();
     }
 
     @AfterEach

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtilsTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtilsTest.java
@@ -17,18 +17,19 @@ package org.eclipse.jnosql.databases.valkey.communication;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 
 public class ValkeyUtilsTest {
 
     @Test
     public void shouldReturnNameSpace() {
-        assertEquals("namespace:key", ValkeyUtils.createKeyWithNameSpace("key", "namespace"));
+        assertThat(ValkeyUtils.createKeyWithNameSpace("key", "namespace")).isEqualTo("namespace:key");
     }
 
     @Test
     public void shouldThrowWithNullKey() {
-        assertThrows(IrregularKeyValue.class, () -> ValkeyUtils.createKeyWithNameSpace(null, ""));
+        assertThatExceptionOfType(IrregularKeyValue.class).isThrownBy(() -> ValkeyUtils.createKeyWithNameSpace(null, ""));
     }
 }


### PR DESCRIPTION
This pull request refactors the test code across several files in the `jnosql-arangodb` module to use AssertJ assertions instead of JUnit's built-in assertions. This change improves the readability and expressiveness of the tests, and aligns the codebase with a more modern assertion style.

**Assertion Library Migration:**

* Replaced all usages of `assertNotNull`, `assertTrue`, `assertFalse`, and `assertEquals` from JUnit with AssertJ's `assertThat(...).isNotNull()`, `assertThat(...).isTrue()`, `assertThat(...).isFalse()`, and `assertThat(...).isEqualTo(...)` in the following test files:
  - `ArangoDBDocumentConfigurationTest.java` [[1]](diffhunk://#diff-202eff9e73136cf00a17ec9c433bfcd8847c186b42c410b5ae516d123a6374a9L20-R23) [[2]](diffhunk://#diff-202eff9e73136cf00a17ec9c433bfcd8847c186b42c410b5ae516d123a6374a9L33-R48)
  - `ArangoDBDocumentManagerFactoryTest.java` [[1]](diffhunk://#diff-5b6f5b109b08bf62b76cc61470b68d38d4d6bbf392c0f0d6e31a6b602f3c8f72L24-R24) [[2]](diffhunk://#diff-5b6f5b109b08bf62b76cc61470b68d38d4d6bbf392c0f0d6e31a6b602f3c8f72L39-R39)
  - `ArangoDBDocumentManagerTest.java` [[1]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL56-L59) [[2]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL90-R86) [[3]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL100-R96) [[4]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL130-R131) [[5]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL183-R184) [[6]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL205-R206) [[7]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL221-R217) [[8]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL230-R226) [[9]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL256-R252) [[10]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL269-R265) [[11]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL279-R283)
  - `ArangoDBValueWriteDecoratorTest.java` [[1]](diffhunk://#diff-35ad485cd159f0e3a956d090000f1c60cbb77599a1fcf74cf24f2ac8d1426968L21-R22) [[2]](diffhunk://#diff-35ad485cd159f0e3a956d090000f1c60cbb77599a1fcf74cf24f2ac8d1426968L31-R32)
  - `QueryAQLConverterTest.java` [[1]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L31-R33) [[2]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L45-R46) [[3]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L60-R61) [[4]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L75-R76) [[5]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L89-R90) [[6]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L103-R104) [[7]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L117-R118) [[8]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L131-R132) [[9]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L143-R144)

**Test Consistency Improvements:**

* Ensured all assertion imports are consistent and removed unused JUnit assertion imports in favor of AssertJ. [[1]](diffhunk://#diff-202eff9e73136cf00a17ec9c433bfcd8847c186b42c410b5ae516d123a6374a9L20-R23) [[2]](diffhunk://#diff-5b6f5b109b08bf62b76cc61470b68d38d4d6bbf392c0f0d6e31a6b602f3c8f72L24-R24) [[3]](diffhunk://#diff-0b2c6f408543084ed37b0e748f5de720f49207d356893524f9afbfe0a6d7032bL56-L59) [[4]](diffhunk://#diff-35ad485cd159f0e3a956d090000f1c60cbb77599a1fcf74cf24f2ac8d1426968L21-R22) [[5]](diffhunk://#diff-fc59a6034b447b56844ca920ef9a19c7b8c208ab6d6478b44d983e80eed2f0b3L31-R33)

These changes are limited to test code and do not affect production logic. They help make the tests more expressive and maintainable.