### PR TITLE
Update license references to Eclipse Public License 2.0 across …

### DIFF
--- a/NOTICE.adoc
+++ b/NOTICE.adoc
@@ -6,7 +6,7 @@ Committers project.
 == Declared Project Licenses
 
 This program and the accompanying materials are made available under the terms of the Eclipse Public License 1.0 which is
- available at http://www.eclipse.org/legal/epl-v10.html, or the Apache Software License 2.0 which is available 
+ available at https://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0 which is available 
  at https://www.apache.org/licenses/LICENSE-2.0.
 
 
@@ -21,7 +21,7 @@ Copyright 2016-2017 The Eclipse Foundation
 == Third-party Content
 
 JUniT Version: 4.12
-* License: Eclipse Public License, 1.0
+* License: Eclipse Public License, 2.0
 
 
 == Cryptography

--- a/jnosql-arangodb/pom.xml
+++ b/jnosql-arangodb/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/AQLQueryResult.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/AQLQueryResult.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBAccessor.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBAccessor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBBuilder.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBBuilders.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBBuilders.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBCommunicationEdge.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBCommunicationEdge.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBConfiguration.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBConfigurations.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentConfiguration.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManager.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerFactory.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBException.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBUtil.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBValueWriteDecorator.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBValueWriteDecorator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/DefaultArangoDBDocumentManager.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/DefaultArangoDBDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/package-info.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/AQL.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/AQL.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/AQLProviderHandler.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/AQLProviderHandler.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBExtension.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBRepository.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBRepositoryBean.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBRepositoryBean.java
@@ -46,11 +46,12 @@ class ArangoDBRepositoryBean<T, K> extends AbstractBean<ArangoDBRepository<T, K>
         return type;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public ArangoDBRepository<T, K> create(CreationalContext<ArangoDBRepository<T, K>> creationalContext) {
         var template = getInstance(ArangoDBTemplate.class);
         var semiStructuredConverter = getInstance(SemistructuredRepositoryProducer.class);
-        return semiStructuredConverter.get(type, template);
+        return (ArangoDBRepository<T, K>) semiStructuredConverter.get(type, template);
     }
 
     @Override

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBRepositoryBean.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBTemplate.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/DefaultArangoDBTemplate.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/DefaultArangoDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/DocumentManagerSupplier.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/DocumentManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/package-info.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/mapping/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/package-info.java
+++ b/jnosql-arangodb/src/main/java/org/eclipse/jnosql/databases/arangodb/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/main/resources/META-INF/beans.xml
+++ b/jnosql-arangodb/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-arangodb/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/jnosql-arangodb/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2022 Contributors to the Eclipse Foundation
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentConfigurationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerFactoryTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBValueWriteDecoratorTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ArangoDBValueWriteDecoratorTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ContactType.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/DocumentDatabase.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/Human.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/QueryAQLConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/User.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBEnumIntegrationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBEnumIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBTemplateIntegrationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBTemplateIntegrationUsingIdAnnotationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/ArangoDBTemplateIntegrationUsingIdAnnotationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/Article.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/Article.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/GraphTemplateIntegrationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/GraphTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/Magazine.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MagazineRepository.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MagazineRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MailCategory.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MailCategory.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MailTemplate.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MailTemplate.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MailTemplateRepository.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MailTemplateRepository.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2025 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MainStepType.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/MainStepType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/RepositoryIntegrationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/RepositoryIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/StepTransitionReason.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/StepTransitionReason.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/TemplateIntegrationTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/Transition.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/Transition.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/WorkflowStep.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/WorkflowStep.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/WorkflowStepBuilder.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/integration/WorkflowStepBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBDocumentRepositoryProxyTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBDocumentRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBExtensionTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/ArangoDBExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/DefaultArangoDBTemplateTest.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/DefaultArangoDBTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/Human.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/HumanRepository.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/HumanRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/MockProducer.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/tck/ArangoDBTemplateSupplier.java
+++ b/jnosql-arangodb/src/test/java/org/eclipse/jnosql/databases/arangodb/tck/ArangoDBTemplateSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-arangodb/src/test/resources/META-INF/beans.xml
+++ b/jnosql-arangodb/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-cassandra/pom.xml
+++ b/jnosql-cassandra/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManager.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactory.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfiguration.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfigurations.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConverter.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraPreparedStatement.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraPreparedStatement.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraProperties.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraProperties.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraQuery.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraQuery.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultCassandraColumnManager.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultCassandraColumnManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultUDT.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultUDT.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DeleteQueryConverter.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/DeleteQueryConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/IterableUDT.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/IterableUDT.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/QueryExecutor.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/QueryExecutor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/QueryExecutorType.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/QueryExecutorType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/QueryUtils.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/QueryUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/Relations.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/Relations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDT.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDT.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTBuilder.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTElementBuilder.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTElementBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTFinisherBuilder.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTFinisherBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTNameBuilder.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/UDTNameBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/package-info.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CQL.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CQL.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CQLProviderHandler.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CQLProviderHandler.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverter.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraExtension.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepository.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryBean.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryBean.java
@@ -45,11 +45,12 @@ class CassandraRepositoryBean<T, K> extends AbstractBean<CassandraRepository<T, 
         return type;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public CassandraRepository<T, K> create(CreationalContext<CassandraRepository<T, K>> creationalContext) {
         var template = getInstance(CassandraTemplate.class);
         var semiStructuredConverter = getInstance(SemistructuredRepositoryProducer.class);
-        return semiStructuredConverter.get(type, template);
+        return (CassandraRepository<T, K>) semiStructuredConverter.get(type, template);
     }
 
 

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryBean.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraTemplate.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraUDTType.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraUDTType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/ColumnManagerSupplier.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/ColumnManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/DefaultCassandraTemplate.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/DefaultCassandraTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/TimestampConverter.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/TimestampConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/package-info.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/package-info.java
+++ b/jnosql-cassandra/src/main/java/org/eclipse/jnosql/databases/cassandra/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/main/resources/META-INF/beans.xml
+++ b/jnosql-cassandra/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactoryTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraColumnManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfigurationTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/CassandraConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/ColumnDatabase.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/ColumnDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/Constants.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/Constants.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultUDTTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/communication/DefaultUDTTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/integration/CassandraTemplateIntegrationTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/integration/CassandraTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/integration/Magazine.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/integration/TemplateIntegrationTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/Address.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/Address.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverterTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraColumnEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraExtensionTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryProxyTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/CassandraRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/ContactCassandra.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/ContactCassandra.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/ContactRepository.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/ContactRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/DefaultCassandraTemplateTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/DefaultCassandraTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/HumanRepository.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/HumanRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/MockProducer.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/TimestampConverterTest.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/converters/TimestampConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Actor.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Actor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/ActorBuilder.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/ActorBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/AppointmentBook.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/AppointmentBook.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Artist.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Artist.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/ArtistBuilder.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/ArtistBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Contact.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Contact.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Creature.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Creature.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Director.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Director.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/History2.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/History2.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Job.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Job.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Machine.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Machine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Money.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Money.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/MoneyConverter.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/MoneyConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Movie.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Movie.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/User.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Worker.java
+++ b/jnosql-cassandra/src/test/java/org/eclipse/jnosql/databases/cassandra/mapping/model/Worker.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-cassandra/src/test/resources/META-INF/beans.xml
+++ b/jnosql-cassandra/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManager.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManagerFactory.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseConfiguration.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseConfigurations.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentConfiguration.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManager.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerFactory.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseKeyValueConfiguration.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseKeyValueConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseNoKeyFoundException.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseNoKeyFoundException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseSettings.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseSettings.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseValue.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseValue.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseBucketManagerFactory.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseDocumentManager.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DeleteQueryWrapper.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/DeleteQueryWrapper.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/EntityConverter.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/EntityConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLBuilder.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLQuery.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLSelectQueryBuilder.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLSelectQueryBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLUpdateQueryBuilder.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/communication/N1QLUpdateQueryBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseExtension.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseRepository.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseRepositoryBean.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseRepositoryBean.java
@@ -47,11 +47,12 @@ class CouchbaseRepositoryBean<T, K> extends AbstractBean<CouchbaseRepository<T, 
     }
 
 
