### PR TITLE
Chore/update database drivers

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -39,11 +39,11 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Validate update query parameters in Couchbase driver
 - Update jakarta data engine
 - Upgraded Elasticsearch to 9.5.2
-- Upgraded Jedis to 8.0.0 and migrated pooled and sentinel clients to connection providers
+- Upgraded Jedis to 8.0.1 and migrated pooled and sentinel clients to connection providers
 - Updated OrientDB to 3.2.55
-- Updated MongoDB to 5.10.0
+- Updated MongoDB to 5.11.0
 - Updated HBase to 3.0.0
-- Updated DynamoDB to 2.54.4
+- Updated DynamoDB to 2.54.7
 - Updated Neo4J to 6.2.1
 - Updated Couchbase to 3.12.2
 - Updated CouchDB HttpClient to 5.6.3

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.54.4</dynamodb.version>
+        <dynamodb.version>2.54.7</dynamodb.version>
 
     </properties>
 

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.10.0</monbodb.driver>
+        <monbodb.driver>5.11.0</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>8.0.0</version>
+            <version>8.0.1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This pull request updates several dependencies across the project to their latest patch versions, improving compatibility and security. The main changes include upgrades for Jedis, MongoDB, and DynamoDB libraries, with corresponding updates in their respective `pom.xml` files and the changelog.

**Dependency Upgrades:**

* Upgraded Jedis from version 8.0.0 to 8.0.1 in both `CHANGELOG.adoc` and `jnosql-redis/pom.xml`, ensuring the Redis integration uses the latest fixes. [[1]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L42-R46) [[2]](diffhunk://#diff-69ad13eebdf294c2d377e3b743fbc4a615356922327d6a367fba607bac048dbeL41-R41)
* Updated MongoDB driver from 5.10.0 to 5.11.0 in both `CHANGELOG.adoc` and `jnosql-mongodb/pom.xml` for improved MongoDB support. [[1]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L42-R46) [[2]](diffhunk://#diff-e1b669724e73ee37895391783648ea288d4d0756200b02e61e7017324dcadcecL32-R32)
* Updated DynamoDB dependency from 2.54.4 to 2.54.7 in both `CHANGELOG.adoc` and `jnosql-dynamodb/pom.xml` for better AWS DynamoDB compatibility. [[1]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93L42-R46) [[2]](diffhunk://#diff-9e2007ee92cb3f4a52db02b7139cd9c0c1b36014d4490aa41e2dec9333226257L26-R26)