### PR TITLE
Update Database backport

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,10 +11,10 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 === Changed
 
 - Upgraded Elasticsearch to 9.5.2
-- Upgraded Jedis to 8.0.0 and migrated pooled and sentinel clients to connection providers
-- Updated MongoDB to 5.10.0
+- Upgraded Jedis to 8.0.1 and migrated pooled and sentinel clients to connection providers
+- Updated MongoDB to 5.11.0
 - Updated HBase to 3.0.0
-- Updated DynamoDB to 2.54.4
+- Updated DynamoDB to 2.54.7
 - Updated Neo4J to 6.2.1
 
 == [1.1.16] - 2026-08-10

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -23,7 +23,7 @@
     <description>The Eclipse JNoSQL layer implementation AWS DynamoDB</description>
 
     <properties>
-        <dynamodb.version>2.54.4</dynamodb.version>
+        <dynamodb.version>2.54.7</dynamodb.version>
     </properties>
 
     <dependencies>

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -29,7 +29,7 @@
     <description>The Eclipse JNoSQL layer to MongoDB</description>
 
     <properties>
-        <monbodb.driver>5.10.0</monbodb.driver>
+        <monbodb.driver>5.11.0</monbodb.driver>
     </properties>
     <dependencies>
         <dependency>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>8.0.0</version>
+            <version>8.0.1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This pull request upgrades several dependencies to their latest patch versions for improved stability and compatibility. The updates affect the Redis, MongoDB, and DynamoDB modules, as well as the project changelog.

**Dependency Upgrades:**

*Redis:*
- Upgraded Jedis library to version `8.0.1` in `jnosql-redis/pom.xml`.
- Updated changelog to reflect Jedis upgrade and migration of pooled and sentinel clients to connection providers.

*MongoDB:*
- Upgraded MongoDB Java driver to version `5.11.0` in `jnosql-mongodb/pom.xml`.
- Updated changelog to reflect MongoDB upgrade.

*DynamoDB:*
- Upgraded DynamoDB SDK to version `2.54.7` in `jnosql-dynamodb/pom.xml`.
- Updated changelog to reflect DynamoDB upgrade.