+    @SuppressWarnings("unchecked")
     @Override
     public CouchbaseRepository<T, K> create(CreationalContext<CouchbaseRepository<T, K>> creationalContext) {
         var template = getInstance(CouchbaseTemplate.class);
         var semiStructuredConverter = getInstance(SemistructuredRepositoryProducer.class);
-        return semiStructuredConverter.get(type, template);
+        return (CouchbaseRepository<T, K>) semiStructuredConverter.get(type, template);
     }
 
 

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseRepositoryBean.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseTemplate.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/DefaultCouchbaseTemplate.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/DefaultCouchbaseTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/DocumentManagerSupplier.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/DocumentManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/JsonObjectUtil.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/JsonObjectUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/N1QL.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/N1QL.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/N1QLProviderHandler.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/N1QLProviderHandler.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/package-info.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/mapping/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/package-info.java
+++ b/jnosql-couchbase/src/main/java/org/eclipse/jnosql/databases/couchbase/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/main/resources/META-INF/beans.xml
+++ b/jnosql-couchbase/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/ContactType.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManagerTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseBucketManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentConfigurationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerFactoryTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseKeyValueConfigurationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseKeyValueConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseUtil.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/CouchbaseUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/Database.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/Database.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseBucketManagerFactoryTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DefaultCouchbaseBucketManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DocumentQueryTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/DocumentQueryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/ProductCart.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/ProductCart.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/User.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseDocumentRepositoryIntegrationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseDocumentRepositoryIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseTemplateIntegrationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/CouchbaseTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/DocumentTemplateIntegrationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/DocumentTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/Library.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/Library.java
@@ -2,10 +2,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/Magazine.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/TemplateIntegrationTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseDocumentRepositoryProxyTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseDocumentRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseExtensionTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/CouchbaseExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/DefaultCouchbaseTemplateTest.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/DefaultCouchbaseTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/Human.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/HumanRepository.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/HumanRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/MockProducer.java
+++ b/jnosql-couchbase/src/test/java/org/eclipse/jnosql/databases/couchbase/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchbase/src/test/resources/META-INF/beans.xml
+++ b/jnosql-couchbase/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-couchbase/src/test/resources/couchbase.properties
+++ b/jnosql-couchbase/src/test/resources/couchbase.properties
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2017 Otávio Santana and others
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-couchdb/pom.xml
+++ b/jnosql-couchdb/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategy.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategy.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategyFactory.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategyFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBConfigurations.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBConfigurations.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBConstant.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBConstant.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentConfiguration.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentConfiguration.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentManager.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentManager.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentManagerFactory.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentManagerFactory.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentQuery.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentQuery.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpClient.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpClient.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpClientException.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpClientException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpConfiguration.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpConfigurationBuilder.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBHttpConfigurationBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchdbDeleteQuery.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/CouchdbDeleteQuery.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManager.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManager.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/DeleteElement.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/DeleteElement.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/HttpExecute.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/HttpExecute.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/MangoQueryConverter.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/MangoQueryConverter.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/package-info.java
+++ b/jnosql-couchdb/src/main/java/org/eclipse/jnosql/databases/couchdb/communication/package-info.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategyFactoryTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBAuthenticationStrategyFactoryTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentConfigurationTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/CouchDBDocumentConfigurationTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/DefaultCouchDBDocumentManagerTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/JsonArgumentProvider.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/JsonArgumentProvider.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/JsonSource.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/JsonSource.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/MangoQueryConverterTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/MangoQueryConverterTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/configuration/CouchDBContainer.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/configuration/CouchDBContainer.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/configuration/DocumentDatabase.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/configuration/DocumentDatabase.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/integration/Failure.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/integration/Failure.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/integration/Magazine.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/integration/TemplateIntegrationTest.java
+++ b/jnosql-couchdb/src/test/java/org/eclipse/jnosql/databases/couchdb/communication/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-couchdb/src/test/resources/couchdb.properties
+++ b/jnosql-couchdb/src/test/resources/couchdb.properties
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2017 Otávio Santana and others
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-couchdb/src/test/resources/logback-test.xml
+++ b/jnosql-couchdb/src/test/resources/logback-test.xml
@@ -1,10 +1,10 @@
 <!--
    Copyright (c) 2022 Contributors to the Eclipse Foundation
     All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
+    are made available under the terms of the Eclipse Public License 2.0
     and Apache License v2.0 which accompanies this distribution.
-    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 
     You may elect to redistribute this code under either of these licenses.
 

