### PR TITLE
build: release version 1.1.17 across all database modules

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-arangodb</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -202,7 +202,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-cassandra</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -353,7 +353,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-couchbase</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -478,7 +478,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-couchdb</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -557,7 +557,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-dynamodb</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -707,7 +707,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-elasticsearch</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -791,7 +791,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-hazelcast</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -899,7 +899,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-hbase</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -942,7 +942,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-infinispan</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -992,7 +992,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-memcached</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1076,7 +1076,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-mongodb</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1189,7 +1189,7 @@ You can include Oracle NoSQL as a dependency using either Maven or Gradle:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-oracle-nosql</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1337,7 +1337,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-orientdb</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1448,7 +1448,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-ravendb</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1493,7 +1493,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-redis</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1706,7 +1706,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-redis</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1752,7 +1752,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-solr</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1852,7 +1852,7 @@ You can use either the Maven or Gradle dependencies:
 <dependency>
   <groupId>org.eclipse.jnosql.databases</groupId>
   <artifactId>jnosql-neo4j</artifactId>
-    <version>1.1.16</version>
+    <version>1.1.17</version>
 </dependency>
 ----
 
@@ -1922,7 +1922,7 @@ Eclipse JNoSQL offers a mapping implementation for Graph NoSQL types:
 <dependency>
     <groupId>org.eclipse.jnosql.databases</groupId>
     <artifactId>jnosql-tinkerpop</artifactId>
-      <version>1.1.16</version>
+      <version>1.1.17</version>
 </dependency>
 ----
 

--- a/jnosql-arangodb/pom.xml
+++ b/jnosql-arangodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-arangodb</artifactId>

--- a/jnosql-cassandra/pom.xml
+++ b/jnosql-cassandra/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-cassandra</artifactId>

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-couchbase</artifactId>

--- a/jnosql-couchdb/pom.xml
+++ b/jnosql-couchdb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <properties>

--- a/jnosql-database-commons/pom.xml
+++ b/jnosql-database-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-database-commons</artifactId>

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-dynamodb</artifactId>

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-elasticsearch</artifactId>

--- a/jnosql-hazelcast/pom.xml
+++ b/jnosql-hazelcast/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-hazelcast</artifactId>

--- a/jnosql-hbase/pom.xml
+++ b/jnosql-hbase/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-hbase</artifactId>

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-infinispan</artifactId>

--- a/jnosql-memcached/pom.xml
+++ b/jnosql-memcached/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-memcached</artifactId>

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-mongodb</artifactId>

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-neo4j</artifactId>

--- a/jnosql-oracle-nosql/pom.xml
+++ b/jnosql-oracle-nosql/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-oracle-nosql</artifactId>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-orientdb</artifactId>

--- a/jnosql-ravendb/pom.xml
+++ b/jnosql-ravendb/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-ravendb</artifactId>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-redis</artifactId>

--- a/jnosql-riak/pom.xml
+++ b/jnosql-riak/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-riak</artifactId>

--- a/jnosql-solr/pom.xml
+++ b/jnosql-solr/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-solr</artifactId>

--- a/jnosql-tinkerpop/pom.xml
+++ b/jnosql-tinkerpop/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-tinkerpop</artifactId>

--- a/jnosql-valkey/pom.xml
+++ b/jnosql-valkey/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <artifactId>jnosql-valkey</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <relativePath/>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.17-SNAPSHOT</version>
+        <version>1.1.17</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.databases</groupId>


### PR DESCRIPTION
This pull request updates the project version from `1.1.17-SNAPSHOT` to the official release version `1.1.17` across all modules and documentation. This ensures that all references, both in the codebase and in the README, are consistent with the latest stable release.

Key changes include:

**Documentation Updates:**
- Updated all Maven dependency snippets in `README.adoc` to reference version `1.1.17` instead of `1.1.16` or `1.1.17-SNAPSHOT`, ensuring users can copy the correct version for each supported database. [[1]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L25-R25) [[2]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L205-R205) [[3]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L356-R356) [[4]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L481-R481) [[5]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L560-R560) [[6]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L710-R710) [[7]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L794-R794) [[8]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L902-R902) [[9]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L945-R945) [[10]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L995-R995) [[11]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1079-R1079) [[12]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1192-R1192) [[13]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1340-R1340) [[14]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1451-R1451) [[15]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1496-R1496) [[16]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1709-R1709) [[17]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1755-R1755) [[18]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1855-R1855) [[19]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1925-R1925)

