### PR TITLE
Chore/update database drivers

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -43,7 +43,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Updated OrientDB to 3.2.55
 - Updated MongoDB to 5.9.1
 - Updated Hbase 2.6.6
-- Updated DynamoDB to 2.50.2
+- Updated DynamoDB to 2.54.4
 - Updated Couchbase to 3.12.2
 - Updated CouchDB HttpClient to 5.6.3
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -44,6 +44,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Updated MongoDB to 5.10.0
 - Updated HBase to 3.0.0
 - Updated DynamoDB to 2.54.4
+- Updated Neo4J to 6.2.1
 - Updated Couchbase to 3.12.2
 - Updated CouchDB HttpClient to 5.6.3
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -39,7 +39,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Validate update query parameters in Couchbase driver
 - Update jakarta data engine
 - Upgraded Elasticsearch to 9.5.2
-- Upgraded Jedis to 7.5.3
+- Upgraded Jedis to 8.0.0 and migrated pooled and sentinel clients to connection providers
 - Updated OrientDB to 3.2.55
 - Updated MongoDB to 5.10.0
 - Updated HBase to 3.0.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -41,7 +41,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Upgraded Elasticsearch to 9.5.2
 - Upgraded Jedis to 7.5.3
 - Updated OrientDB to 3.2.55
-- Updated MongoDB to 5.9.1
+- Updated MongoDB to 5.10.0
 - Updated HBase to 3.0.0
 - Updated DynamoDB to 2.54.4
 - Updated Couchbase to 3.12.2

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -38,7 +38,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Validate required fields in N1QLUpdateQueryBuilder for Couchbase
 - Validate update query parameters in Couchbase driver
 - Update jakarta data engine
-- Upgraded Elasticsearch to 9.4.5
+- Upgraded Elasticsearch to 9.5.2
 - Upgraded Jedis to 7.5.3
 - Updated OrientDB to 3.2.55
 - Updated MongoDB to 5.9.1

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -42,7 +42,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Upgraded Jedis to 7.5.3
 - Updated OrientDB to 3.2.55
 - Updated MongoDB to 5.9.1
-- Updated Hbase 2.6.6
+- Updated HBase to 3.0.0
 - Updated DynamoDB to 2.54.4
 - Updated Couchbase to 3.12.2
 - Updated CouchDB HttpClient to 5.6.3

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.50.2</dynamodb.version>
+        <dynamodb.version>2.54.4</dynamodb.version>
 
     </properties>
 

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to Elasticsearch</description>
 
     <properties>
-        <elasticsearch-java.version>9.4.5</elasticsearch-java.version>
+        <elasticsearch-java.version>9.5.2</elasticsearch-java.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-hbase/pom.xml
+++ b/jnosql-hbase/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>2.6.6</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.9.1</monbodb.driver>
+        <monbodb.driver>5.10.0</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -27,7 +27,7 @@
     <name>JNoSQL Neo4J Driver</name>
 
     <properties>
-        <neo4j.driver>6.2.0</neo4j.driver>
+        <neo4j.driver>6.2.1</neo4j.driver>
     </properties>
 
     <dependencies>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>7.5.3</version>
+            <version>8.0.0</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
@@ -25,10 +25,11 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.JedisPooled;
-import redis.clients.jedis.JedisSentineled;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.providers.ConnectionProvider;
+import redis.clients.jedis.providers.PooledConnectionProvider;
+import redis.clients.jedis.providers.SentineledConnectionProvider;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -85,10 +86,11 @@ public final class RedisConfiguration implements KeyValueConfiguration {
 
         ConnectionPoolConfig connectionPoolConfig = getConnectionPoolConfig(settings);
 
-        UnifiedJedis jedis = new JedisPooled(
-                connectionPoolConfig,
+        var connectionProvider = new PooledConnectionProvider(
                 hostAndPort,
-                simpleJedisConfig);
+                simpleJedisConfig,
+                connectionPoolConfig);
+        UnifiedJedis jedis = new ConfiguredUnifiedJedis(connectionProvider, simpleJedisConfig.getRedisProtocol());
 
         return new DefaultRedisBucketManagerFactory(jedis);
     }