--- a/jnosql-database-commons/pom.xml
+++ b/jnosql-database-commons/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/CompositeValueWriter.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/CompositeValueWriter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/ConfigurationReader.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/ConfigurationReader.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/DefaultJsonbSupplier.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/DefaultJsonbSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/IntegrationTest.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/IntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/JsonbSupplier.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/JsonbSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/JsonbSupplierServiceLoader.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/JsonbSupplierServiceLoader.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/StringMatch.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/StringMatch.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/UUIDValueWriter.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/UUIDValueWriter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/ValueJSON.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/ValueJSON.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/ByteArrayEntityAttachment.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/ByteArrayEntityAttachment.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/EntityAttachment.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/EntityAttachment.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/PathEntityAttachment.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/communication/driver/attachment/PathEntityAttachment.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/main/java/org/eclipse/jnosql/mapping/driver/ParamUtil.java
+++ b/jnosql-database-commons/src/main/java/org/eclipse/jnosql/mapping/driver/ParamUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/AttachmentTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/AttachmentTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/CompositeValueWriterTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/CompositeValueWriterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/DefaultJsonBSupplierTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/DefaultJsonBSupplierTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/StringMatchTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/StringMatchTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/UUIDValueWriterTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/UUIDValueWriterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/User.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/ValueJSONTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/communication/driver/ValueJSONTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-database-commons/src/test/java/org/eclipse/jnosql/mapping/driver/ParamUtilTest.java
+++ b/jnosql-database-commons/src/test/java/org/eclipse/jnosql/mapping/driver/ParamUtilTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ~ Copyright (c) 2022 Contributors to the Eclipse Foundation ~ All rights reserved.
 	This program and the accompanying materials ~ are made available under the 
-	terms of the Eclipse Public License v1.0 ~ and Apache License v2.0 which 
+	terms of the Eclipse Public License 2.0 ~ and Apache License v2.0 which 
 	accompanies this distribution. ~ The Eclipse Public License is available 
-	at http://www.eclipse.org/legal/epl-v10.html ~ and the Apache License v2.0 
-	is available at http://www.opensource.org/licenses/apache2.0.php. ~ ~ You 
+	at https://www.eclipse.org/legal/epl-2.0 ~ and the Apache License v2.0 
+	is available at https://www.apache.org/licenses/LICENSE-2.0. ~ ~ You 
 	may elect to redistribute this code under either of these licenses. ~ ~ Contributors: 
 	~ ~ Otavio Santana -->
 

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/ConfigurationAmazonEntity.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/ConfigurationAmazonEntity.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManager.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManager.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBucketManager.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBucketManagerFactory.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilder.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilderASync.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilderASync.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilderSync.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilderSync.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilders.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBBuilders.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConfiguration.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConfigurations.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConverter.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConverter.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDatabaseManager.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDatabaseManager.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDatabaseManagerFactory.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDatabaseManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDocumentConfiguration.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueConfiguration.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQuery.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQuery.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQueryBuilder.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQueryBuilder.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQuerySelectBuilder.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBQuerySelectBuilder.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBUtils.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoTableUtils.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoTableUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/package-info.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DefaultDynamoDBTemplate.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DefaultDynamoDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DocumentManagerSupplier.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DocumentManagerSupplier.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBExtension.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBExtension.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepository.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepository.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryBean.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryProxy.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryProxy.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBTemplate.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/PartiQL.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/mapping/PartiQL.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/package-info.java
+++ b/jnosql-dynamodb/src/main/java/org/eclipse/jnosql/databases/dynamodb/package-info.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/main/resources/META-INF/beans.xml
+++ b/jnosql-dynamodb/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~ Copyright (c) 2024 Contributors to the Eclipse Foundation
   ~ All rights reserved. This program and the accompanying materials
-  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ are made available under the terms of the Eclipse Public License 2.0
   ~ and Apache License v2.0 which accompanies this distribution.
-  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~ and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~ The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~ and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~ You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-dynamodb/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/jnosql-dynamodb/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,10 +1,10 @@
 #
 # Copyright (c) 2024 Contributors to the Eclipse Foundation
 # All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
+# are made available under the terms of the Eclipse Public License 2.0
 # and Apache License v2.0 which accompanies this distribution.
-# The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-# and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+# The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+# and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 # You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/CommunicationEntityGenerator.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/CommunicationEntityGenerator.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerFactoryTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DefaultDynamoDBDatabaseManagerTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConverterTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBConverterTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDocumentConfigurationTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueConfigurationTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueEntityManagerTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBKeyValueEntityManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBTestUtils.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/DynamoDBTestUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/User.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/integration/DynamoDBTemplateIntegrationTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/integration/DynamoDBTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/integration/Magazine.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DefaultDynamoDBTemplateTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DefaultDynamoDBTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBExtensionTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryProxyTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/DynamoDBRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/Human.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/Human.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/HumanNoSQLRepository.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/HumanNoSQLRepository.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/MockProducer.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/BigProject.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/BigProject.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/BigProjects.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/BigProjects.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/InheritanceWithCustomRepositoryTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/InheritanceWithCustomRepositoryTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/InheritanceWithDifferentRepositoriesTest.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/InheritanceWithDifferentRepositoriesTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/Project.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/Project.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/Projects.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/Projects.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/SmallProject.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/SmallProject.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/SmallProjects.java
+++ b/jnosql-dynamodb/src/test/java/org/eclipse/jnosql/databases/dynamodb/mapping/inheritance/SmallProjects.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/DefaultElasticsearchDocumentManager.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/DefaultElasticsearchDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchAddress.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchAddress.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchConfigurations.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfiguration.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfiguration.java
@@ -2,10 +2,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManager.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerFactory.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentQuery.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchEntry.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchEntry.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchException.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchKeyFoundException.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchKeyFoundException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/EntityConverter.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/EntityConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverter.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterResult.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterResult.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/package-info.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DefaultElasticsearchTemplate.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DefaultElasticsearchTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DocumentManagerSupplier.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DocumentManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/mapping/ElasticsearchTemplate.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/mapping/ElasticsearchTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/package-info.java
+++ b/jnosql-elasticsearch/src/main/java/org/eclipse/jnosql/databases/elasticsearch/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/main/resources/META-INF/beans.xml
+++ b/jnosql-elasticsearch/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ContactType.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentDatabase.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentEntityGerator.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/DocumentEntityGerator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfigurationTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerFactoryTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/ElasticsearchDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/communication/QueryConverterTest.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Author.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Author.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/ElasticsearchTemplateIntegrationTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/ElasticsearchTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Library.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Library.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * are made available under the terms of the Eclipse Public License 2.0
  * and Apache License v2.0 which accompanies this distribution.
- * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ * The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ * and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  * You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Magazine.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/RepositoryIntegrationTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/RepositoryIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/TemplateIntegrationTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DefaultElasticsearchTemplateTest.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/mapping/DefaultElasticsearchTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/mapping/Human.java
+++ b/jnosql-elasticsearch/src/test/java/org/eclipse/jnosql/databases/elasticsearch/mapping/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-elasticsearch/src/test/resources/META-INF/beans.xml
+++ b/jnosql-elasticsearch/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-hazelcast/pom.xml
+++ b/jnosql-hazelcast/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManager.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManagerFactory.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManager.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerFactory.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastConfigurations.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastKeyValueConfiguration.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastKeyValueConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/BucketManagerSupplier.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/BucketManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/DefaultHazelcastTemplate.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/DefaultHazelcastTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/HazelcastTemplate.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/HazelcastTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/package-info.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/mapping/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/package-info.java
+++ b/jnosql-hazelcast/src/main/java/org/eclipse/jnosql/databases/hazelcast/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/main/resources/META-INF/beans.xml
+++ b/jnosql-hazelcast/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManagerFactoryTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/DefaultHazelcastBucketManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerQueryTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerQueryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/HazelcastBucketManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueConfigurationTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueEntityManagerFactoryTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/KeyValueEntityManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/ListTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/ListTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/MapTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/QueueTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/QueueTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/SetTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/SetTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/Human.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/LineBank.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/LineBank.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/Movie.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/Movie.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/ProductCart.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/ProductCart.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/Species.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/Species.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/User.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/model/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/util/KeyValueEntityManagerFactoryUtils.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/communication/util/KeyValueEntityManagerFactoryUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/integration/HazelcastTemplateIntegrationTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/integration/HazelcastTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/integration/KeyValueTemplateIntegrationTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/integration/KeyValueTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/integration/Magazine.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/DefaultHazelcastTemplateTest.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/DefaultHazelcastTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/Human.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/MockProducer.java
+++ b/jnosql-hazelcast/src/test/java/org/eclipse/jnosql/databases/hazelcast/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hazelcast/src/test/resources/beans.xml
+++ b/jnosql-hazelcast/src/test/resources/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-hbase/pom.xml
+++ b/jnosql-hbase/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/EntityUnit.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/EntityUnit.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnConfiguration.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManager.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManagerFactory.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseException.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseUtils.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HBaseUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HbaseConfigurations.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/HbaseConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/package-info.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/package-info.java
+++ b/jnosql-hbase/src/main/java/org/eclipse/jnosql/databases/hbase/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnConfigurationTest.java
+++ b/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManagerFactoryTest.java
+++ b/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseColumnManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseFamilyManagerTest.java
+++ b/jnosql-hbase/src/test/java/org/eclipse/jnosql/databases/hbase/communication/HBaseFamilyManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanBucketManager.java
+++ b/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanBucketManagerFactory.java
+++ b/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanConfigurations.java
+++ b/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanKeyValueConfiguration.java
+++ b/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/InfinispanKeyValueConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/package-info.java
+++ b/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/package-info.java
+++ b/jnosql-infinispan/src/main/java/org/eclipse/jnosql/databases/infinispan/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueConfigurationTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerFactoryTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/KeyValueEntityManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/MapTest.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/MapTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/Human.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/LineBank.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/LineBank.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/ProductCart.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/ProductCart.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/Species.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/Species.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/User.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/model/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/util/KeyValueEntityManagerFactoryUtils.java
+++ b/jnosql-infinispan/src/test/java/org/eclipse/jnosql/databases/infinispan/communication/util/KeyValueEntityManagerFactoryUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-infinispan/src/test/resources/infinispan.xml
+++ b/jnosql-infinispan/src/test/resources/infinispan.xml
@@ -1,10 +1,10 @@
 <!--
  Copyright (c) 2022 Contributors to the Eclipse Foundation
  All rights reserved. This program and the accompanying materials
- are made available under the terms of the Eclipse Public License v1.0
+ are made available under the terms of the Eclipse Public License 2.0
  and Apache License v2.0 which accompanies this distribution.
- The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 
  You may elect to redistribute this code under either of these licenses.
 