**Project Version Updates:**
- Changed the parent version in all module `pom.xml` files from `1.1.17-SNAPSHOT` to `1.1.17`, finalizing the release version for modules such as `jnosql-arangodb`, `jnosql-cassandra`, `jnosql-couchbase`, `jnosql-couchdb`, `jnosql-database-commons`, `jnosql-dynamodb`, `jnosql-elasticsearch`, `jnosql-hazelcast`, `jnosql-hbase`, `jnosql-infinispan`, `jnosql-memcached`, `jnosql-mongodb`, `jnosql-neo4j`, `jnosql-oracle-nosql`, `jnosql-orientdb`, `jnosql-ravendb`, `jnosql-redis`, `jnosql-riak`, and `jnosql-solr`. [[1]](diffhunk://#diff-af32f9ac8d623ed713e931c8ca52cc0f2819b8aa80482e3f21914ad131e6f1f4L24-R24) [[2]](diffhunk://#diff-b461428ba6cba645f2d99ef97e939cffb0f0ca3a1dd03a7c1241fd32a5ee6c6cL24-R24) [[3]](diffhunk://#diff-51e30bd038cf45cbfe5245a8cffbe0ee43a0f8cdbe3e91a91478c44bf06c6c72L24-R24) [[4]](diffhunk://#diff-b83235c08c16d72f8c2589ffb23bb672fde5cdce7bfe3686e0550b0e01a32604L24-R24) [[5]](diffhunk://#diff-bc122afff1fcf14fada462893b913eb687ad7c238ff307aa12b8410636c59b4dL23-R23) [[6]](diffhunk://#diff-9e2007ee92cb3f4a52db02b7139cd9c0c1b36014d4490aa41e2dec9333226257L18-R18) [[7]](diffhunk://#diff-985671ca809cf46956cc0e4bf7c9beb50b04f5fdd77464b0554cb91452cabc0dL24-R24) [[8]](diffhunk://#diff-71bd1727dfe291d16cf49ece0b2667bad051e76f1fecb60b41de2c0ae77749e9L23-R23) [[9]](diffhunk://#diff-5757c2961e0122376f06e590817a1b7281f836df5cc14c633c50b0052f37b81cL23-R23) [[10]](diffhunk://#diff-cbfaec6d22386ffb093e5d926d3a279dfcf86ed33ba2ba214d9cdc8ba437746aL22-R22) [[11]](diffhunk://#diff-b7d6fecd8d83d2e2239e1769d89bcafee259d1fabb4ba7a33daefaa80ffbb483L23-R23) [[12]](diffhunk://#diff-e1b669724e73ee37895391783648ea288d4d0756200b02e61e7017324dcadcecL24-R24) [[13]](diffhunk://#diff-f8d1322c9b20bfcd71c0b9be797e7d1305558887783a8a855f2a04923a9859baL23-R23) [[14]](diffhunk://#diff-01a65b82478acc1cb62f7bfc8190035fe473a234ad48f7cec2fc2762808a2395L23-R23) [[15]](diffhunk://#diff-548bb2ecf4bf31a6d4758916131b8a16fb5731f238587258a2f1e79606d81b12L23-R23) [[16]](diffhunk://#diff-eb876fdf026d7482657f64c5387114d410078917551c4f3f8abdb26e06298a13L23-R23) [[17]](diffhunk://#diff-69ad13eebdf294c2d377e3b743fbc4a615356922327d6a367fba607bac048dbeL23-R23) [[18]](diffhunk://#diff-2b191f3243a8fe13d26ecc19ca5edbe3c6362e874dc3996dca9b8d5a811d6591L24-R24) [[19]](diffhunk://#diff-19ac22dc1e14de8ae0d7653807e5542f462fa242d56a02d79a7919feb86b48b8L23-R23)