### PR TITLE
Backport/update database drivers 1.1.x

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Updated MongoDB to 5.10.0
 - Updated HBase to 3.0.0
 - Updated DynamoDB to 2.54.4
+- Updated Neo4J to 6.2.1
 
 == [1.1.16] - 2026-08-10
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,7 +10,9 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 === Changed
 
+- Upgraded Elasticsearch to 9.5.2
 - Updated DynamoDB to 2.54.4
+
 == [1.1.16] - 2026-08-10
 
 === Changed

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 === Changed
 
 - Upgraded Elasticsearch to 9.5.2
+- Updated HBase to 3.0.0
 - Updated DynamoDB to 2.54.4
 
 == [1.1.16] - 2026-08-10

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 === Changed
 
 - Upgraded Elasticsearch to 9.5.2
+- Upgraded Jedis to 8.0.0 and migrated pooled and sentinel clients to connection providers
 - Updated MongoDB to 5.10.0
 - Updated HBase to 3.0.0
 - Updated DynamoDB to 2.54.4

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 === Changed
 
 - Upgraded Elasticsearch to 9.5.2
+- Updated MongoDB to 5.10.0
 - Updated HBase to 3.0.0
 - Updated DynamoDB to 2.54.4
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,9 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Changed
+
+- Updated DynamoDB to 2.54.4
 == [1.1.16] - 2026-08-10
 
 === Changed

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.50.2</dynamodb.version>
+        <dynamodb.version>2.54.4</dynamodb.version>
     </properties>
 
     <dependencies>

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to Elasticsearch</description>
 
     <properties>
-        <elasticsearch-java.version>9.4.5</elasticsearch-java.version>
+        <elasticsearch-java.version>9.5.2</elasticsearch-java.version>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-hbase/pom.xml
+++ b/jnosql-hbase/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>2.6.6</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.9.1</monbodb.driver>
+        <monbodb.driver>5.10.0</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -27,7 +27,7 @@
     <name>JNoSQL Neo4J Driver</name>
 
     <properties>
-        <neo4j.driver>6.2.0</neo4j.driver>
+        <neo4j.driver>6.2.1</neo4j.driver>
     </properties>
 
     <dependencies>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>7.5.3</version>
+            <version>8.0.0</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
+++ b/jnosql-redis/src/main/java/org/eclipse/jnosql/databases/redis/communication/RedisConfiguration.java
@@ -25,10 +25,11 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.JedisPooled;
-import redis.clients.jedis.JedisSentineled;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.providers.ConnectionProvider;
+import redis.clients.jedis.providers.PooledConnectionProvider;
+import redis.clients.jedis.providers.SentineledConnectionProvider;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -85,10 +86,11 @@ public final class RedisConfiguration implements KeyValueConfiguration {
 
         ConnectionPoolConfig connectionPoolConfig = getConnectionPoolConfig(settings);
 
-        UnifiedJedis jedis = new JedisPooled(
-                connectionPoolConfig,
+        var connectionProvider = new PooledConnectionProvider(
                 hostAndPort,
-                simpleJedisConfig);
+                simpleJedisConfig,
+                connectionPoolConfig);
+        UnifiedJedis jedis = new ConfiguredUnifiedJedis(connectionProvider, simpleJedisConfig.getRedisProtocol());
 
         return new DefaultRedisBucketManagerFactory(jedis);
     }
@@ -155,11 +157,13 @@ public final class RedisConfiguration implements KeyValueConfiguration {
         var slaveJedisClientConfig = getJedisClientConfig(
                 RedisSentinelConfigurations.SentinelMasterConfigurationsResolver.INSTANCE, settings);
 
-        JedisSentineled jedis = new JedisSentineled(masterName,
+        var connectionProvider = new SentineledConnectionProvider(masterName,
                 masterJedisClientConfig,
                 connectionPoolConfig,
                 hostAndPorts,
                 slaveJedisClientConfig);
+        UnifiedJedis jedis = new ConfiguredUnifiedJedis(
+                connectionProvider, masterJedisClientConfig.getRedisProtocol());
 
         return new DefaultRedisBucketManagerFactory(jedis);
     }
@@ -236,4 +240,10 @@ public final class RedisConfiguration implements KeyValueConfiguration {
         return poolConfig;
     }
 
+    private static final class ConfiguredUnifiedJedis extends UnifiedJedis {
+
+        private ConfiguredUnifiedJedis(ConnectionProvider provider, RedisProtocol protocol) {
+            super(provider, protocol);
+        }
+    }
 }


### PR DESCRIPTION
This pull request upgrades several dependencies across the project to their latest versions, focusing on major database drivers and libraries. Additionally, it refactors the Redis configuration to use the new Jedis connection provider APIs, modernizing the way pooled and sentinel Redis clients are managed.

Dependency upgrades:

* Upgraded Elasticsearch to version 9.5.2 (`jnosql-elasticsearch/pom.xml`)
* Upgraded Jedis (Redis client) to version 8.0.0 (`jnosql-redis/pom.xml`)
* Updated MongoDB driver to version 5.10.0 (`jnosql-mongodb/pom.xml`)
* Updated HBase client to version 3.0.0 (`jnosql-hbase/pom.xml`)
* Updated DynamoDB driver to version 2.54.4 (`jnosql-dynamodb/pom.xml`)
* Updated Neo4J driver to version 6.2.1 (`jnosql-neo4j/pom.xml`)

Redis client refactoring:

* Migrated pooled and sentinel Redis clients to use Jedis connection providers (`PooledConnectionProvider` and `SentineledConnectionProvider`) in `RedisConfiguration.java`, replacing direct use of `JedisPooled` and `JedisSentineled` [[1]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L28-R32) [[2]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L88-R93) [[3]](diffhunk://#diff-9b264e1f65901d23cc3191b665fa3f2ceb9aa1dca25668a3deb73a8248dbff78L158-R166)
* Introduced a `ConfiguredUnifiedJedis` wrapper to support the new connection provider approach (`RedisConfiguration.java`)

Documentation:

* Updated the `CHANGELOG.adoc` to reflect all major dependency upgrades and the Redis client migration