--- a/jnosql-memcached/pom.xml
+++ b/jnosql-memcached/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManager.java
+++ b/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerFactory.java
+++ b/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedConfigurations.java
+++ b/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedException.java
+++ b/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedKeyValueConfiguration.java
+++ b/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedKeyValueConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/package-info.java
+++ b/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/package-info.java
+++ b/jnosql-memcached/src/main/java/org/eclipse/jnosql/databases/memcached/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/KeyValueConfigurationTest.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/KeyValueConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/KeyValueDatabase.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/KeyValueDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerFactoryTest.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerTest.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/MemcachedBucketManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/User.java
+++ b/jnosql-memcached/src/test/java/org/eclipse/jnosql/databases/memcached/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-memcached/src/test/resources/diana-memcached.properties
+++ b/jnosql-memcached/src/test/resources/diana-memcached.properties
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2019 Otávio Santana and others
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/BinaryValueReader.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/BinaryValueReader.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/DocumentQueryConversor.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/DocumentQueryConversor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/HostPortConfiguration.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/HostPortConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoAuthentication.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoAuthentication.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfiguration.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfigurations.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManager.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerFactory.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBUtils.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBValueWriteDecorator.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBValueWriteDecorator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/DefaultMongoDBTemplate.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/DefaultMongoDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/DocumentManagerSupplier.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/DocumentManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/MongoDBTemplate.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/MongoDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/ObjectIdConverter.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/mapping/ObjectIdConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/package-info.java
+++ b/jnosql-mongodb/src/main/java/org/eclipse/jnosql/databases/mongodb/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/main/resources/META-INF/beans.xml
+++ b/jnosql-mongodb/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/BinaryValueReaderTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/BinaryValueReaderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/ContactType.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/DocumentDatabase.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/DocumentQueryConverterTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/DocumentQueryConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoAuthenticationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoAuthenticationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfigurationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerFactoryTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBQueryTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBQueryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBSpecificFeaturesTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBSpecificFeaturesTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBValueWriteDecoratorTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/MongoDBValueWriteDecoratorTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/type/Money.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/type/Money.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/type/MoneyValueReader.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/type/MoneyValueReader.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/type/MoneyValueWriter.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/communication/type/MoneyValueWriter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Article.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Article.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/AsciiCharacter.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/AsciiCharacter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/AsciiCharacters.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/AsciiCharacters.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/BookOrder.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/BookOrder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/BookOrderItem.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/BookOrderItem.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/BookStore.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/BookStore.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/ComputerRecord.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/ComputerRecord.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/CustomRepositoryIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/CustomRepositoryIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Machine.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Machine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MachineRepository.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MachineRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Magazine.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MagazineCustomRepository.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MagazineCustomRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MagazineRepository.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MagazineRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MainStepType.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MainStepType.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MongoDBComputer.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MongoDBComputer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MongoDBProgram.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MongoDBProgram.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MongoDBTemplateIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/MongoDBTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/ProgramRecord.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/ProgramRecord.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/RepositoryIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/StepTransitionReason.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/StepTransitionReason.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/TemplateIntegrationTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Transition.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/Transition.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/WorkflowStep.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/WorkflowStep.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/WorkflowStepBuilder.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/integration/WorkflowStepBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/Birthday.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/Birthday.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DefaultMongoDBTemplateTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DefaultMongoDBTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DocumentEntityConverterTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/DocumentEntityConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/MongoDBTemplateTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/MongoDBTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/Music.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/Music.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/ObjectIdConverterTest.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/mapping/ObjectIdConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/tck/MongoDBTemplateSupplier.java
+++ b/jnosql-mongodb/src/test/java/org/eclipse/jnosql/databases/mongodb/tck/MongoDBTemplateSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-mongodb/src/test/resources/META-INF/beans.xml
+++ b/jnosql-mongodb/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-mongodb/src/test/resources/diana-mongodb.properties
+++ b/jnosql-mongodb/src/test/resources/diana-mongodb.properties
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2017 Otávio Santana and others
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/DefaultNeo4JDatabaseManager.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/DefaultNeo4JDatabaseManager.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/EdgeCommunicationException.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/EdgeCommunicationException.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/LikeToCypherRegex.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/LikeToCypherRegex.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JCommunicationException.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JCommunicationException.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JConfiguration.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JConfiguration.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JConfigurations.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JConfigurations.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManager.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManager.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerFactory.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerFactory.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilder.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4Property.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4Property.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4jCommunicationEdge.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4jCommunicationEdge.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/package-info.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/communication/package-info.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Cypher.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Cypher.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/DefaultNeo4JTemplate.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/DefaultNeo4JTemplate.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/GraphManagerSupplier.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/GraphManagerSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JExtension.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JRepository.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JRepositoryBean.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JRepositoryProxy.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JRepositoryProxy.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JTemplate.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JTemplate.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/ParamConverterUtils.java
+++ b/jnosql-neo4j/src/main/java/org/eclipse/jnosql/databases/neo4j/mapping/ParamConverterUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/main/resources/META-INF/beans.xml
+++ b/jnosql-neo4j/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/DatabaseContainer.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/DatabaseContainer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/LikeToCypherRegexTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/LikeToCypherRegexTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JDatabaseManagerTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/communication/Neo4JQueryBuilderTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/GraphTemplateIntegrationTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/GraphTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/Magazine.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/MagazineRepository.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/MagazineRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/RepositoryIntegrationTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/RepositoryIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/TemplateIntegrationTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Birthday.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Birthday.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Contact.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Contact.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/DefaultNeo4JTemplateTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/DefaultNeo4JTemplateTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Music.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Music.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/MusicRepository.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/MusicRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/MusicStoreRepository.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/MusicStoreRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JTemplateTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4JTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jExtensionTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jRepositoryProxyTest.java
+++ b/jnosql-neo4j/src/test/java/org/eclipse/jnosql/databases/neo4j/mapping/Neo4jRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-neo4j/src/test/resources/META-INF/beans.xml
+++ b/jnosql-neo4j/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-oracle-nosql/pom.xml
+++ b/jnosql-oracle-nosql/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/AbstractQueryBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeleteBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeleteBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeploymentType.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/DeploymentType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/NoSQLHandleConfigConfiguration.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/NoSQLHandleConfigConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/NoSQLHandleConfiguration.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/NoSQLHandleConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentConfiguration.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentManagerFactory.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManagerFactory.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLConfigurations.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManager.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLException.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLKeyValueConfiguration.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLKeyValueConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLValueWriteDecorator.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLValueWriteDecorator.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverter.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleQuery.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/OracleQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectCountBuilder.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/SelectCountBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/TableCreationConfiguration.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/communication/TableCreationConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/DefaultOracleNoSQLTemplate.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/DefaultOracleNoSQLTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/DocumentManagerSupplier.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/DocumentManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2024 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDocumentRepositoryProxy.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDocumentRepositoryProxy.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleExtension.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleNoSQLRepository.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleNoSQLRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleNoSQLTemplate.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleNoSQLTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleRepositoryBean.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/OracleRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/ParamUtil.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/ParamUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/SQL.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/mapping/SQL.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/package-info.java
+++ b/jnosql-oracle-nosql/src/main/java/org/eclipse/jnosql/databases/oracle/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/main/resources/META-INF/beans.xml
+++ b/jnosql-oracle-nosql/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-oracle-nosql/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/jnosql-oracle-nosql/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2022 Contributors to the Eclipse Foundation
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/ContactType.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/Database.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/Database.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerDeleteCountTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerDeleteCountTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DefaultOracleNoSQLDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DeploymentTypeTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/DeploymentTypeTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/FieldValueConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/NullPredicateQueryBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/NullPredicateQueryBuilderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentConfigurationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLBucketManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLKeyValueConfigurationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLKeyValueConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionFieldValueConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionFieldValueConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionResultTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSQLProjectionResultTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverterTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/OracleNoSqlLikeConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/QueryValueNormalizationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/QueryValueNormalizationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/SelectBuilderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  */

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/User.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Contact.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Contact.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/ContactRepository.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/ContactRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Crew.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Crew.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Magazine.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/OracleNoSQLTemplateIntegrationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/OracleNoSQLTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Wine.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/Wine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/WineBuilder.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/WineBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/WineTemplateIntegrationTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/integration/WineTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/DefaultOracleNoSQLTemplateTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/DefaultOracleNoSQLTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/Human.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/HumanNoSQLRepository.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/HumanNoSQLRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/MockProducer.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDBExtensionTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDBExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDocumentRepositoryProxyTest.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/mapping/OracleDocumentRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/tck/OracleNoSQLTemplateSupplier.java
+++ b/jnosql-oracle-nosql/src/test/java/org/eclipse/jnosql/databases/oracle/tck/OracleNoSQLTemplateSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-oracle-nosql/src/test/resources/META-INF/beans.xml
+++ b/jnosql-oracle-nosql/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/DefaultOrientDBDocumentManager.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/DefaultOrientDBDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/LiveQueryListener.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/LiveQueryListener.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBConverter.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfiguration.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurations.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManager.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerFactory.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentQuery.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBException.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallback.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallback.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallbackBuilder.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallbackBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCreateCallback.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCreateCallback.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveDeleteCallback.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveDeleteCallback.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveUpdateCallback.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveUpdateCallback.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverter.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLFactory.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/DefaultOrientDBTemplate.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/DefaultOrientDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/DocumentManagerSupplier.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/DocumentManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBCrudRepository.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBCrudRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBDocumentRepositoryProxy.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBDocumentRepositoryProxy.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBExtension.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBLiveCallbackBuilder.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBLiveCallbackBuilder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBRepositoryBean.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBTemplate.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/SQL.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/SQL.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/package-info.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/mapping/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/package-info.java
+++ b/jnosql-orientdb/src/main/java/org/eclipse/jnosql/databases/orientdb/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/main/resources/META-INF/beans.xml
+++ b/jnosql-orientdb/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/ContactType.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/Database.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/Database.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/DocumentDatabase.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurationTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerFactoryTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallbackBuilderTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/OrientDBLiveCallbackBuilderTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverterTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/communication/QueryOSQLConverterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/Magazine.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/OrientDBTemplateIntegrationTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/OrientDBTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/TemplateIntegrationTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/DefaultOrientDBTemplateTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/DefaultOrientDBTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/MockProducer.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBDocumentRepositoryProxyTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBDocumentRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBExtensionTest.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/OrientDBExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/PersonRepository.java
+++ b/jnosql-orientdb/src/test/java/org/eclipse/jnosql/databases/orientdb/mapping/PersonRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-orientdb/src/test/resources/META-INF/beans.xml
+++ b/jnosql-orientdb/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-orientdb/src/test/resources/orientdb.properties
+++ b/jnosql-orientdb/src/test/resources/orientdb.properties
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2017 Otávio Santana and others
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-ravendb/pom.xml
+++ b/jnosql-ravendb/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/DocumentQueryConverter.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/DocumentQueryConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/EntityConverter.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/EntityConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentConfiguration.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManager.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerFactory.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBEntry.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBEntry.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDeleteQuery.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDeleteQuery.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/package-info.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/package-info.java
+++ b/jnosql-ravendb/src/main/java/org/eclipse/jnosql/databases/ravendb/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/ContactType.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/DocumentConfigurationUtils.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/DocumentConfigurationUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentConfigurationTest.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerFactoryTest.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerTest.java
+++ b/jnosql-ravendb/src/test/java/org/eclipse/jnosql/databases/ravendb/communication/RavenDBDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/Counter.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/Counter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounter.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultRanking.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultRanking.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultRedisBucketManagerFactory.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultRedisBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSet.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSet.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/IrregularKeyValue.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/IrregularKeyValue.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/Ranking.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/Ranking.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManager.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerFactory.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisClusterConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisCollection.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisCollection.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationsResolver.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationsResolver.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisList.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisMap.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisMap.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisQueue.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisQueue.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSentinelConfigurations.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSentinelConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSet.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisSet.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisUtils.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/SortedSet.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/SortedSet.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/package-info.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/mapping/BucketManagerFactorySupplier.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/mapping/BucketManagerFactorySupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2023 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 package org.eclipse.jnosql.databases.redis.mapping;

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/mapping/CollectionSupplier.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/mapping/CollectionSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2023 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 package org.eclipse.jnosql.databases.redis.mapping;

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/package-info.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/main/resources/META-INF/beans.xml
+++ b/jnosql-redis/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounterTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultCounterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSetTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/DefaultSortedSetTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/Human.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/KeyValueDatabase.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/KeyValueDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/LineBank.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/LineBank.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/ProductCart.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/ProductCart.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerFactoryTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisBucketManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisListTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisMapTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisQueueTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetStringTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisSetTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisUtilsTest.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/RedisUtilsTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/Species.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/Species.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/User.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/tck/RedisDBTemplateSupplier.java
+++ b/jnosql-redis/src/test/java/org/eclipse/jnosql/databases/redis/tck/RedisDBTemplateSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-redis/src/test/resources/META-INF/beans.xml
+++ b/jnosql-redis/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-riak/pom.xml
+++ b/jnosql-riak/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManager.java
+++ b/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManagerFactory.java
+++ b/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakCommunicationException.java
+++ b/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakCommunicationException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakKeyValueConfiguration.java
+++ b/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakKeyValueConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakUtils.java
+++ b/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/RiakUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/package-info.java
+++ b/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/package-info.java
+++ b/jnosql-riak/src/main/java/org/eclipse/jnosql/databases/riak/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManagerTest.java
+++ b/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakBucketManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakKeyValueConfigurationTest.java
+++ b/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakKeyValueConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakTestUtils.java
+++ b/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/RiakTestUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/User.java
+++ b/jnosql-riak/src/test/java/org/eclipse/jnosql/databases/riak/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-riak/src/test/resources/diana-riak.properties
+++ b/jnosql-riak/src/test/resources/diana-riak.properties
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2017 Otávio Santana and others
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-solr/pom.xml
+++ b/jnosql-solr/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManager.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/DocumentQueryConverter.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/DocumentQueryConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfiguration.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfigurations.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentManager.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentManagerFactory.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrException.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrUtils.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/communication/SolrUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/DefaultSolrTemplate.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/DefaultSolrTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/DocumentManagerSupplier.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/DocumentManagerSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2022 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/MapParams.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/MapParams.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/Param.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/Param.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/Solr.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/Solr.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrExtension.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepository.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryBean.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryProxy.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryProxy.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrTemplate.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/SolrTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/package-info.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/mapping/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/package-info.java
+++ b/jnosql-solr/src/main/java/org/eclipse/jnosql/databases/solr/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/main/resources/META-INF/beans.xml
+++ b/jnosql-solr/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/ContactType.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/ContactType.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DefaultSolrDocumentManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DocumentDatabase.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/DocumentDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfigurationTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/SolrDocumentConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/SolrInjectionSecurityTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/communication/SolrInjectionSecurityTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/integration/Magazine.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/integration/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/integration/SolrTemplateIntegrationTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/integration/SolrTemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/integration/TemplateIntegrationTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/integration/TemplateIntegrationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/DefaultSolrTemplateTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/DefaultSolrTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/Human.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/HumannRepository.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/HumannRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/MockProducer.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/MockProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrExtensionTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryProxyTest.java
+++ b/jnosql-solr/src/test/java/org/eclipse/jnosql/databases/solr/mapping/SolrRepositoryProxyTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-solr/src/test/resources/META-INF/beans.xml
+++ b/jnosql-solr/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-tinkerpop/pom.xml
+++ b/jnosql-tinkerpop/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/CommunicationEntityConverter.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/CommunicationEntityConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/DatabaseConfigurationAdapter.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/DatabaseConfigurationAdapter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManager.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/GraphConfiguration.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/GraphConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/GraphTransactionUtil.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/GraphTransactionUtil.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/LikeToRegex.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/LikeToRegex.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/TinkerpopCommunicationEdge.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/TinkerpopCommunicationEdge.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/TinkerpopGraphDatabaseManager.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/TinkerpopGraphDatabaseManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/TraversalExecutor.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/TraversalExecutor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/package-info.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractEdgeTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractEdgeTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplate.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractVertexTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractVertexTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeEntity.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeEntity.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeRepeatStepTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeRepeatStepTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeRepeatTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeRepeatTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversalOrder.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversalOrder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeUntilTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeUntilTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultPreparedStatement.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultPreparedStatement.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultTinkerpopTemplate.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultTinkerpopTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexRepeatStepTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexRepeatStepTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexRepeatTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexRepeatTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversalOrder.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversalOrder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexUntilTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexUntilTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeConditionTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeConditionTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeEntity.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeEntity.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeRepeatStepTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeRepeatStepTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeRepeatTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeRepeatTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeTraversalOrder.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeTraversalOrder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeUntilTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeUntilTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphEntityConverter.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphEntityConverter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphTemplateProducer.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphTemplateProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/Gremlin.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/Gremlin.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GremlinExecutor.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GremlinExecutor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GremlinParamParser.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GremlinParamParser.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2023 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GremlinQueryException.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GremlinQueryException.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerPopRepository.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerPopRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplate.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/Transactional.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/Transactional.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TransactionalInterceptor.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TransactionalInterceptor.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/ValueMapTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/ValueMapTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexConditionTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexConditionTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexRepeatStepTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexRepeatStepTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexRepeatTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexRepeatTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexTraversalOrder.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexTraversalOrder.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexUntilTraversal.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/VertexUntilTraversal.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphSupplier.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/query/ParamConverterUtils.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/query/ParamConverterUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/query/TinkerpopRepositoryBean.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/query/TinkerpopRepositoryBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/query/TinkerpopRepositoryProxy.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/query/TinkerpopRepositoryProxy.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TemplateBean.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TemplateBean.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TinkerpopExtension.java
+++ b/jnosql-tinkerpop/src/main/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TinkerpopExtension.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/main/resources/META-INF/beans.xml
+++ b/jnosql-tinkerpop/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-tinkerpop/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/jnosql-tinkerpop/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,10 +1,10 @@
 #
 #  Copyright (c) 2022 Contributors to the Eclipse Foundation
 #   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Eclipse Public License v1.0
