### PR TITLE
build(all): update versions to 1.2.0-M2

### DIFF
--- a/jnosql-arangodb/pom.xml
+++ b/jnosql-arangodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-arangodb</artifactId>

--- a/jnosql-cassandra/pom.xml
+++ b/jnosql-cassandra/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-cassandra</artifactId>

--- a/jnosql-couchbase/pom.xml
+++ b/jnosql-couchbase/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-couchbase</artifactId>

--- a/jnosql-couchdb/pom.xml
+++ b/jnosql-couchdb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <properties>

--- a/jnosql-database-commons/pom.xml
+++ b/jnosql-database-commons/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-database-commons</artifactId>

--- a/jnosql-dynamodb/pom.xml
+++ b/jnosql-dynamodb/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-dynamodb</artifactId>

--- a/jnosql-elasticsearch/pom.xml
+++ b/jnosql-elasticsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-elasticsearch</artifactId>

--- a/jnosql-hazelcast/pom.xml
+++ b/jnosql-hazelcast/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-hazelcast</artifactId>

--- a/jnosql-hbase/pom.xml
+++ b/jnosql-hbase/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-hbase</artifactId>

--- a/jnosql-infinispan/pom.xml
+++ b/jnosql-infinispan/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-infinispan</artifactId>

--- a/jnosql-memcached/pom.xml
+++ b/jnosql-memcached/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-memcached</artifactId>

--- a/jnosql-mongodb/pom.xml
+++ b/jnosql-mongodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-mongodb</artifactId>

--- a/jnosql-neo4j/pom.xml
+++ b/jnosql-neo4j/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-neo4j</artifactId>

--- a/jnosql-oracle-nosql/pom.xml
+++ b/jnosql-oracle-nosql/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-oracle-nosql</artifactId>

--- a/jnosql-orientdb/pom.xml
+++ b/jnosql-orientdb/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-orientdb</artifactId>

--- a/jnosql-ravendb/pom.xml
+++ b/jnosql-ravendb/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-ravendb</artifactId>

--- a/jnosql-redis/pom.xml
+++ b/jnosql-redis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-redis</artifactId>

--- a/jnosql-riak/pom.xml
+++ b/jnosql-riak/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-riak</artifactId>

--- a/jnosql-solr/pom.xml
+++ b/jnosql-solr/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-solr</artifactId>

--- a/jnosql-tinkerpop/pom.xml
+++ b/jnosql-tinkerpop/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-tinkerpop</artifactId>

--- a/jnosql-valkey/pom.xml
+++ b/jnosql-valkey/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.databases</groupId>
         <artifactId>jnosql-databases-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <artifactId>jnosql-valkey</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <relativePath/>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.2.0-SNAPSHOT</version>
+        <version>1.2.0-M2</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.databases</groupId>


### PR DESCRIPTION
This pull request updates the parent POM version for all database modules from `1.2.0-SNAPSHOT` to `1.2.0-M2`. This change ensures that all modules now depend on the latest milestone version of the shared parent, which may include important dependency, plugin, or configuration updates.

Version alignment:

* Updated the parent POM version from `1.2.0-SNAPSHOT` to `1.2.0-M2` in the following modules to ensure consistency and take advantage of the latest milestone improvements:
  - `jnosql-arangodb/pom.xml`
  - `jnosql-cassandra/pom.xml`
  - `jnosql-couchbase/pom.xml`
  - `jnosql-couchdb/pom.xml`
  - `jnosql-database-commons/pom.xml`
  - `jnosql-dynamodb/pom.xml`
  - `jnosql-elasticsearch/pom.xml`
  - `jnosql-hazelcast/pom.xml`
  - `jnosql-hbase/pom.xml`
  - `jnosql-infinispan/pom.xml`
  - `jnosql-memcached/pom.xml`
  - `jnosql-mongodb/pom.xml`
  - `jnosql-neo4j/pom.xml`
  - `jnosql-oracle-nosql/pom.xml`
  - `jnosql-orientdb/pom.xml`
  - `jnosql-ravendb/pom.xml`
  - `jnosql-redis/pom.xml`
  - `jnosql-riak/pom.xml`
  - `jnosql-solr/pom.xml`
  - `jnosql-tinkerpop/pom.xml`