@@ -155,11 +157,13 @@ public final class RedisConfiguration implements KeyValueConfiguration {
         var slaveJedisClientConfig = getJedisClientConfig(
                 RedisSentinelConfigurations.SentinelMasterConfigurationsResolver.INSTANCE, settings);
 
-        JedisSentineled jedis = new JedisSentineled(masterName,
+        var connectionProvider = new SentineledConnectionProvider(masterName,
                 masterJedisClientConfig,
                 connectionPoolConfig,
                 hostAndPorts,
                 slaveJedisClientConfig);
+        UnifiedJedis jedis = new ConfiguredUnifiedJedis(
+                connectionProvider, masterJedisClientConfig.getRedisProtocol());
 
         return new DefaultRedisBucketManagerFactory(jedis);
     }
@@ -236,4 +240,10 @@ public final class RedisConfiguration implements KeyValueConfiguration {
         return poolConfig;
     }
 
+    private static final class ConfiguredUnifiedJedis extends UnifiedJedis {
+
+        private ConfiguredUnifiedJedis(ConnectionProvider provider, RedisProtocol protocol) {
+            super(provider, protocol);
+        }
+    }
 }


### PR DESCRIPTION
This pull request primarily updates several dependencies across different database modules to their latest versions, with significant changes to the Redis integration. The Redis module now migrates its pooled and sentinel clients to use the new connection provider classes introduced in Jedis 8.0.0, ensuring compatibility and improved resource management.

**Dependency upgrades:**

* Upgraded Elasticsearch client library to version 9.5.2 (`jnosql-elasticsearch/pom.xml`, `CHANGELOG.adoc`) [[1]](diffhunk://#diff-985671ca809cf46956cc0e4bf7c9beb50b04f5fdd77464b0554cb91452cabc0dL32-R32) [[2]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L41-R47)
* Upgraded Jedis (Redis client) to 8.0.0 and migrated pooled and sentinel clients to use `PooledConnectionProvider` and `SentineledConnectionProvider` for improved connection management (`jnosql-redis/pom.xml`, `RedisConfiguration.java`, `CHANGELOG.adoc`) [[1]](diffhunk://#diff-69ad13eebdf294c2d377e3b743fbc4a615356922327d6a367fba607bac048dbeL41-R41) [[2]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L28-R32) [[3]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L88-R93) [[4]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L158-R166) [[5]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78R243-R248) [[6]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L41-R47)
* Updated MongoDB driver to 5.10.0 (`jnosql-mongodb/pom.xml`, `CHANGELOG.adoc`) [[1]](diffhunk://#diff-e1b669724e73ee37895391783648ea288d4d0756200b02e61e7017324dcadcecL32-R32) [[2]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L41-R47)
* Updated HBase client to 3.0.0 (`jnosql-hbase/pom.xml`, `CHANGELOG.adoc`) [[1]](diffhunk://#diff-5757c2961e0122376f06e590817a1b7281f836df5cc14c633c50b0052f37b81cL43-R43) [[2]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L41-R47)
* Updated DynamoDB SDK to 2.54.4 (`jnosql-dynamodb/pom.xml`, `CHANGELOG.adoc`) [[1]](diffhunk://#diff-9e2007ee92cb3f4a52db02b7139cd9c0c1b36014d4490aa41e2dec9333226257L26-R26) [[2]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L41-R47)
* Updated Neo4J driver to 6.2.1 (`jnosql-neo4j/pom.xml`, `CHANGELOG.adoc`) [[1]](diffhunk://#diff-f8d1322c9b20bfcd71c0b9be797e7d1305558887783a8a855f2a04923a9859baL30-R30) [[2]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L41-R47)

**Redis module improvements:**

* Migrated from direct usage of `JedisPooled` and `JedisSentineled` to using `PooledConnectionProvider` and `SentineledConnectionProvider` with a custom `ConfiguredUnifiedJedis` wrapper, aligning with Jedis 8.0.0 best practices (`RedisConfiguration.java`) [[1]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L28-R32) [[2]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L88-R93) [[3]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L158-R166) [[4]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78R243-R248) [[5]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L41-R47)

These updates ensure the project remains compatible with the latest database drivers and client libraries, and the Redis changes in particular modernize the connection management approach for better stability and performance.