+#   are made available under the terms of the Eclipse Public License 2.0
 #   and Apache License v2.0 which accompanies this distribution.
-#   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-#   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
 #
 #   You may elect to redistribute this code under either of these licenses.
 #

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/ArangoDeployment.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/ArangoDeployment.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/TestGraphSupplier.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/TestGraphSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/arangodb/ArangoDBGraphProducer.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/arangodb/ArangoDBGraphProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/mock/MockGraphProducer.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/mock/MockGraphProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/neo4j/Neo4jGraphProducer.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/neo4j/Neo4jGraphProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/tinkergraph/TinkerGraphProducer.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/cdi/tinkergraph/TinkerGraphProducer.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/communication/DefaultTinkerpopGraphDatabaseManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTinkerpopTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTraversalTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/AbstractTraversalTest.java
@@ -2,10 +2,10 @@
  *
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversalTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultEdgeTraversalTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultGraphTraversalSourceTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultGraphTraversalSourceTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultTinkerpopTemplateProducerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultTinkerpopTemplateProducerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversalTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultValueMapTraversalTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversalTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/DefaultVertexTraversalTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeEntityTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/EdgeEntityTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/GraphTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/MagazineRepository.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/MagazineRepository.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/MagazineTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/MagazineTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/Population.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/Population.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/PopulationTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/PopulationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateProducerTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateProducerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/TinkerpopTemplateTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphConfigurationMock.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphConfigurationMock.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphConfigurationMock2.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphConfigurationMock2.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphDatabaseConfiguration.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphDatabaseConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2025 Contributors to the Eclipse Foundation
  *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
+ *  are made available under the terms of the Eclipse Public License 2.0
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *  You may elect to redistribute this code under either of these licenses.
  *  Contributors:
  *  Otavio Santana

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphSupplierTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/configuration/GraphSupplierTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/Creature.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/Creature.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/Human.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/Human.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/HumanBuilder.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/HumanBuilder.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/HumanRepository.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/HumanRepository.java
@@ -1,10 +1,10 @@
 /*
  *   Copyright (c) 2023 Contributors to the Eclipse Foundation
  *    All rights reserved. This program and the accompanying materials
- *    are made available under the terms of the Eclipse Public License v1.0
+ *    are made available under the terms of the Eclipse Public License 2.0
  *    and Apache License v2.0 which accompanies this distribution.
- *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *    You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/Magazine.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/Magazine.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/MagazineTemplate.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/MagazineTemplate.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/People.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/People.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/WrongEntity.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/entities/WrongEntity.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TinkerpopExtensionTest.java
+++ b/jnosql-tinkerpop/src/test/java/org/eclipse/jnosql/databases/tinkerpop/mapping/spi/TinkerpopExtensionTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2022 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-tinkerpop/src/test/resources/META-INF/beans.xml
+++ b/jnosql-tinkerpop/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-valkey/pom.xml
+++ b/jnosql-valkey/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Counter.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Counter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounter.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounter.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultRanking.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultRanking.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSet.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSet.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultValkeyBucketManagerFactory.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/DefaultValkeyBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/IrregularKeyValue.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/IrregularKeyValue.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Ranking.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/Ranking.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/SortedSet.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/SortedSet.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManager.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManager.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactory.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactory.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyClusterConfigurations.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyClusterConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyCollection.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyCollection.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfiguration.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfiguration.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurations.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationsResolver.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationsResolver.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyList.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyList.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMap.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMap.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyQueue.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyQueue.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySentinelConfigurations.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySentinelConfigurations.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySet.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeySet.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtils.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtils.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/package-info.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/communication/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/BucketManagerFactorySupplier.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/BucketManagerFactorySupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2023 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 package org.eclipse.jnosql.databases.valkey.mapping;

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/CollectionSupplier.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/mapping/CollectionSupplier.java
@@ -2,8 +2,8 @@
  *  Copyright (c) 2023 Eclipse Contribuitor
  * All rights reserved. This program and the accompanying materials
  *  and Apache License v2.0 which accompanies this distribution.
- *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *  and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *    You may elect to redistribute this code under either of these licenses.
  */
 package org.eclipse.jnosql.databases.valkey.mapping;

--- a/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/package-info.java
+++ b/jnosql-valkey/src/main/java/org/eclipse/jnosql/databases/valkey/package-info.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/main/resources/META-INF/beans.xml
+++ b/jnosql-valkey/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounterTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultCounterTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSetTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/DefaultSortedSetTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Human.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Human.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/KeyValueDatabase.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/KeyValueDatabase.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/LineBank.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/LineBank.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ProductCart.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ProductCart.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisListTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisQueueTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/RedisSetTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Species.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/Species.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/User.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/User.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactoryTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerFactoryTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyBucketManagerTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyConfigurationTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapStringTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapStringTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyMapTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtilsTest.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/communication/ValkeyUtilsTest.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/tck/ValkeyDBTemplateSupplier.java
+++ b/jnosql-valkey/src/test/java/org/eclipse/jnosql/databases/valkey/tck/ValkeyDBTemplateSupplier.java
@@ -1,10 +1,10 @@
 /*
  *  Copyright (c) 2024 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
- *   are made available under the terms of the Eclipse Public License v1.0
+ *   are made available under the terms of the Eclipse Public License 2.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
  *
  *   You may elect to redistribute this code under either of these licenses.
  *

--- a/jnosql-valkey/src/test/resources/META-INF/beans.xml
+++ b/jnosql-valkey/src/test/resources/META-INF/beans.xml
@@ -1,10 +1,10 @@
 <!--
   ~  Copyright (c) 2026 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
 <!--
   ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~   All rights reserved. This program and the accompanying materials
-  ~   are made available under the terms of the Eclipse Public License v1.0
+  ~   are made available under the terms of the Eclipse Public License 2.0
   ~   and Apache License v2.0 which accompanies this distribution.
-  ~   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  ~   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
   ~
   ~   You may elect to redistribute this code under either of these licenses.
   ~


### PR DESCRIPTION

This pull request updates the project licensing information to reference the Eclipse Public License 2.0 instead of version 1.0, and updates associated URLs throughout the codebase and documentation. There are no functional code changes—these updates are to ensure compliance with the correct license terms and references.

**License and Documentation Updates:**

* Updated all Java source files in the `org.eclipse.jnosql.databases.arangodb.communication` and `org.eclipse.jnosql.databases.arangodb.mapping` packages to reference Eclipse Public License 2.0 and updated the license URLs to their correct, current locations. [[1]](diffhunk://#diff-73dda8c47b00631cb5f9469c3cb306e94072bb1eaa9bf949d618f08deded7234L4-R7) [[2]](diffhunk://#diff-5a4fc3aeb316838301087edaa1d5690356b3c1f2c2f8b7c588a1e8ac0d74e094L4-R7) [[3]](diffhunk://#diff-21eae29061d3f97332bc918fb2320528d7b640d257c98600de7e54237cbdd884L4-R7) [[4]](diffhunk://#diff-0067d0b97dfb7c8c9470344fde489b7b0b038b13bd5e1a7b71a96b38500d6489L4-R7) [[5]](diffhunk://#diff-622897f9eb6145c06cd3d294231bf12308d792d8f33aa2d4f2fb39a49b7a50abL5-R8) [[6]](diffhunk://#diff-8589cf1cc1b689541e6d163017793c5179c68e1324e47a0a9751e0e5aee497ceL4-R7) [[7]](diffhunk://#diff-4492cb087aa7eb17fd5da6105e8abe8a8cee6d9009be6c9f9369716f528736daL4-R7) [[8]](diffhunk://#diff-f7f6943cb0e78fbe4a9e7a4b0eac7c23d9c72029e16dd14d7aece673a1643a62L4-R7) [[9]](diffhunk://#diff-ea8276343dac5c749dc4697c255dfb53f31550d6b7845d42d3bf12da190a7a56L4-R7) [[10]](diffhunk://#diff-07f7e31f68dccf8421a2fb5fd93c0182a27746065bc41b077ea2e3dc8a454705L4-R7) [[11]](diffhunk://#diff-f12aae513a6f712ec3a65af9abbccb50d329b0c655397055dfd30185a8d148edL4-R7) [[12]](diffhunk://#diff-87923528142035f239fa6f7fd5f0968124f0671b2a2832467b08168d18598f61L4-R7) [[13]](diffhunk://#diff-2511409bae24ded7ec9b7d8757065fdd030fd9f1dfbb922852606c98c4e4fd52L4-R7) [[14]](diffhunk://#diff-ace47d2c39d6c3e6c5666ce990fc06c24a26d72c496522e93e8a7f74e5b85503L4-R7) [[15]](diffhunk://#diff-3e3080b73455ce123d6bd2343917a2f29b22406409361e00ac21fa206cdd1cddL4-R7) [[16]](diffhunk://#diff-f5454466a1bc0090d80e77603d3ea1f99d860256e5c104d29ebd3aab2cbf2225L4-R7) [[17]](diffhunk://#diff-d6fc50542520c58be3e0355bc189b103bc3fa7184b79e3250db1538da08227a5L4-R7) [[18]](diffhunk://#diff-2afacf46a91ad699ae2a4aaaa5256af579aa5f0c0a3ee8ca598895c61a3cbfbdL4-R7)

* Updated the `jnosql-arangodb/pom.xml` file to reference Eclipse Public License 2.0 and the correct URLs for both EPL and Apache licenses.

* Updated `NOTICE.adoc` to reference Eclipse Public License 2.0, update license URLs, and correct the JUnit third-party license entry. [[1]](diffhunk://#diff-e323383efb11da621e126750300f8838b9d55df8e2be97c5ecedb49b295273f6L9-R9) [[2]](diffhunk://#diff-e323383efb11da621e126750300f8838b9d55df8e2be97c5ecedb49b295273f6L24-R24)